### PR TITLE
feat(rust): improve defaults handling of branding compile env vars

### DIFF
--- a/implementations/rust/ockam/ockam_command/build.rs
+++ b/implementations/rust/ockam/ockam_command/build.rs
@@ -12,7 +12,8 @@ fn hash() {
 }
 
 fn binary_name() {
-    let is_developer = env::var("COMPILE_OCKAM_DEVELOPER").unwrap_or("false".to_string());
+    let is_developer = env::var("COMPILE_OCKAM_DEVELOPER")
+        .unwrap_or(env::var("OCKAM_DEVELOPER").unwrap_or("false".to_string()));
     println!("cargo:rustc-env=COMPILE_OCKAM_DEVELOPER={is_developer}");
     println!("cargo:rerun-if-env-changed=COMPILE_OCKAM_DEVELOPER");
 
@@ -29,7 +30,7 @@ fn binary_name() {
     println!("cargo:rustc-env=COMPILE_OCKAM_COMMAND_SUPPORT_EMAIL={support_email}");
     println!("cargo:rerun-if-env-changed=COMPILE_OCKAM_COMMAND_SUPPORT_EMAIL");
 
-    let home_dir = env::var("COMPILE_OCKAM_HOME").unwrap_or("".to_string());
+    let home_dir = env::var("COMPILE_OCKAM_HOME").unwrap_or(format!("$HOME/.{}", bin_name));
     println!("cargo:rustc-env=COMPILE_OCKAM_HOME={home_dir}");
     println!("cargo:rerun-if-env-changed=COMPILE_OCKAM_HOME");
 

--- a/implementations/rust/ockam/ockam_command/src/bin/brand.sample.yaml
+++ b/implementations/rust/ockam/ockam_command/src/bin/brand.sample.yaml
@@ -2,13 +2,13 @@ acme:
   support_email: support@acme.com
   # the following fields are optional
   brand_name: Acme # if not set, will default to Bin
-  home_dir: /home/acme # if not set, will default to $HOME/.bin
+  home_dir: $HOME/.acme # if not set, will default to $HOME/.bin
   orchestrator_identifier: I25242aa3d4a7b5aa986fb2bec15b3780aad0530660e5e5a46c7f9ce429e9ec99 # if not set, will default to the OCKAM_CONTROLLER_IDENTIFIER env var
   orchestrator_address: /dnsaddr/acme.io/tcp/6252/service/api # if not set, will default to the OCKAM_CONTROLLER_ADDRESS env var
-  build_args: # if not set, will default to empty string
-    - --no-default-features
-    - --features
-    - 'no_std alloc software_vault rust-crypto'
+#  build_args: # if not set, will default to empty string
+#    - --no-default-features
+#    - --features
+#    - 'no_std alloc software_vault rust-crypto'
   commands:
     - node: "host"
     - project

--- a/implementations/rust/ockam/ockam_command/src/branding/compile_env_vars.rs
+++ b/implementations/rust/ockam/ockam_command/src/branding/compile_env_vars.rs
@@ -25,6 +25,22 @@ const COMPILE_CONTROLLER_IDENTIFIER: &str = env!("COMPILE_OCKAM_CONTROLLER_IDENT
 /// in the format `command1=customName,command2,command3`
 const COMPILE_COMMANDS: &str = env!("COMPILE_OCKAM_COMMANDS");
 
+pub fn get_compile_time_vars() -> Vec<(&'static str, &'static str)> {
+    vec![
+        (COMPILE_OCKAM_DEVELOPER, COMPILE_DEVELOPER),
+        (COMPILE_OCKAM_HOME, COMPILE_HOME),
+        (COMPILE_OCKAM_COMMAND_BIN_NAME, COMPILE_BIN_NAME),
+        (COMPILE_OCKAM_COMMAND_BRAND_NAME, COMPILE_BRAND_NAME),
+        (COMPILE_OCKAM_COMMAND_SUPPORT_EMAIL, COMPILE_SUPPORT_EMAIL),
+        (COMPILE_OCKAM_CONTROLLER_ADDRESS, COMPILE_CONTROLLER_ADDRESS),
+        (
+            COMPILE_OCKAM_CONTROLLER_IDENTIFIER,
+            COMPILE_CONTROLLER_IDENTIFIER,
+        ),
+        (COMPILE_OCKAM_COMMANDS, COMPILE_COMMANDS),
+    ]
+}
+
 pub fn load_compile_time_vars() {
     // If OCKAM_DEVELOPER is not set, set it to the COMPILE_OCKAM_DEVELOPER value
     if get_env_ignore_error::<bool>(ockam_api::logs::env_variables::OCKAM_DEVELOPER).is_none() {

--- a/implementations/rust/ockam/ockam_command/src/environment/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/environment/mod.rs
@@ -1,6 +1,9 @@
+use crate::{docs, pager};
 use clap::Args;
-
-use crate::docs;
+use ockam_api::colors::{color_primary, color_warn};
+use ockam_api::fmt_log;
+use ockam_api::output::Output;
+use ockam_api::terminal::{INDENTATION, PADDING};
 
 const ENV_INFO: &str = include_str!("./static/env_info.txt");
 
@@ -10,11 +13,46 @@ pub struct EnvironmentCommand {}
 
 impl EnvironmentCommand {
     pub fn run(self) -> miette::Result<()> {
-        println!("{}", ENV_INFO);
+        pager::render_output(&format!("{}\n\n{}", Self::info(), Self::values()));
         Ok(())
     }
 
     pub fn name(&self) -> String {
-        "show environment variables".to_string()
+        "environment".to_string()
+    }
+
+    fn info() -> String {
+        ENV_INFO.padded_display()
+    }
+
+    fn values() -> String {
+        // get all the env vars and filter those containing OCKAM in their name
+        let runtime_vars = std::env::vars()
+            .filter(|(k, _)| k.contains("OCKAM"))
+            .map(|(k, v)| {
+                format!(
+                    "{}{}{}={}",
+                    PADDING,
+                    INDENTATION,
+                    color_primary(k),
+                    color_warn(v)
+                )
+            })
+            .collect::<Vec<String>>()
+            .join("\n");
+        let compile_vars = crate::branding::compile_env_vars::get_compile_time_vars()
+            .iter()
+            .map(|(k, v)| {
+                format!(
+                    "{}{}{}={}",
+                    PADDING,
+                    INDENTATION,
+                    color_primary(k),
+                    color_warn(v)
+                )
+            })
+            .collect::<Vec<String>>()
+            .join("\n");
+        fmt_log!("Values:\n{}\n{}", runtime_vars, compile_vars)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/pager.rs
+++ b/implementations/rust/ockam/ockam_command/src/pager.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 use std::path::PathBuf;
 use std::process;
-use std::process::Stdio;
+use std::process::{ExitStatus, Stdio};
 
 use console::Term;
 use miette::IntoDiagnostic;
@@ -10,20 +10,20 @@ use ockam_core::env::get_env_with_default;
 
 use crate::util::exitcode;
 
-pub fn render_help(help: clap::Error) {
+pub fn render_output(s: &str) {
     let pager = get_env_with_default("PAGER", "less".to_string()).expect("Invalid PAGER value");
     match which::which(pager) {
         Ok(pager_binary_path) => {
-            paginate_with(pager_binary_path, help).expect("Failed to paginate help");
+            paginate_with(pager_binary_path, s).expect("Failed to paginate output");
         }
-        // The pager binary was not found, so we just print the help without pagination
+        // The pager binary was not found, so we just print the output without pagination
         Err(_) => {
-            help.exit();
+            println!("{}", s);
         }
     }
 }
 
-fn paginate_with(pager_binary_path: PathBuf, help: clap::Error) -> miette::Result<()> {
+fn paginate_with(pager_binary_path: PathBuf, s: &str) -> miette::Result<ExitStatus> {
     let pager = pager_binary_path.file_name().unwrap().to_string_lossy();
     let mut pager_cmd = process::Command::new(pager.as_ref());
     if pager.as_ref() == "less" {
@@ -39,18 +39,33 @@ fn paginate_with(pager_binary_path: PathBuf, help: clap::Error) -> miette::Resul
             .stdin
             .take()
             .expect("Failed to get pager's stdin");
-        // Strip ANSI escape sequences if stdout is not a TTY (e.g. when piping to another command)
-        let rendered_text = if Term::stdout().is_term() {
-            help.render().ansi().to_string()
-        } else {
-            help.render().to_string()
-        };
         // Write the rendered text to the pager's stdin
-        pager_stdin
-            .write_all(rendered_text.as_bytes())
-            .into_diagnostic()?;
+        pager_stdin.write_all(s.as_bytes()).into_diagnostic()?;
     }
-    let _ = pager_process.wait();
+    pager_process.wait().into_diagnostic()
+}
+
+pub fn render_help(help: clap::Error) {
+    let pager = get_env_with_default("PAGER", "less".to_string()).expect("Invalid PAGER value");
+    match which::which(pager) {
+        Ok(pager_binary_path) => {
+            paginate_help_with(pager_binary_path, help).expect("Failed to paginate help");
+        }
+        // The pager binary was not found, so we just print the help without pagination
+        Err(_) => {
+            help.exit();
+        }
+    }
+}
+
+fn paginate_help_with(pager_binary_path: PathBuf, help: clap::Error) -> miette::Result<()> {
+    // Strip ANSI escape sequences if stdout is not a TTY (e.g. when piping to another command)
+    let rendered_text = if Term::stdout().is_term() {
+        help.render().ansi().to_string()
+    } else {
+        help.render().to_string()
+    };
+    paginate_with(pager_binary_path, &rendered_text)?;
     let code = if help.use_stderr() {
         exitcode::USAGE
     } else {


### PR DESCRIPTION
- show env values in `environment` command
- improve defaults handling of branding compile env vars
  - if OCKAM_HOME is not set, the command will use the default COMPILE_OCKAM_HOME value `$HOME/.$COMPILE_OCKAM_COMMAND_BIN_NAME`. This allows us to not fallback to the `$HOME/.ockam` in custom binaries and not expose that value.
  - when building custom binaries, if COMPILE_OCKAM_DEVELOPER is always set to false. In the build.rs script, COMPILE_OCKAM_DEVELOPER will be set to OCKAM_DEVELOPER, so that we don't have to specify both on our machines