### PR TITLE
feat(rust): make portal handshake optional

### DIFF
--- a/implementations/rust/ockam/ockam/src/remote/worker.rs
+++ b/implementations/rust/ockam/ockam/src/remote/worker.rs
@@ -32,7 +32,7 @@ impl Worker for RemoteRelay {
         ctx: &mut Context,
         msg: Routed<Self::Message>,
     ) -> Result<()> {
-        if msg.msg_addr() == self.addresses.main_remote {
+        if msg.msg_addr() == &self.addresses.main_remote {
             let mut local_message = msg.into_local_message();
 
             // Remove my address from the onward_route

--- a/implementations/rust/ockam/ockam_api/src/influxdb/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/influxdb/portal.rs
@@ -39,6 +39,8 @@ impl NodeManagerWorker {
             policy_expression,
             privileged,
             tls,
+            skip_handshake,
+            enable_nagle,
         } = body.tcp_outlet;
         let address = self
             .node_manager
@@ -95,6 +97,8 @@ impl NodeManagerWorker {
                 reachable_from_default_secure_channel,
                 OutletAccessControl::WithPolicyExpression(policy_expression),
                 privileged,
+                skip_handshake,
+                enable_nagle,
             )
             .await
         {
@@ -121,6 +125,8 @@ impl NodeManagerWorker {
             disable_tcp_fallback,
             privileged,
             tls_certificate_provider,
+            skip_handshake,
+            enable_nagle,
         } = body.tcp_inlet.clone();
 
         //TODO: should be an easier way to tweak the multiaddr
@@ -189,6 +195,8 @@ impl NodeManagerWorker {
                 disable_tcp_fallback,
                 privileged,
                 tls_certificate_provider,
+                skip_handshake,
+                enable_nagle,
             )
             .await
         {
@@ -334,7 +342,8 @@ impl InfluxDBPortals for BackgroundNodeClient {
         policy_expression: Option<PolicyExpression>,
         influxdb_config: InfluxDBOutletConfig,
     ) -> miette::Result<OutletStatus> {
-        let mut outlet_payload = CreateOutlet::new(to, tls, from.cloned(), true, false);
+        let mut outlet_payload =
+            CreateOutlet::new(to, tls, from.cloned(), true, false, false, false);
         if let Some(policy_expression) = policy_expression {
             outlet_payload.set_policy_expression(policy_expression);
         }
@@ -376,6 +385,8 @@ impl InfluxDBPortals for BackgroundNodeClient {
                 disable_tcp_fallback,
                 false,
                 tls_certificate_provider,
+                false,
+                false,
             );
             let payload = CreateInfluxDBInlet::new(inlet_payload, lease_usage, lease_issuer_route);
             Request::post("/node/influxdb_inlet").body(payload)

--- a/implementations/rust/ockam/ockam_api/src/kafka/inlet_controller.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/inlet_controller.rs
@@ -141,6 +141,8 @@ impl KafkaInletController {
                     false,
                     false,
                     None,
+                    false,
+                    false,
                 )
                 .await?;
 

--- a/implementations/rust/ockam/ockam_api/src/kafka/outlet_controller.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/outlet_controller.rs
@@ -77,6 +77,8 @@ impl KafkaOutletController {
                     false,
                     OutletAccessControl::WithPolicyExpression(self.policy_expression.clone()),
                     false,
+                    false,
+                    false,
                 )
                 .await
                 .map(|info| info.to)?;

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -57,6 +57,10 @@ pub struct CreateInlet {
     #[n(12)] pub(crate) privileged: bool,
     /// TLS certificate provider route.
     #[n(13)] pub(crate) tls_certificate_provider: Option<MultiAddr>,
+    /// Skip Portal handshake for lower latency, but also lower throughput
+    #[n(14)] pub(crate) skip_handshake: bool,
+    /// Enable Nagle's algorithm for potentially higher throughput, but higher latency
+    #[n(15)] pub(crate) enable_nagle: bool,
 }
 
 impl CreateInlet {
@@ -69,6 +73,8 @@ impl CreateInlet {
         enable_udp_puncture: bool,
         disable_tcp_fallback: bool,
         privileged: bool,
+        skip_handshake: bool,
+        enable_nagle: bool,
     ) -> Self {
         Self {
             listen_addr: listen,
@@ -83,6 +89,8 @@ impl CreateInlet {
             disable_tcp_fallback,
             privileged,
             tls_certificate_provider: None,
+            skip_handshake,
+            enable_nagle,
         }
     }
 
@@ -96,6 +104,8 @@ impl CreateInlet {
         enable_udp_puncture: bool,
         disable_tcp_fallback: bool,
         privileged: bool,
+        skip_handshake: bool,
+        enable_nagle: bool,
     ) -> Self {
         Self {
             listen_addr: listen,
@@ -110,6 +120,8 @@ impl CreateInlet {
             disable_tcp_fallback,
             privileged,
             tls_certificate_provider: None,
+            skip_handshake,
+            enable_nagle,
         }
     }
 
@@ -169,7 +181,11 @@ pub struct CreateOutlet {
     /// will be used.
     #[n(5)] pub policy_expression: Option<PolicyExpression>,
     /// Use eBPF and RawSocket to access TCP packets instead of TCP data stream.
-    #[n(6)] pub privileged: bool
+    #[n(6)] pub privileged: bool,
+    /// Skip Portal handshake for lower latency, but also lower throughput
+    #[n(7)] pub skip_handshake: bool,
+    /// Enable Nagle's algorithm for potentially higher throughput, but higher latency
+    #[n(8)] pub(crate) enable_nagle: bool,
 }
 
 impl CreateOutlet {
@@ -179,6 +195,8 @@ impl CreateOutlet {
         worker_addr: Option<Address>,
         reachable_from_default_secure_channel: bool,
         privileged: bool,
+        skip_handshake: bool,
+        enable_nagle: bool,
     ) -> Self {
         Self {
             hostname_port,
@@ -187,6 +205,8 @@ impl CreateOutlet {
             reachable_from_default_secure_channel,
             policy_expression: None,
             privileged,
+            skip_handshake,
+            enable_nagle,
         }
     }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/kafka_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/kafka_services.rs
@@ -220,6 +220,8 @@ impl InMemoryNode {
             false,
             false,
             None,
+            false,
+            false,
         )
         .await?;
 
@@ -323,6 +325,8 @@ impl InMemoryNode {
             Some(KAFKA_OUTLET_BOOTSTRAP_ADDRESS.into()),
             false,
             OutletAccessControl::WithPolicyExpression(outlet_policy_expression),
+            false,
+            false,
             false,
         )
         .await?;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/background_node_client.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/background_node_client.rs
@@ -26,6 +26,8 @@ pub fn create_inlet_payload(
     disable_tcp_fallback: bool,
     privileged: bool,
     tls_certificate_provider: &Option<MultiAddr>,
+    skip_handshake: bool,
+    enable_nagle: bool,
 ) -> CreateInlet {
     let via_project = outlet_addr.matches(0, &[ProjectProto::CODE.into()]);
     let mut payload = if via_project {
@@ -37,6 +39,8 @@ pub fn create_inlet_payload(
             enable_udp_puncture,
             disable_tcp_fallback,
             privileged,
+            skip_handshake,
+            enable_nagle,
         )
     } else {
         CreateInlet::to_node(
@@ -48,6 +52,8 @@ pub fn create_inlet_payload(
             enable_udp_puncture,
             disable_tcp_fallback,
             privileged,
+            skip_handshake,
+            enable_nagle,
         )
     };
     if let Some(e) = policy_expression.as_ref() {
@@ -80,6 +86,8 @@ impl Inlets for BackgroundNodeClient {
         disable_tcp_fallback: bool,
         privileged: bool,
         tls_certificate_provider: &Option<MultiAddr>,
+        skip_handshake: bool,
+        enable_nagle: bool,
     ) -> miette::Result<Reply<InletStatus>> {
         let request = {
             let payload = create_inlet_payload(
@@ -95,6 +103,8 @@ impl Inlets for BackgroundNodeClient {
                 disable_tcp_fallback,
                 privileged,
                 tls_certificate_provider,
+                skip_handshake,
+                enable_nagle,
             );
             Request::post("/node/inlet").body(payload)
         };

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/in_memory_node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/in_memory_node.rs
@@ -30,6 +30,8 @@ impl InMemoryNode {
         disable_tcp_fallback: bool,
         privileged: bool,
         tls_certificate_provider: Option<MultiAddr>,
+        skip_handshake: bool,
+        enable_nagle: bool,
     ) -> Result<InletStatus> {
         self.node_manager
             .create_inlet(
@@ -48,6 +50,8 @@ impl InMemoryNode {
                 disable_tcp_fallback,
                 privileged,
                 tls_certificate_provider,
+                skip_handshake,
+                enable_nagle,
             )
             .await
     }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/inlets_trait.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/inlets_trait.rs
@@ -27,6 +27,8 @@ pub trait Inlets {
         disable_tcp_fallback: bool,
         privileged: bool,
         tls_certificate_provider: &Option<MultiAddr>,
+        skip_handshake: bool,
+        enable_nagle: bool,
     ) -> miette::Result<Reply<InletStatus>>;
 
     async fn show_inlet(&self, ctx: &Context, alias: &str) -> miette::Result<Reply<InletStatus>>;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/node_manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/node_manager.rs
@@ -41,6 +41,8 @@ impl NodeManager {
         disable_tcp_fallback: bool,
         privileged: bool,
         tls_certificate_provider: Option<MultiAddr>,
+        skip_handshake: bool,
+        enable_nagle: bool,
     ) -> Result<InletStatus> {
         debug! {
             %listen_address,
@@ -50,6 +52,8 @@ impl NodeManager {
             %alias,
             %enable_udp_puncture,
             %disable_tcp_fallback,
+            %skip_handshake,
+            %enable_nagle,
             "creating inlet"
         }
 
@@ -127,6 +131,8 @@ impl NodeManager {
             udp_puncture: None,
             additional_route: None,
             privileged,
+            skip_handshake,
+            enable_nagle,
         };
 
         let replacer = Arc::new(Mutex::new(replacer));

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/node_manager_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/node_manager_worker.rs
@@ -30,6 +30,8 @@ impl NodeManagerWorker {
             disable_tcp_fallback,
             privileged,
             tls_certificate_provider,
+            skip_handshake,
+            enable_nagle,
         } = create_inlet;
         match self
             .node_manager
@@ -49,6 +51,8 @@ impl NodeManagerWorker {
                 disable_tcp_fallback,
                 privileged,
                 tls_certificate_provider,
+                skip_handshake,
+                enable_nagle,
             )
             .await
         {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/session_replacer.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/session_replacer.rs
@@ -55,6 +55,8 @@ pub(super) struct InletSessionReplacer {
     pub(super) udp_puncture: Option<UdpPuncture>,
     pub(super) additional_route: Option<Route>,
     pub(super) privileged: bool,
+    pub(super) skip_handshake: bool,
+    pub(super) enable_nagle: bool,
 }
 
 impl InletSessionReplacer {
@@ -109,7 +111,9 @@ impl InletSessionReplacer {
         let (incoming_ac, outgoing_ac) = self.access_control(node_manager).await?;
         let options = TcpInletOptions::new()
             .with_incoming_access_control(incoming_ac)
-            .with_outgoing_access_control(outgoing_ac);
+            .with_outgoing_access_control(outgoing_ac)
+            .set_skip_handshake(self.skip_handshake)
+            .set_enable_nagle(self.enable_nagle);
 
         let options = if self.udp_puncture_enabled() && self.disable_tcp_fallback {
             options.paused()

--- a/implementations/rust/ockam/ockam_api/src/test_utils/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/test_utils/mod.rs
@@ -214,7 +214,10 @@ impl TestNode {
     }
 
     pub async fn create(runtime: Arc<Runtime>, listen_addr: Option<&str>) -> Self {
-        let (mut context, executor) = NodeBuilder::new().with_runtime(runtime).build();
+        let (mut context, executor) = NodeBuilder::new()
+            .with_runtime(runtime)
+            .no_logging()
+            .build();
         let node_manager_handle = start_manager_for_tests(
             &mut context,
             listen_addr,

--- a/implementations/rust/ockam/ockam_api/tests/portals.rs
+++ b/implementations/rust/ockam/ockam_api/tests/portals.rs
@@ -36,6 +36,8 @@ async fn inlet_outlet_local_successful(context: &mut Context) -> ockam::Result<(
             true,
             OutletAccessControl::AccessControl((Arc::new(AllowAll), Arc::new(AllowAll))),
             false,
+            false,
+            false,
         )
         .await?;
 
@@ -60,6 +62,8 @@ async fn inlet_outlet_local_successful(context: &mut Context) -> ockam::Result<(
             false,
             false,
             None,
+            false,
+            false,
         )
         .await?;
 
@@ -112,6 +116,8 @@ fn portal_node_goes_down_reconnect() {
                     true,
                     OutletAccessControl::AccessControl((Arc::new(AllowAll), Arc::new(AllowAll))),
                     false,
+                    false,
+                    false,
                 )
                 .await?;
 
@@ -138,6 +144,8 @@ fn portal_node_goes_down_reconnect() {
                     false,
                     false,
                     None,
+                    false,
+                    false,
                 )
                 .await?;
 
@@ -182,6 +190,8 @@ fn portal_node_goes_down_reconnect() {
                     Some(Address::from_string("outlet")),
                     true,
                     OutletAccessControl::AccessControl((Arc::new(AllowAll), Arc::new(AllowAll))),
+                    false,
+                    false,
                     false,
                 )
                 .await?;
@@ -258,6 +268,8 @@ fn portal_low_bandwidth_connection_keep_working_for_60s() {
                     true,
                     OutletAccessControl::AccessControl((Arc::new(AllowAll), Arc::new(AllowAll))),
                     false,
+                    false,
+                    false,
                 )
                 .await?;
 
@@ -296,6 +308,8 @@ fn portal_low_bandwidth_connection_keep_working_for_60s() {
                     false,
                     false,
                     None,
+                    false,
+                    false,
                 )
                 .await?;
 
@@ -379,6 +393,8 @@ fn portal_heavy_load_exchanged() {
                     true,
                     OutletAccessControl::AccessControl((Arc::new(AllowAll), Arc::new(AllowAll))),
                     false,
+                    false,
+                    false,
                 )
                 .await?;
 
@@ -410,6 +426,8 @@ fn portal_heavy_load_exchanged() {
                     false,
                     false,
                     None,
+                    false,
+                    false,
                 )
                 .await?;
 
@@ -525,6 +543,8 @@ fn test_portal_payload_transfer(outgoing_disruption: Disruption, incoming_disrup
                     true,
                     OutletAccessControl::AccessControl((Arc::new(AllowAll), Arc::new(AllowAll))),
                     false,
+                    false,
+                    false,
                 )
                 .await?;
 
@@ -563,6 +583,8 @@ fn test_portal_payload_transfer(outgoing_disruption: Disruption, incoming_disrup
                     false,
                     false,
                     None,
+                    false,
+                    false,
                 )
                 .await?;
 

--- a/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
@@ -212,6 +212,8 @@ impl AppState {
                 false,
                 false,
                 &None,
+                false,
+                false,
             )
             .await
             .map_err(|err| {

--- a/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/create.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/create.rs
@@ -47,6 +47,8 @@ impl AppState {
                 true,
                 OutletAccessControl::AccessControl((Arc::new(incoming_ac), Arc::new(outgoing_ac))),
                 false,
+                false,
+                false,
             )
             .await
         {

--- a/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/state.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/state.rs
@@ -77,6 +77,8 @@ impl AppState {
                         Arc::new(outgoing_ac),
                     )),
                     false,
+                    false,
+                    false,
                 )
                 .await
                 .map_err(|e| {

--- a/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
+++ b/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
@@ -53,8 +53,10 @@ UDP
 - OCKAM_UDP_MAX_ON_THE_WIRE_PACKET_SIZE: maximum size of a UDP packet on the wire. Default value: 508
 
 TCP
-- OCKAM_PRIVILEGED: if variable is set, all TCP Inlets/Outlets will use eBPF (overrides `--privileged` argument for `ockam tcp-inlet create` and `ockam tcp-outlet create`).
+- OCKAM_PRIVILEGED: if variable is set, all TCP Inlets/Outlets will use eBPF (overrides `--privileged` argument for `ockam tcp-inlet create` and `ockam tcp-outlet create`). WARNING: This flag value should be equal on both ends of a portal (inlet and outlet)
 - OCKAM_TCP_PORTAL_PAYLOAD_LENGTH: size of the buffer into which TCP Portal reads the TCP stream. Default value: `128 * 1024`
+- OCKAM_TCP_PORTAL_SKIP_HANDSHAKE: skip Portal handshake for lower latency, but also lower throughput. WARNING: This flag value should be equal on both ends of a portal (inlet and outlet)
+- OCKAM_TCP_PORTAL_ENABLE_NAGLE: enable Nagle's algorithm for Portal TCP streams for potentially higher throughput, but higher latency
 
 Devs Usage
 - OCKAM: a `string` that defines the path to the ockam binary to use.

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -142,6 +142,7 @@ pub struct CreateCommand {
 
     /// Use eBPF and RawSocket to access TCP packets instead of TCP data stream.
     /// If `OCKAM_PRIVILEGED` env variable is set to 1, this argument will be `true`.
+    /// WARNING: This flag value should be equal on both ends of a portal (inlet and outlet)
     #[arg(long, env = "OCKAM_PRIVILEGED", value_parser = FalseyValueParser::default(), hide = true)]
     pub privileged: bool,
 
@@ -153,6 +154,15 @@ pub struct CreateCommand {
     /// Requires `ockam-tls-certificate` credential attribute.
     #[arg(long, value_name = "ROUTE", hide = true)]
     pub tls_certificate_provider: Option<MultiAddr>,
+
+    /// Skip Portal handshake for lower latency, but also lower throughput
+    /// WARNING: This flag value should be equal on both ends of a portal (inlet and outlet)
+    #[arg(long, env = "OCKAM_TCP_PORTAL_SKIP_HANDSHAKE", value_parser = FalseyValueParser::default())]
+    pub skip_handshake: bool,
+
+    /// Enable Nagle's algorithm for potentially higher throughput, but higher latency
+    #[arg(long, env = "OCKAM_TCP_PORTAL_ENABLE_NAGLE", value_parser = FalseyValueParser::default())]
+    pub enable_nagle: bool,
 }
 
 pub(crate) fn tcp_inlet_default_from_addr() -> SchemeHostnamePort {
@@ -199,6 +209,8 @@ impl Command for CreateCommand {
                         cmd.no_tcp_fallback,
                         cmd.privileged,
                         &cmd.tls_certificate_provider,
+                        cmd.skip_handshake,
+                        cmd.enable_nagle,
                     )
                     .await?;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -71,8 +71,18 @@ pub struct CreateCommand {
 
     /// Use eBPF and RawSocket to access TCP packets instead of TCP data stream.
     /// If `OCKAM_PRIVILEGED` env variable is set to 1, this argument will be `true`.
+    /// WARNING: This flag value should be equal on both ends of a portal (inlet and outlet)
     #[arg(long, env = "OCKAM_PRIVILEGED", value_parser = FalseyValueParser::default(), hide = true)]
     pub privileged: bool,
+
+    /// Skip Portal handshake for lower latency, but also lower throughput
+    /// WARNING: This flag value should be equal on both ends of a portal (inlet and outlet)
+    #[arg(long, env = "OCKAM_TCP_PORTAL_SKIP_HANDSHAKE", value_parser = FalseyValueParser::default())]
+    pub skip_handshake: bool,
+
+    /// Enable Nagle's algorithm for potentially higher throughput, but higher latency
+    #[arg(long, env = "OCKAM_TCP_PORTAL_ENABLE_NAGLE", value_parser = FalseyValueParser::default())]
+    pub enable_nagle: bool,
 }
 
 #[async_trait]
@@ -100,6 +110,8 @@ impl Command for CreateCommand {
                 cmd.name.clone().map(Address::from).as_ref(),
                 cmd.allow.clone(),
                 cmd.privileged,
+                cmd.skip_handshake,
+                cmd.enable_nagle,
             )
             .await?
         };

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/portals.bats
@@ -14,162 +14,6 @@ teardown() {
 
 # ===== TESTS
 
-@test "portals - create tcp outlet on implicit default node" {
-  run_success "$OCKAM" node delete --all -y
-
-  outlet_port="$(random_port)"
-  run_success $OCKAM tcp-outlet create --to "127.0.0.1:$outlet_port"
-  assert_output --partial "/service/outlet"
-}
-
-@test "portals - create tcp outlet" {
-  run_success "$OCKAM" node delete --all -y
-
-  outlet_port="$(random_port)"
-  run_success $OCKAM tcp-outlet create --to "127.0.0.1:$outlet_port" --from "test-outlet"
-  assert_output --partial "/service/test-outlet"
-
-  # The first outlet that is created without `--from` flag should be named `outlet`
-  run_success $OCKAM tcp-outlet create --to "127.0.0.1:$outlet_port"
-  assert_output --partial "/service/outlet"
-
-  # After that, the next outlet should be randomly named
-  run_success $OCKAM tcp-outlet create --to "127.0.0.1:$outlet_port"
-  refute_output --partial "/service/outlet"
-}
-
-@test "portals - tcp inlet CRUD" {
-
-  # Create nodes for inlet/outlet pair
-  run_success "$OCKAM" node create n1
-  run_success "$OCKAM" node create n2
-
-  # Create inlet/outlet pair
-  outlet_port="$(random_port)"
-  run_success $OCKAM tcp-outlet create --at /node/n1 --to "127.0.0.1:$outlet_port"
-  assert_output --partial "/service/outlet"
-
-  inlet_port="$(random_port)"
-  run_success $OCKAM tcp-inlet create "test-inlet" --at /node/n2 --from 127.0.0.1:$inlet_port --to /node/n1/service/outlet
-  run_success $OCKAM tcp-inlet create --at /node/n2 --from 6102 --to /node/n1/service/outlet
-
-  sleep 1
-
-  # Check that inlet is available for deletion and delete it
-  run_success $OCKAM tcp-inlet show test-inlet --at /node/n2 --output json
-  assert_output --partial "\"alias\": \"test-inlet\""
-  assert_output --partial "\"bind_addr\": \"127.0.0.1:$inlet_port\""
-
-  run_success $OCKAM tcp-inlet delete "test-inlet" --at /node/n2 --yes
-
-  # Test deletion of a previously deleted TCP inlet
-  run_failure $OCKAM tcp-inlet delete "test-inlet" --at /node/n2 --yes
-  assert_output --partial "not found"
-}
-
-@test "portals - tcp outlet CRUD" {
-  run_success "$OCKAM" node create n1
-
-  run_success "$OCKAM" node create n2
-
-  port_1="$(random_port)"
-  run_success $OCKAM tcp-outlet create --at /node/n1 --to "127.0.0.1:$port_1"
-  assert_output --partial "/service/outlet"
-
-  port_2="$(random_port)"
-  run_success $OCKAM tcp-outlet create --at /node/n2 --to $port_2
-
-  run_success $OCKAM tcp-outlet show outlet --at /node/n1
-  assert_output --partial "\"worker_address\": \"/service/outlet\""
-  assert_output --partial "\"to\": \"127.0.0.1:$port_1\""
-
-  run_success $OCKAM tcp-outlet delete "outlet" --yes
-
-  # Test deletion of a previously deleted TCP outlet
-  run_success $OCKAM tcp-outlet delete "outlet" --yes
-  assert_output --partial "[]"
-}
-
-@test "portals - list inlets on a node" {
-  run_success "$OCKAM" node create n1
-  run_success "$OCKAM" node create n2
-
-  port="$(random_port)"
-  run_success $OCKAM tcp-inlet create tcp-inlet-2 --at /node/n2 --from $port --to /node/n1/service/outlet
-  sleep 1
-
-  run_success $OCKAM tcp-inlet list --at /node/n2
-  assert_output --partial "tcp-inlet-2"
-  assert_output --partial "127.0.0.1:$port"
-}
-
-@test "portals - list inlets on a node, using deprecated --alias flag" {
-  run_success "$OCKAM" node create n1
-  run_success "$OCKAM" node create n2
-
-  port="$(random_port)"
-  run_success $OCKAM tcp-inlet create --at /node/n2 --from $port --to /node/n1/service/outlet --alias tcp-inlet-2
-  sleep 1
-
-  run_success $OCKAM tcp-inlet list --at /node/n2
-  assert_output --partial "tcp-inlet-2"
-  assert_output --partial "127.0.0.1:$port"
-}
-
-@test "portals - list inlets on a node, using deprecated --alias flag overriding name" {
-  run_success "$OCKAM" node create n1
-  run_success "$OCKAM" node create n2
-
-  port="$(random_port)"
-  run_success $OCKAM tcp-inlet create my-inlet --at /node/n2 --from $port --to /node/n1/service/outlet --alias tcp-inlet-2
-  sleep 1
-
-  run_success $OCKAM tcp-inlet list --at /node/n2
-  assert_output --partial "tcp-inlet-2"
-  assert_output --partial "127.0.0.1:$port"
-}
-
-@test "portals - list outlets on a node" {
-  run_success "$OCKAM" node create n1
-
-  port="$(random_port)"
-  run_success $OCKAM tcp-outlet create --at /node/n1 --to "$port"
-  assert_output --partial "/service/outlet"
-
-  run_success $OCKAM tcp-outlet list --at /node/n1
-  assert_output --partial "/service/outlet"
-  assert_output --partial "127.0.0.1:$port"
-}
-
-@test "portals - show a tcp inlet" {
-  run_success "$OCKAM" node create n1
-  run_success "$OCKAM" node create n2
-
-  port="$(random_port)"
-  run_success $OCKAM tcp-inlet create "test-inlet" --at /node/n2 --from $port --to /node/n1/service/outlet
-  sleep 1
-
-  run_success $OCKAM tcp-inlet show "test-inlet" --at /node/n2
-
-  # Test if non-existing TCP inlet returns NotFound
-  run_failure $OCKAM tcp-inlet show "non-existing-inlet" --at /node/n2
-  assert_output --partial "not found"
-}
-
-@test "portals - show a tcp outlet" {
-  run_success "$OCKAM" node create n1
-
-  port="$(random_port)"
-  run_success $OCKAM tcp-outlet create --at /node/n1 --to "$port"
-  assert_output --partial "/service/outlet"
-
-  run_success $OCKAM tcp-outlet show "outlet"
-
-  # Test if non-existing TCP outlet returns NotFound
-  run_failure $OCKAM tcp-outlet show "non-existing-outlet"
-  assert_output --partial "not found"
-}
-
 @test "portals - create an inlet/outlet pair and move tcp traffic through it" {
   run_success "$OCKAM" node create n1
   run_success "$OCKAM" node create n2
@@ -234,6 +78,77 @@ teardown() {
   port="$(random_port)"
   run_success bash -c "$OCKAM secure-channel create --from /node/green --to /node/relay/service/forward_to_blue/service/api \
     | $OCKAM tcp-inlet create --at /node/green --from $port --to -/service/outlet"
+
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
+
+  run_success "$OCKAM" secure-channel list --at green
+  assert_output --partial "/service"
+}
+
+@test "portals no handshake - create an inlet/outlet pair and move tcp traffic through it" {
+  run_success "$OCKAM" node create n1
+  run_success "$OCKAM" node create n2
+
+  run_success "$OCKAM" tcp-outlet create --at /node/n1 --to "$PYTHON_SERVER_PORT" --skip-handshake
+  port="$(random_port)"
+  run_success "$OCKAM" tcp-inlet create --at /node/n2 --from "$port" --to /node/n1/service/outlet --skip-handshake
+
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
+}
+
+@test "portals no handshake - create an inlet/outlet, download file" {
+  run_success "$OCKAM" node create n1
+  run_success "$OCKAM" node create n2
+
+  run_success "$OCKAM" tcp-outlet create --at /node/n1 --to "$PYTHON_SERVER_PORT" --skip-handshake
+  port="$(random_port)"
+  run_success "$OCKAM" tcp-inlet create --at /node/n2 --from "$port" --to /node/n1/service/outlet --skip-handshake
+
+  file_name="$(random_str)".bin
+  pushd "$OCKAM_HOME_BASE" && dd if=/dev/urandom of="./.tmp/$file_name" bs=1M count=50 && popd
+  run_success curl -sSf --retry-all-errors --retry-delay 5 --retry 10 -m 20 -o /dev/null "http://127.0.0.1:$port/.tmp/$file_name"
+}
+
+@test "portals no handshake - create an inlet/outlet, upload file" {
+  run_success "$OCKAM" node create n1
+  run_success "$OCKAM" node create n2
+
+  run_success "$OCKAM" tcp-outlet create --at /node/n1 --to "$PYTHON_SERVER_PORT" --skip-handshake
+  port="$(random_port)"
+  run_success "$OCKAM" tcp-inlet create --at /node/n2 --from "$port" --to /node/n1/service/outlet --skip-handshake
+
+  file_name="$(random_str)".bin
+  tmp_dir_name="$(random_str)"
+  pushd "$OCKAM_HOME_BASE/.tmp"
+  mkdir "$tmp_dir_name"
+  dd if=/dev/urandom of="./$tmp_dir_name/$file_name" bs=1M count=50
+  popd
+  run_success curl -sS --retry-all-errors --retry-delay 5 --retry 10 -m 20 -X POST "http://127.0.0.1:$port/upload" -F "files=@$OCKAM_HOME_BASE/.tmp/$tmp_dir_name/$file_name"
+}
+
+@test "portals no handshake - create an inlet/outlet pair and move tcp traffic through it, where the outlet points to an HTTPs endpoint" {
+  run_success "$OCKAM" node create n1
+  run_success "$OCKAM" node create n2
+
+  run_success "$OCKAM" tcp-outlet create --at /node/n1 --to google.com:443 --skip-handshake
+  port="$(random_port)"
+  run_success "$OCKAM" tcp-inlet create --at /node/n2 --from "$port" --to /node/n1/service/outlet --skip-handshake
+
+  # This test does not pass on CI
+  # run_success curl --fail --head --max-time 10 "127.0.0.1:$port"
+}
+
+@test "portals no handshake - create an inlet/outlet pair with relay through a relay and move tcp traffic through it" {
+  run_success "$OCKAM" node create relay
+  run_success "$OCKAM" node create blue
+
+  run_success "$OCKAM" tcp-outlet create --at /node/blue --to "$PYTHON_SERVER_PORT" --skip-handshake
+  run_success "$OCKAM" relay create blue --at /node/relay --to /node/blue
+
+  run_success "$OCKAM" node create green
+  port="$(random_port)"
+  run_success bash -c "$OCKAM secure-channel create --from /node/green --to /node/relay/service/forward_to_blue/service/api \
+    | $OCKAM tcp-inlet create --at /node/green --from $port --to -/service/outlet --skip-handshake"
 
   run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/portals_lifecycle.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/portals_lifecycle.bats
@@ -1,0 +1,166 @@
+#!/bin/bash
+
+# ===== SETUP
+
+setup() {
+  load ../load/base.bash
+  load_bats_ext
+  setup_home_dir
+}
+
+teardown() {
+  teardown_home_dir
+}
+
+# ===== TESTS
+
+@test "portals - create tcp outlet on implicit default node" {
+  outlet_port="$(random_port)"
+  run_success $OCKAM tcp-outlet create --to "127.0.0.1:$outlet_port"
+  assert_output --partial "/service/outlet"
+}
+
+@test "portals - create tcp outlet" {
+  outlet_port="$(random_port)"
+  run_success $OCKAM tcp-outlet create --to "127.0.0.1:$outlet_port" --from "test-outlet"
+  assert_output --partial "/service/test-outlet"
+
+  # The first outlet that is created without `--from` flag should be named `outlet`
+  run_success $OCKAM tcp-outlet create --to "127.0.0.1:$outlet_port"
+  assert_output --partial "/service/outlet"
+
+  # After that, the next outlet should be randomly named
+  run_success $OCKAM tcp-outlet create --to "127.0.0.1:$outlet_port"
+  refute_output --partial "/service/outlet"
+}
+
+@test "portals - tcp inlet CRUD" {
+  # Create nodes for inlet/outlet pair
+  run_success "$OCKAM" node create n1
+  run_success "$OCKAM" node create n2
+
+  # Create inlet/outlet pair
+  outlet_port="$(random_port)"
+  run_success $OCKAM tcp-outlet create --at /node/n1 --to "127.0.0.1:$outlet_port"
+  assert_output --partial "/service/outlet"
+
+  inlet_port="$(random_port)"
+  run_success $OCKAM tcp-inlet create "test-inlet" --at /node/n2 --from 127.0.0.1:$inlet_port --to /node/n1/service/outlet
+  run_success $OCKAM tcp-inlet create --at /node/n2 --from 6102 --to /node/n1/service/outlet
+
+  sleep 1
+
+  # Check that inlet is available for deletion and delete it
+  run_success $OCKAM tcp-inlet show test-inlet --at /node/n2 --output json
+  assert_output --partial "\"alias\": \"test-inlet\""
+  assert_output --partial "\"bind_addr\": \"127.0.0.1:$inlet_port\""
+
+  run_success $OCKAM tcp-inlet delete "test-inlet" --at /node/n2 --yes
+
+  # Test deletion of a previously deleted TCP inlet
+  run_failure $OCKAM tcp-inlet delete "test-inlet" --at /node/n2 --yes
+  assert_output --partial "not found"
+}
+
+@test "portals - tcp outlet CRUD" {
+  run_success "$OCKAM" node create n1
+
+  run_success "$OCKAM" node create n2
+
+  port_1="$(random_port)"
+  run_success $OCKAM tcp-outlet create --at /node/n1 --to "127.0.0.1:$port_1"
+  assert_output --partial "/service/outlet"
+
+  port_2="$(random_port)"
+  run_success $OCKAM tcp-outlet create --at /node/n2 --to $port_2
+
+  run_success $OCKAM tcp-outlet show outlet --at /node/n1
+  assert_output --partial "\"worker_address\": \"/service/outlet\""
+  assert_output --partial "\"to\": \"127.0.0.1:$port_1\""
+
+  run_success $OCKAM tcp-outlet delete "outlet" --yes
+
+  # Test deletion of a previously deleted TCP outlet
+  run_success $OCKAM tcp-outlet delete "outlet" --yes
+  assert_output --partial "[]"
+}
+
+@test "portals - list inlets on a node" {
+  run_success "$OCKAM" node create n1
+  run_success "$OCKAM" node create n2
+
+  port="$(random_port)"
+  run_success $OCKAM tcp-inlet create tcp-inlet-2 --at /node/n2 --from $port --to /node/n1/service/outlet
+  sleep 1
+
+  run_success $OCKAM tcp-inlet list --at /node/n2
+  assert_output --partial "tcp-inlet-2"
+  assert_output --partial "127.0.0.1:$port"
+}
+
+@test "portals - list inlets on a node, using deprecated --alias flag" {
+  run_success "$OCKAM" node create n1
+  run_success "$OCKAM" node create n2
+
+  port="$(random_port)"
+  run_success $OCKAM tcp-inlet create --at /node/n2 --from $port --to /node/n1/service/outlet --alias tcp-inlet-2
+  sleep 1
+
+  run_success $OCKAM tcp-inlet list --at /node/n2
+  assert_output --partial "tcp-inlet-2"
+  assert_output --partial "127.0.0.1:$port"
+}
+
+@test "portals - list inlets on a node, using deprecated --alias flag overriding name" {
+  run_success "$OCKAM" node create n1
+  run_success "$OCKAM" node create n2
+
+  port="$(random_port)"
+  run_success $OCKAM tcp-inlet create my-inlet --at /node/n2 --from $port --to /node/n1/service/outlet --alias tcp-inlet-2
+  sleep 1
+
+  run_success $OCKAM tcp-inlet list --at /node/n2
+  assert_output --partial "tcp-inlet-2"
+  assert_output --partial "127.0.0.1:$port"
+}
+
+@test "portals - list outlets on a node" {
+  run_success "$OCKAM" node create n1
+
+  port="$(random_port)"
+  run_success $OCKAM tcp-outlet create --at /node/n1 --to "$port"
+  assert_output --partial "/service/outlet"
+
+  run_success $OCKAM tcp-outlet list --at /node/n1
+  assert_output --partial "/service/outlet"
+  assert_output --partial "127.0.0.1:$port"
+}
+
+@test "portals - show a tcp inlet" {
+  run_success "$OCKAM" node create n1
+  run_success "$OCKAM" node create n2
+
+  port="$(random_port)"
+  run_success $OCKAM tcp-inlet create "test-inlet" --at /node/n2 --from $port --to /node/n1/service/outlet
+  sleep 1
+
+  run_success $OCKAM tcp-inlet show "test-inlet" --at /node/n2
+
+  # Test if non-existing TCP inlet returns NotFound
+  run_failure $OCKAM tcp-inlet show "non-existing-inlet" --at /node/n2
+  assert_output --partial "not found"
+}
+
+@test "portals - show a tcp outlet" {
+  run_success "$OCKAM" node create n1
+
+  port="$(random_port)"
+  run_success $OCKAM tcp-outlet create --at /node/n1 --to "$port"
+  assert_output --partial "/service/outlet"
+
+  run_success $OCKAM tcp-outlet show "outlet"
+
+  # Test if non-existing TCP outlet returns NotFound
+  run_failure $OCKAM tcp-outlet show "non-existing-outlet"
+  assert_output --partial "not found"
+}

--- a/implementations/rust/ockam/ockam_command/tests/bats/run.sh
+++ b/implementations/rust/ockam/ockam_command/tests/bats/run.sh
@@ -48,11 +48,12 @@ done
 if [ "$local_suite" = true ]; then
   echo "Running local suite..."
   bats "$current_directory/local" --timing -j 3
+  OCKAM_TCP_PORTAL_SKIP_HANDSHAKE=1 bats "$current_directory/local/portals.bats" --timing -j 3
 fi
 
 if [ "$local_as_root_suite" = true ]; then
   echo "Running local root suite..."
-  OCKAM_PRIVILEGED=1 bats "$current_directory/local/portals.bats" --timing -j 3
+  OCKAM_PRIVILEGED=1 bats "$current_directory/local/portals_lifecycle.bats" "$current_directory/local/portals.bats" --timing -j 3
 fi
 
 if [ -z "${ORCHESTRATOR_TESTS}" ]; then

--- a/implementations/rust/ockam/ockam_core/src/message.rs
+++ b/implementations/rust/ockam/ockam_core/src/message.rs
@@ -214,14 +214,14 @@ impl<M: Message> Routed<M> {
 
     /// Return a copy of the message address.
     #[inline]
-    pub fn msg_addr(&self) -> Address {
-        self.msg_addr.clone()
+    pub fn msg_addr(&self) -> &Address {
+        &self.msg_addr
     }
 
     /// True sender of the message
     #[inline]
-    pub fn src_addr(&self) -> Address {
-        self.src_addr.clone()
+    pub fn src_addr(&self) -> &Address {
+        &self.src_addr
     }
 
     /// Return a copy of the onward route for the wrapped message.

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/encryptor_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/encryptor_worker.rs
@@ -369,16 +369,16 @@ impl Worker for EncryptorWorker {
         let msg_addr = msg.msg_addr();
 
         if self.key_exchange_only {
-            if msg_addr == self.addresses.encryptor_api {
+            if msg_addr == &self.addresses.encryptor_api {
                 self.handle_encrypt_api(ctx, msg).await?;
             } else {
                 return Err(IdentityError::UnknownChannelMsgDestination)?;
             }
-        } else if msg_addr == self.addresses.encryptor {
+        } else if msg_addr == &self.addresses.encryptor {
             self.handle_encrypt(ctx, msg).await?;
-        } else if msg_addr == self.addresses.encryptor_api {
+        } else if msg_addr == &self.addresses.encryptor_api {
             self.handle_encrypt_api(ctx, msg).await?;
-        } else if msg_addr == self.addresses.encryptor_internal {
+        } else if msg_addr == &self.addresses.encryptor_internal {
             self.handle_refresh_credentials(ctx).await?;
         } else {
             return Err(IdentityError::UnknownChannelMsgDestination)?;

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_worker.rs
@@ -332,14 +332,14 @@ impl HandshakeWorker {
         let msg_addr = message.msg_addr();
 
         if self.key_exchange_only {
-            if msg_addr == self.addresses.decryptor_api {
+            if msg_addr == &self.addresses.decryptor_api {
                 decryptor_handler.handle_decrypt_api(context, message).await
             } else {
                 Err(IdentityError::UnknownChannelMsgDestination)?
             }
-        } else if msg_addr == self.addresses.decryptor_remote {
+        } else if msg_addr == &self.addresses.decryptor_remote {
             decryptor_handler.handle_decrypt(context, message).await
-        } else if msg_addr == self.addresses.decryptor_api {
+        } else if msg_addr == &self.addresses.decryptor_api {
             decryptor_handler.handle_decrypt_api(context, message).await
         } else {
             Err(IdentityError::UnknownChannelMsgDestination)?

--- a/implementations/rust/ockam/ockam_node/src/error.rs
+++ b/implementations/rust/ockam/ockam_node/src/error.rs
@@ -154,6 +154,8 @@ pub enum WorkerReason {
     Faulty,
     /// The worker is otherwise corrupt and can not be recovered
     Corrupt,
+    /// Couldn't send shutdown signal
+    CtrlChannelError,
 }
 
 impl fmt::Display for WorkerReason {
@@ -165,6 +167,7 @@ impl fmt::Display for WorkerReason {
                 Self::Shutdown => "target worker is shutting down",
                 Self::Faulty => "target worker is faulty and waiting for supervisor",
                 Self::Corrupt => "target worker is corrupt and can not be recovered",
+                Self::CtrlChannelError => "target worker cannot receive shutdown signal",
             }
         )
     }

--- a/implementations/rust/ockam/ockam_node/src/router/record.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/record.rs
@@ -1,7 +1,7 @@
 use crate::channel_types::{oneshot_channel, MessageSender, OneshotReceiver, OneshotSender};
-use crate::error::{NodeError, NodeReason};
+use crate::error::NodeError;
 use crate::relay::CtrlSignal;
-use crate::WorkerShutdownPriority;
+use crate::{WorkerReason, WorkerShutdownPriority};
 use core::default::Default;
 use core::fmt::Debug;
 use core::sync::atomic::{AtomicUsize, Ordering};
@@ -461,7 +461,7 @@ impl AddressRecord {
         if !self.meta.detached && !skip_sending_stop_signal {
             self.ctrl_tx
                 .send(CtrlSignal::InterruptStop)
-                .map_err(|_| NodeError::NodeState(NodeReason::Unknown).internal())?;
+                .map_err(|_| NodeError::WorkerState(WorkerReason::CtrlChannelError).internal())?;
         }
 
         Ok(())

--- a/implementations/rust/ockam/ockam_transport_ble/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/router/mod.rs
@@ -110,11 +110,11 @@ impl Worker for BleRouter {
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<Any>) -> Result<()> {
         let msg_addr = msg.msg_addr();
 
-        if msg_addr == self.main_addr {
+        if msg_addr == &self.main_addr {
             let msg = LocalMessage::decode(msg.payload())?;
             trace!("handle_message route: {:?}", msg.onward_route());
             self.handle_route(ctx, msg).await?;
-        } else if msg_addr == self.api_addr {
+        } else if msg_addr == &self.api_addr {
             let msg = BleRouterMessage::decode(msg.payload())?;
             match msg {
                 BleRouterMessage::Register { accepts, self_addr } => {

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
@@ -177,7 +177,10 @@ impl Processor for TcpInletListenProcessor {
     #[instrument(skip_all, name = "TcpInletListenProcessor::process")]
     async fn process(&mut self, ctx: &mut Self::Context) -> Result<bool> {
         let (stream, socket_addr) = self.inner.accept().await.map_err(TransportError::from)?;
-        stream.set_nodelay(true).map_err(TransportError::from)?;
+
+        stream
+            .set_nodelay(!self.options.enable_nagle)
+            .map_err(TransportError::from)?;
 
         let addresses = Addresses::generate(PortalType::Inlet);
 
@@ -227,6 +230,7 @@ impl Processor for TcpInletListenProcessor {
             self.options.incoming_access_control.clone(),
             self.options.outgoing_access_control.clone(),
             self.options.portal_payload_length,
+            self.options.skip_handshake,
         )?;
 
         Ok(true)

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/interceptor.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/interceptor.rs
@@ -95,7 +95,7 @@ impl Worker for PortalOutletInterceptor {
         context: &mut Context,
         message: Routed<Self::Message>,
     ) -> ockam_core::Result<()> {
-        let source_address = message.src_addr();
+        let source_address = message.src_addr().clone();
         let mut message = message.into_local_message();
 
         // Remove our address
@@ -314,7 +314,7 @@ impl Worker for PortalInterceptorWorker {
                 match self.direction {
                     Direction::FromInletToOutlet => {
                         // if we receive a pong message, it means it must be from the other worker
-                        if routed_message.src_addr() == self.other_worker_address {
+                        if routed_message.src_addr() == &self.other_worker_address {
                             if let Some(fixed_onward_route) = self.fixed_onward_route.as_ref() {
                                 debug!(
                                     "updating onward route from {} to {}",

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/mod.rs
@@ -4,6 +4,7 @@ mod inlet_shared_state;
 mod interceptor;
 pub mod options;
 mod outlet_listener;
+mod outlet_listener_registry;
 mod portal_message;
 mod portal_receiver;
 mod portal_worker;

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/options.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/options.rs
@@ -18,6 +18,8 @@ pub struct TcpInletOptions {
     pub(crate) is_paused: bool,
     pub(crate) tls_certificate_provider: Option<Arc<dyn TlsCertificateProvider>>,
     pub(crate) portal_payload_length: usize,
+    pub(crate) skip_handshake: bool,
+    pub(crate) enable_nagle: bool,
 }
 
 impl TcpInletOptions {
@@ -29,7 +31,33 @@ impl TcpInletOptions {
             is_paused: false,
             tls_certificate_provider: None,
             portal_payload_length: read_portal_payload_length(),
+            skip_handshake: false,
+            enable_nagle: false,
         }
+    }
+
+    /// Skip Portal handshake for lower latency, but also lower throughput
+    pub fn set_skip_handshake(mut self, skip_handshake: bool) -> Self {
+        self.skip_handshake = skip_handshake;
+        self
+    }
+
+    /// Skip Portal handshake for lower latency, but also lower throughput
+    pub fn skip_handshake(mut self) -> Self {
+        self.skip_handshake = true;
+        self
+    }
+
+    /// Enable Nagle's algorithm for potentially higher throughput, but higher latency
+    pub fn set_enable_nagle(mut self, enable_nagle: bool) -> Self {
+        self.enable_nagle = enable_nagle;
+        self
+    }
+
+    /// Enable Nagle's algorithm for potentially higher throughput, but higher latency
+    pub fn enable_nagle(mut self) -> Self {
+        self.enable_nagle = true;
+        self
     }
 
     /// Set TCP inlet to paused mode after start. No unpause call [`TcpInlet::unpause`]
@@ -121,6 +149,8 @@ pub struct TcpOutletOptions {
     pub(crate) outgoing_access_control: Arc<dyn OutgoingAccessControl>,
     pub(crate) tls: bool,
     pub(crate) portal_payload_length: usize,
+    pub(crate) skip_handshake: bool,
+    pub(crate) enable_nagle: bool,
 }
 
 impl TcpOutletOptions {
@@ -132,7 +162,33 @@ impl TcpOutletOptions {
             outgoing_access_control: Arc::new(AllowAll),
             tls: false,
             portal_payload_length: read_portal_payload_length(),
+            skip_handshake: false,
+            enable_nagle: false,
         }
+    }
+
+    /// Skip Portal handshake for lower latency, but also lower throughput
+    pub fn set_skip_handshake(mut self, skip_handshake: bool) -> Self {
+        self.skip_handshake = skip_handshake;
+        self
+    }
+
+    /// Skip Portal handshake for lower latency, but also lower throughput
+    pub fn skip_handshake(mut self) -> Self {
+        self.skip_handshake = true;
+        self
+    }
+
+    /// Enable Nagle's algorithm for potentially higher throughput, but higher latency
+    pub fn set_enable_nagle(mut self, enable_nagle: bool) -> Self {
+        self.enable_nagle = enable_nagle;
+        self
+    }
+
+    /// Enable Nagle's algorithm for potentially higher throughput, but higher latency
+    pub fn enable_nagle(mut self) -> Self {
+        self.enable_nagle = true;
+        self
     }
 
     /// Set Incoming Access Control

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/outlet_listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/outlet_listener.rs
@@ -1,7 +1,9 @@
 use crate::portal::addresses::{Addresses, PortalType};
+use crate::portal::outlet_listener_registry::{MapKey, OutletListenerRegistry};
 use crate::{portal::TcpPortalWorker, PortalMessage, TcpOutletOptions, TcpRegistry};
 use ockam_core::{
-    async_trait, Address, DenyAll, NeutralMessage, Result, Routed, SecureChannelLocalInfo, Worker,
+    async_trait, route, Address, AllowAll, LocalMessage, NeutralMessage, Result, Routed,
+    SecureChannelLocalInfo, Worker,
 };
 use ockam_node::{Context, WorkerBuilder};
 use ockam_transport_core::{HostnamePort, TransportError};
@@ -16,6 +18,7 @@ pub(crate) struct TcpOutletListenWorker {
     registry: TcpRegistry,
     hostname_port: HostnamePort,
     options: TcpOutletOptions,
+    outlet_registry: OutletListenerRegistry,
 }
 
 impl TcpOutletListenWorker {
@@ -25,6 +28,7 @@ impl TcpOutletListenWorker {
             registry,
             hostname_port,
             options,
+            outlet_registry: Default::default(),
         }
     }
 
@@ -44,8 +48,30 @@ impl TcpOutletListenWorker {
         WorkerBuilder::new(worker)
             .with_address(address)
             .with_incoming_access_control_arc(access_control)
-            .with_outgoing_access_control(DenyAll)
+            .with_outgoing_access_control(AllowAll)
             .start(ctx)?;
+
+        Ok(())
+    }
+
+    async fn reroute_msg(ctx: &Context, sender_remote: Address, msg: LocalMessage) -> Result<()> {
+        let res = ctx
+            .forward_from_address(
+                LocalMessage::new()
+                    .with_onward_route(route![sender_remote.clone()])
+                    .with_return_route(msg.return_route)
+                    .with_local_info(msg.local_info)
+                    .with_payload(msg.payload),
+                ctx.primary_address().clone(),
+            )
+            .await;
+
+        if res.is_err() {
+            debug!(
+                "Couldn't forward message from the outlet to {}",
+                sender_remote
+            )
+        }
 
         Ok(())
     }
@@ -81,34 +107,85 @@ impl Worker for TcpOutletListenWorker {
         let their_identifier = SecureChannelLocalInfo::find_info(msg.local_message())
             .map(|l| l.their_identifier())
             .ok();
-        let src_addr = msg.src_addr();
-        let msg = msg.into_local_message();
-        let return_route = msg.return_route;
-        let body = msg.payload;
-        let msg = PortalMessage::decode(&body)?;
 
-        if !matches!(msg, PortalMessage::Ping) {
-            return Err(TransportError::Protocol)?;
+        let src_addr = msg.src_addr().clone();
+        let msg = msg.into_local_message();
+
+        let remote_address = msg.return_route.recipient()?.clone();
+
+        let map_key = MapKey {
+            identifier: their_identifier.clone(),
+            remote_address,
+        };
+
+        if self.options.skip_handshake {
+            let sender_remote = self
+                .outlet_registry
+                .started_workers
+                .read()
+                .unwrap()
+                .get(&map_key)
+                .cloned();
+
+            if let Some(sender_remote) = sender_remote {
+                return Self::reroute_msg(ctx, sender_remote, msg).await;
+            }
+        } else {
+            let msg = PortalMessage::decode(msg.payload())?;
+
+            if !matches!(msg, PortalMessage::Ping) {
+                return Err(TransportError::Protocol)?;
+            }
         }
 
         let addresses = Addresses::generate(PortalType::Outlet);
 
-        TcpOutletOptions::setup_flow_control_for_outlet(ctx.flow_controls(), &addresses, &src_addr);
+        if self.options.skip_handshake {
+            TcpPortalWorker::start_new_outlet_no_handshake(
+                ctx,
+                self.registry.clone(),
+                self.hostname_port.clone(),
+                self.options.tls,
+                msg.return_route.clone(),
+                their_identifier,
+                addresses.clone(),
+                self.options.outgoing_access_control.clone(),
+                self.options.portal_payload_length,
+                map_key.clone(),
+                self.outlet_registry.clone(),
+            )?;
 
-        TcpPortalWorker::start_new_outlet(
-            ctx,
-            self.registry.clone(),
-            self.hostname_port.clone(),
-            self.options.tls,
-            return_route.clone(),
-            their_identifier,
-            addresses.clone(),
-            self.options.incoming_access_control.clone(),
-            self.options.outgoing_access_control.clone(),
-            self.options.portal_payload_length,
-        )?;
+            debug!("Created Tcp Outlet at {}", addresses.sender_remote);
 
-        debug!("Created Tcp Outlet at {}", addresses.sender_remote);
+            self.outlet_registry
+                .started_workers
+                .write()
+                .unwrap()
+                .insert(map_key.clone(), addresses.sender_remote.clone());
+
+            Self::reroute_msg(ctx, addresses.sender_remote, msg).await?;
+        } else {
+            TcpOutletOptions::setup_flow_control_for_outlet(
+                ctx.flow_controls(),
+                &addresses,
+                &src_addr,
+            );
+
+            TcpPortalWorker::start_new_outlet(
+                ctx,
+                self.registry.clone(),
+                self.hostname_port.clone(),
+                self.options.tls,
+                msg.return_route.clone(),
+                their_identifier,
+                addresses.clone(),
+                self.options.incoming_access_control.clone(),
+                self.options.outgoing_access_control.clone(),
+                self.options.portal_payload_length,
+            )?;
+
+            debug!("Created Tcp Outlet at {}", addresses.sender_remote);
+        }
 
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/outlet_listener_registry.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/outlet_listener_registry.rs
@@ -1,0 +1,14 @@
+use ockam_core::compat::collections::HashMap;
+use ockam_core::compat::sync::{Arc, RwLock};
+use ockam_core::{Address, LocalInfoIdentifier};
+
+#[derive(Hash, Eq, PartialEq, Clone)]
+pub(crate) struct MapKey {
+    pub(crate) identifier: Option<LocalInfoIdentifier>,
+    pub(crate) remote_address: Address,
+}
+
+#[derive(Default, Clone)]
+pub struct OutletListenerRegistry {
+    pub(crate) started_workers: Arc<RwLock<HashMap<MapKey, Address>>>,
+}

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport/connection.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport/connection.rs
@@ -111,7 +111,7 @@ impl TcpTransport {
         let peer = HostnamePort::from_str(&peer.into())?;
         debug!("Connecting to {}", peer.clone());
 
-        let (read_half, write_half) = connect(&peer, options.timeout).await?;
+        let (read_half, write_half) = connect(&peer, false, options.timeout).await?;
         let socket = read_half
             .peer_addr()
             .map_err(|e| ockam_core::Error::new(Origin::Transport, Kind::Internal, e))?;

--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/sender.rs
@@ -108,7 +108,7 @@ impl TcpSendWorker {
 
         WorkerBuilder::new(sender_worker)
             .with_mailboxes(Mailboxes::new(main_mailbox.clone(), vec![internal_mailbox]))
-            .with_shutdown_priority(WorkerShutdownPriority::Priority1)
+            .with_shutdown_priority(WorkerShutdownPriority::Priority2)
             .start(ctx)?;
 
         Ok(())
@@ -116,7 +116,7 @@ impl TcpSendWorker {
 
     #[instrument(skip_all, name = "TcpSendWorker::stop")]
     fn stop(&self, ctx: &Context) -> Result<()> {
-        ctx.stop_address(self.addresses.sender_address())
+        ctx.stop_primary_address()
     }
 
     fn serialize_message(&mut self, local_message: LocalMessage) -> Result<()> {
@@ -215,7 +215,7 @@ impl Worker for TcpSendWorker {
         msg: Routed<Self::Message>,
     ) -> Result<()> {
         let recipient = msg.msg_addr();
-        if &recipient == self.addresses.sender_internal_address() {
+        if recipient == self.addresses.sender_internal_address() {
             let msg = TcpSendWorkerMsg::decode(msg.payload())?;
 
             match msg {

--- a/implementations/rust/ockam/ockam_transport_udp/src/puncture/puncture/receiver.rs
+++ b/implementations/rust/ockam/ockam_transport_udp/src/puncture/puncture/receiver.rs
@@ -283,11 +283,11 @@ impl Worker for UdpPunctureReceiverWorker {
         msg: Routed<Self::Message>,
     ) -> Result<()> {
         let addr = msg.msg_addr();
-        if &addr == self.addresses.remote_address() {
+        if addr == self.addresses.remote_address() {
             let msg = msg.into_local_message();
             let return_route = msg.return_route;
             self.handle_peer(ctx, msg.payload, &return_route).await?;
-        } else if &addr == self.addresses.heartbeat_address() {
+        } else if addr == self.addresses.heartbeat_address() {
             self.handle_heartbeat(ctx).await?;
         } else {
             return Err(PunctureError::Internal)?;

--- a/implementations/rust/ockam/ockam_transport_uds/src/router/uds_router.rs
+++ b/implementations/rust/ockam/ockam_transport_uds/src/router/uds_router.rs
@@ -275,9 +275,9 @@ impl Worker for UdsRouter {
         let return_route = msg.return_route().clone();
         let msg_addr = msg.msg_addr();
 
-        if msg_addr == self.main_addr {
+        if msg_addr == &self.main_addr {
             self.handle_route(ctx, msg.into_local_message()).await?;
-        } else if msg_addr == self.api_addr {
+        } else if msg_addr == &self.api_addr {
             let msg = UdsRouterRequest::decode(msg.payload())?;
             match msg {
                 UdsRouterRequest::Register { accepts, self_addr } => {

--- a/implementations/rust/ockam/ockam_transport_uds/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_uds/src/workers/sender.rs
@@ -253,7 +253,7 @@ impl Worker for UdsSendWorker {
         };
 
         let recipient = msg.msg_addr();
-        if recipient == self.internal_addr {
+        if recipient == &self.internal_addr {
             let msg = UdsSendWorkerMsg::decode(msg.payload())?;
 
             match msg {

--- a/implementations/rust/ockam/ockam_transport_websocket/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/router/mod.rs
@@ -121,9 +121,9 @@ impl Worker for WebSocketRouter {
         let return_route = msg.return_route().clone();
         let msg_addr = msg.msg_addr();
 
-        if msg_addr == self.main_addr {
+        if msg_addr == &self.main_addr {
             self.handle_route(ctx, msg.into_local_message()).await?;
-        } else if msg_addr == self.api_addr {
+        } else if msg_addr == &self.api_addr {
             let msg = WebSocketRouterRequest::decode(msg.payload())?;
             match msg {
                 WebSocketRouterRequest::Register { accepts, self_addr } => {

--- a/implementations/rust/ockam/ockam_transport_websocket/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/workers/sender.rs
@@ -190,7 +190,7 @@ where
         };
 
         let recipient = msg.msg_addr();
-        if recipient == self.internal_addr {
+        if recipient == &self.internal_addr {
             let msg = TransportMessage::latest(route![], route![], vec![]);
             // Sending empty heartbeat
             if ws_sink


### PR DESCRIPTION
1. Add `--skip-handshake` flag to tcp inlets&outlets, that makes handshake non-blocking to optimize latency (but possibly sacrificing throughput)
2. Add `--enable-nagle` flag to tcp inlets&outlets. By default we set nodelay flag on TCP streams, but that may sometimes be unwanted (for high throughput use cases)