### PR TITLE
fix(rust): add missing branding replacements in ockam_command

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/ui/command.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/command.rs
@@ -1,0 +1,92 @@
+use std::fmt::{Debug, Formatter};
+
+#[derive(Clone, Debug)]
+pub struct Commands {
+    pub(crate) commands: Vec<Command>,
+}
+
+#[derive(Clone)]
+pub(crate) struct Command {
+    pub(crate) name: &'static str,
+    pub(crate) custom_name: &'static str,
+}
+
+impl Debug for Command {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Command")
+            .field("name", &self.name)
+            .field("custom_name", &self.custom_name)
+            .finish()
+    }
+}
+
+impl Commands {
+    pub fn new(commands: &'static str) -> Self {
+        let commands = commands
+            .split(',')
+            .filter_map(|c| {
+                if c.is_empty() {
+                    return None;
+                }
+                let mut parts = c.split('=');
+                let name = match parts.next() {
+                    Some(name) => name,
+                    None => return None,
+                };
+                let custom_name = parts.next().unwrap_or(name);
+                Some(Command { name, custom_name })
+            })
+            .collect();
+        Self { commands }
+    }
+
+    pub fn hide(&self, command_name: &'static str) -> bool {
+        // No restrictions
+        if self.commands.is_empty() {
+            return false;
+        }
+        // Check if the command is in the list of hidden commands
+        !self.commands.iter().any(|c| c.name == command_name)
+    }
+
+    pub fn name(&self, command_name: &'static str) -> &'static str {
+        // No restrictions
+        if self.commands.is_empty() {
+            return command_name;
+        }
+        // Check the custom name in the list of renamed commands
+        self.commands
+            .iter()
+            .find(|c| c.name == command_name)
+            .map_or(command_name, |c| c.custom_name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hide() {
+        let commands = Commands::new("node=host,project,enroll");
+        assert!(!commands.hide("node"));
+        assert!(!commands.hide("project"));
+        assert!(!commands.hide("enroll"));
+        assert!(commands.hide("command4"));
+
+        let commands = Commands::new("");
+        assert!(!commands.hide("command1"));
+    }
+
+    #[test]
+    fn test_commands() {
+        let commands = Commands::new("node=host,project,enroll");
+        assert_eq!(commands.name("node"), "host");
+        assert_eq!(commands.name("project"), "project");
+        assert_eq!(commands.name("enroll"), "enroll");
+        assert_eq!(commands.name("command4"), "command4");
+
+        let commands = Commands::new("");
+        assert_eq!(commands.name("command1"), "command1");
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/ui/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/mod.rs
@@ -1,3 +1,4 @@
 pub mod colors;
+pub mod command;
 pub mod output;
 pub mod terminal;

--- a/implementations/rust/ockam/ockam_api/src/ui/output/branding.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/output/branding.rs
@@ -1,0 +1,51 @@
+use crate::command::Commands;
+
+#[derive(Clone, Debug)]
+pub struct OutputBranding {
+    pub brand_name: String,
+    pub bin_name: String,
+    pub commands: Commands,
+}
+
+impl OutputBranding {
+    pub fn new(brand_name: String, bin_name: String, commands: Commands) -> Self {
+        Self {
+            brand_name,
+            bin_name,
+            commands,
+        }
+    }
+
+    pub fn replace(&self, text: &str) -> String {
+        // brand name
+        let mut text = if self.brand_name != "Ockam" {
+            text.replace("Ockam", &self.brand_name)
+        } else {
+            text.to_string()
+        };
+        // command names
+        for command in &self.commands.commands {
+            text = text.replace(
+                &format!("ockam {}", command.name),
+                &format!("ockam {}", command.custom_name),
+            );
+        }
+        // bin name
+        text = if self.bin_name != "ockam" {
+            text.replace("ockam", &self.bin_name)
+        } else {
+            text
+        };
+        text
+    }
+}
+
+impl Default for OutputBranding {
+    fn default() -> Self {
+        Self {
+            brand_name: "Ockam".to_string(),
+            bin_name: "ockam".to_string(),
+            commands: Commands::new(""),
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/ui/output/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/output/mod.rs
@@ -1,8 +1,10 @@
+mod branding;
 mod encode_format;
 mod ockam_abac;
 mod output_format;
 mod utils;
 
+pub use branding::OutputBranding;
 pub use encode_format::EncodeFormat;
 pub use output_format::OutputFormat;
 pub use utils::*;

--- a/implementations/rust/ockam/ockam_api/src/ui/terminal/term.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/terminal/term.rs
@@ -1,31 +1,29 @@
 //! Implementation of the `TerminalWriter` using the `Term` crate
 
+use crate::output::OutputBranding;
+use crate::terminal::{TerminalStream, TerminalWriter};
+use crate::Result;
 use dialoguer::console::Term;
 use std::io::Write;
 
-use crate::terminal::{TerminalStream, TerminalWriter};
-use crate::Result;
-
 impl TerminalWriter for TerminalStream<Term> {
-    fn stdout(no_color: bool, bin_name: impl Into<String>, brand_name: impl Into<String>) -> Self {
+    fn stdout(no_color: bool, branding: OutputBranding) -> Self {
         let writer = Term::stdout();
         let no_color = no_color || !writer.features().colors_supported();
         Self {
             writer,
             no_color,
-            bin_name: bin_name.into(),
-            brand_name: brand_name.into(),
+            branding,
         }
     }
 
-    fn stderr(no_color: bool, bin_name: impl Into<String>, brand_name: impl Into<String>) -> Self {
+    fn stderr(no_color: bool, branding: OutputBranding) -> Self {
         let writer = Term::stderr();
         let no_color = no_color || !writer.features().colors_supported();
         Self {
             writer,
             no_color,
-            bin_name: bin_name.into(),
-            brand_name: brand_name.into(),
+            branding,
         }
     }
 
@@ -62,7 +60,7 @@ mod tests {
     use colorful::Colorful;
     use dialoguer::console::Term;
 
-    use crate::output::OutputFormat;
+    use crate::output::{OutputBranding, OutputFormat};
     use crate::terminal::{Terminal, TerminalStream};
 
     #[test]
@@ -74,8 +72,7 @@ mod tests {
             false,
             false,
             OutputFormat::Plain,
-            "",
-            "",
+            OutputBranding::default(),
         );
         sut.write("1").unwrap();
         sut.rewrite("1-r\n").unwrap();

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -21,7 +21,7 @@ use crate::node::node_callback::NodeCallback;
 use crate::node::util::run_ockam;
 use crate::util::foreground_args::{wait_for_exit_signal, ForegroundArgs};
 use crate::util::parsers::internet_address_parser;
-use crate::{docs, CommandGlobalOpts, Result};
+use crate::{branding, docs, CommandGlobalOpts, Result};
 
 const LONG_ABOUT: &str = include_str!("./static/create/long_about.txt");
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
@@ -144,7 +144,7 @@ impl CreateCommand {
                 0 => "-vv".to_string(),
                 v => format!("-{}", "v".repeat(v as usize)),
             },
-            "authority".to_string(),
+            branding::command::name("authority").to_string(),
             "create".to_string(),
             "--foreground".to_string(),
             "--child-process".to_string(),

--- a/implementations/rust/ockam/ockam_command/src/bin/brand.sample.yaml
+++ b/implementations/rust/ockam/ockam_command/src/bin/brand.sample.yaml
@@ -2,10 +2,10 @@ acme:
   support_email: support@acme.com
   # the following fields are optional
   brand_name: Acme # if not set, will default to Bin
-  home_dir: $HOME/.acme # if not set, will default to $HOME/.bin
+  home_dir: $HOME/.acme # if not set, will default to $HOME/.acme
   orchestrator_identifier: I25242aa3d4a7b5aa986fb2bec15b3780aad0530660e5e5a46c7f9ce429e9ec99 # if not set, will default to the OCKAM_CONTROLLER_IDENTIFIER env var
   orchestrator_address: /dnsaddr/acme.io/tcp/6252/service/api # if not set, will default to the OCKAM_CONTROLLER_ADDRESS env var
-#  build_args: # if not set, will default to empty string
+  build_args: # if not set, will default to empty string
 #    - --no-default-features
 #    - --features
 #    - 'no_std alloc software_vault rust-crypto'

--- a/implementations/rust/ockam/ockam_command/src/branding/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/branding/command.rs
@@ -1,107 +1,13 @@
-use crate::Result;
+use ockam_api::command::Commands;
 use once_cell::sync::Lazy;
-use std::fmt::{Debug, Formatter};
 
-pub(crate) fn name(name: &str) -> &'static str {
+pub(crate) fn name(name: &'static str) -> &'static str {
     CUSTOM_COMMANDS.name(name)
 }
 
-pub(crate) fn hide(name: &str) -> bool {
+pub(crate) fn hide(name: &'static str) -> bool {
     CUSTOM_COMMANDS.hide(name)
 }
 
-static CUSTOM_COMMANDS: Lazy<Commands> =
-    Lazy::new(|| Commands::from_env().expect("Failed to load custom commands"));
-
-pub(crate) struct Commands {
-    commands: Vec<Command>,
-}
-
-pub(crate) struct Command {
-    name: String,
-    custom_name: String,
-}
-
-impl Debug for Command {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Command")
-            .field("name", &self.name)
-            .field("custom_name", &self.custom_name)
-            .finish()
-    }
-}
-
-impl Commands {
-    fn new(commands: &str) -> Result<Self> {
-        let commands = commands
-            .split(',')
-            .filter_map(|c| {
-                if c.is_empty() {
-                    return None;
-                }
-                let mut parts = c.split('=');
-                let name = match parts.next() {
-                    Some(name) => name,
-                    None => return None,
-                };
-                let custom_name = parts.next().unwrap_or(name);
-                Some(Command {
-                    name: name.to_string(),
-                    custom_name: custom_name.to_string(),
-                })
-            })
-            .collect();
-        Ok(Self { commands })
-    }
-
-    pub fn from_env() -> Result<Self> {
-        Self::new(super::BrandingCompileEnvVars::commands())
-    }
-
-    pub fn hide(&self, command_name: &str) -> bool {
-        if self.commands.is_empty() {
-            return false;
-        }
-        !self.commands.iter().any(|c| c.name == command_name)
-    }
-
-    pub fn name(&self, command_name: &str) -> &'static str {
-        if self.commands.is_empty() {
-            return Box::leak(command_name.to_string().into_boxed_str());
-        }
-        self.commands
-            .iter()
-            .find(|c| c.name == command_name)
-            .map(|c| Box::leak(c.custom_name.clone().into_boxed_str()))
-            .unwrap_or(Box::leak(command_name.to_string().into_boxed_str()))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_hide() {
-        let commands = Commands::new("node create=host create,project,enroll").unwrap();
-        assert!(!commands.hide("node create"));
-        assert!(!commands.hide("project"));
-        assert!(!commands.hide("enroll"));
-        assert!(commands.hide("command4"));
-
-        let commands = Commands::new("").unwrap();
-        assert!(!commands.hide("command1"));
-    }
-
-    #[test]
-    fn test_commands() {
-        let commands = Commands::new("node create=host create,project,enroll").unwrap();
-        assert_eq!(commands.name("node create"), "host create");
-        assert_eq!(commands.name("project"), "project");
-        assert_eq!(commands.name("enroll"), "enroll");
-        assert_eq!(commands.name("command4"), "command4");
-
-        let commands = Commands::new("").unwrap();
-        assert_eq!(commands.name("command1"), "command1");
-    }
-}
+pub(crate) static CUSTOM_COMMANDS: Lazy<Commands> =
+    Lazy::new(|| Commands::new(super::BrandingCompileEnvVars::commands()));

--- a/implementations/rust/ockam/ockam_command/src/branding/compile_env_vars.rs
+++ b/implementations/rust/ockam/ockam_command/src/branding/compile_env_vars.rs
@@ -77,6 +77,7 @@ static BRANDING_ENV_VARS: Lazy<BrandingCompileEnvVars> = Lazy::new(|| {
     BrandingCompileEnvVars::new(
         COMPILE_BIN_NAME,
         COMPILE_BRAND_NAME,
+        COMPILE_HOME,
         COMPILE_SUPPORT_EMAIL,
         COMPILE_COMMANDS,
         bool::from_string(COMPILE_DEVELOPER).unwrap_or(false),
@@ -86,6 +87,7 @@ static BRANDING_ENV_VARS: Lazy<BrandingCompileEnvVars> = Lazy::new(|| {
 pub struct BrandingCompileEnvVars {
     bin_name: &'static str,
     brand_name: &'static str,
+    home_dir: &'static str,
     support_email: &'static str,
     commands: &'static str,
     is_ockam_developer: bool,
@@ -95,6 +97,7 @@ impl BrandingCompileEnvVars {
     pub fn new(
         bin_name: &'static str,
         brand_name: &'static str,
+        home_dir: &'static str,
         support_email: &'static str,
         commands: &'static str,
         is_ockam_developer: bool,
@@ -102,6 +105,7 @@ impl BrandingCompileEnvVars {
         Self {
             bin_name,
             brand_name,
+            home_dir,
             support_email,
             commands,
             is_ockam_developer,
@@ -118,6 +122,10 @@ impl BrandingCompileEnvVars {
 
     pub fn brand_name() -> &'static str {
         Self::get().brand_name
+    }
+
+    pub fn home_dir() -> &'static str {
+        Self::get().home_dir
     }
 
     pub fn support_email() -> &'static str {

--- a/implementations/rust/ockam/ockam_command/src/branding/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/branding/mod.rs
@@ -2,3 +2,14 @@ pub mod command;
 pub mod compile_env_vars;
 
 pub use compile_env_vars::{load_compile_time_vars, BrandingCompileEnvVars};
+use ockam_api::command::Commands;
+use ockam_api::output::OutputBranding;
+use once_cell::sync::Lazy;
+
+pub(crate) static OUTPUT_BRANDING: Lazy<OutputBranding> = Lazy::new(|| {
+    OutputBranding::new(
+        BrandingCompileEnvVars::brand_name().to_string(),
+        BrandingCompileEnvVars::bin_name().to_string(),
+        Commands::new(BrandingCompileEnvVars::commands()),
+    )
+});

--- a/implementations/rust/ockam/ockam_command/src/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/command.rs
@@ -1,4 +1,4 @@
-use crate::branding::{load_compile_time_vars, BrandingCompileEnvVars};
+use crate::branding::{load_compile_time_vars, BrandingCompileEnvVars, OUTPUT_BRANDING};
 use crate::command_events::add_command_event;
 use crate::command_global_opts::CommandGlobalOpts;
 use crate::global_args::GlobalArgs;
@@ -80,7 +80,8 @@ impl OckamCommand {
                         BrandingCompileEnvVars::bin_name()
                     )
                 );
-                let ockam_home = std::env::var("OCKAM_HOME").unwrap_or("~/.ockam".to_string());
+                let ockam_home = std::env::var("OCKAM_HOME")
+                    .unwrap_or(BrandingCompileEnvVars::home_dir().to_string());
                 eprintln!(
                     "{}",
                     fmt_log!(
@@ -246,8 +247,7 @@ impl OckamCommand {
             self.global_args.no_color,
             self.global_args.no_input,
             self.global_args.output_format(),
-            BrandingCompileEnvVars::bin_name(),
-            BrandingCompileEnvVars::brand_name(),
+            OUTPUT_BRANDING.clone(),
         );
 
         let options = CommandGlobalOpts::new(self.global_args.clone(), cli_state, terminal);

--- a/implementations/rust/ockam/ockam_command/src/completion/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/completion/mod.rs
@@ -3,6 +3,7 @@ use std::io;
 use clap::{Args, CommandFactory};
 use clap_complete::{generate, Shell};
 
+use crate::branding::BrandingCompileEnvVars;
 use crate::{docs, OckamCommand};
 
 const LONG_ABOUT: &str = include_str!("./static/long_about.txt");
@@ -28,7 +29,7 @@ impl CompletionCommand {
         generate(
             self.shell,
             &mut OckamCommand::command(),
-            "ockam",
+            BrandingCompileEnvVars::bin_name(),
             &mut io::stdout(),
         );
         Ok(())

--- a/implementations/rust/ockam/ockam_command/src/docs.rs
+++ b/implementations/rust/ockam/ockam_command/src/docs.rs
@@ -1,4 +1,4 @@
-use crate::branding::BrandingCompileEnvVars;
+use crate::branding::{BrandingCompileEnvVars, OUTPUT_BRANDING};
 use crate::Result;
 use colorful::Colorful;
 use ockam_api::terminal::TextHighlighter;
@@ -90,27 +90,13 @@ pub(crate) fn after_help(text: &str) -> &'static str {
 /// Render the string if the document should be displayed in a terminal
 /// Otherwise, if it is a Markdown document just return a static string
 fn render(body: &str) -> &'static str {
-    let body = process_branding(body);
+    let body = OUTPUT_BRANDING.replace(body);
     if *IS_MARKDOWN {
         Box::leak(body.into_boxed_str())
     } else {
         let syntax_highlighted = process_terminal_docs(body);
         Box::leak(syntax_highlighted.into_boxed_str())
     }
-}
-
-fn process_branding(text: &str) -> String {
-    let mut text = if BrandingCompileEnvVars::brand_name() != "Ockam" {
-        text.replace("Ockam", BrandingCompileEnvVars::brand_name())
-    } else {
-        text.to_string()
-    };
-    text = if BrandingCompileEnvVars::bin_name() != "ockam" {
-        text.replace("ockam", BrandingCompileEnvVars::bin_name())
-    } else {
-        text
-    };
-    text
 }
 
 /// Use a shell syntax highlighter to render the fenced code blocks in terminals

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -409,7 +409,7 @@ mod tests {
     use super::*;
     use crate::run::parser::resource::utils::parse_cmd_from_args;
     use crate::GlobalArgs;
-    use ockam_api::output::OutputFormat;
+    use ockam_api::output::{OutputBranding, OutputFormat};
     use ockam_api::terminal::Terminal;
     use ockam_api::CliState;
     use std::sync::Arc;
@@ -549,8 +549,7 @@ mod tests {
                     true,
                     false,
                     OutputFormat::Plain,
-                    "",
-                    "",
+                    OutputBranding::default(),
                 ),
                 global_args: GlobalArgs::default(),
             };
@@ -608,8 +607,7 @@ mod tests {
                 true,
                 false,
                 OutputFormat::Plain,
-                "",
-                "",
+                OutputBranding::default(),
             ),
             global_args: GlobalArgs::default(),
         };

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -1,7 +1,8 @@
+use crate::branding::BrandingCompileEnvVars;
 use crate::node::CreateCommand;
 use crate::run::parser::resource::utils::subprocess_stdio;
 use crate::shared_args::TrustOpts;
-use crate::{Command, CommandGlobalOpts};
+use crate::{branding, Command as CommandTrait, CommandGlobalOpts};
 use miette::IntoDiagnostic;
 use miette::{miette, Context as _};
 use ockam_core::env::get_env_with_default;
@@ -81,7 +82,7 @@ pub fn spawn_node(opts: &CommandGlobalOpts, cmd: CreateCommand) -> miette::Resul
             0 => "-vv".to_string(),
             v => format!("-{}", "v".repeat(v as usize)),
         },
-        "node".to_string(),
+        branding::command::name("node").to_string(),
         "create".to_string(),
         "--tcp-listener-address".to_string(),
         tcp_listener_address.to_string(),
@@ -202,7 +203,7 @@ pub fn run_ockam(args: Vec<String>, quiet: bool) -> miette::Result<Child> {
     // development) re-executing the current binary is a more
     // deterministic way of starting a node.
     let ockam_exe = current_exe().unwrap_or_else(|_| {
-        get_env_with_default("OCKAM", "ockam".to_string())
+        get_env_with_default("OCKAM", BrandingCompileEnvVars::bin_name().to_string())
             .unwrap()
             .into()
     });

--- a/implementations/rust/ockam/ockam_command/src/subcommand.rs
+++ b/implementations/rust/ockam/ockam_command/src/subcommand.rs
@@ -17,6 +17,7 @@ use ockam_node::Context;
 
 use crate::admin::AdminCommand;
 use crate::authority::{AuthorityCommand, AuthoritySubcommand};
+use crate::branding::command;
 use crate::command_global_opts::CommandGlobalOpts;
 use crate::completion::CompletionCommand;
 use crate::credential::CredentialCommand;
@@ -63,7 +64,6 @@ use crate::vault::VaultCommand;
 use crate::worker::WorkerCommand;
 use crate::Error;
 use crate::Result;
-use crate::{branding, branding::command};
 
 #[derive(Clone, Debug, Subcommand)]
 #[command(about = docs::about("List of commands which can be executed with `ockam`"))]
@@ -363,11 +363,11 @@ pub trait Command: Debug + Clone + Sized + Send + Sync + 'static {
     const NAME: &'static str;
 
     fn name(&self) -> String {
-        branding::command::name(Self::NAME).to_string()
+        command::name(Self::NAME).to_string()
     }
 
     fn hide() -> bool {
-        branding::command::hide(Self::NAME)
+        command::hide(Self::NAME)
     }
 
     fn retry_opts(&self) -> Option<RetryOpts> {


### PR DESCRIPTION
- replace hardcoded binary names and command names (e.g. when spawning a background node) with their corresponding compile env vars
- replace command names with their custom names in output, docs, and help texts