### PR TITLE
build: bump kafka-protocol from 0.13 to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,15 +450,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,9 +519,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.13"
+version = "1.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a50b30228d3af8865ce83376b4e99e1ffa34728220fe2860e4df0bb5278d6"
+checksum = "dc47e70fc35d054c8fcd296d47a61711f043ac80534a10b4f741904f81e73a90"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -612,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16d1aa50accc11a4b4d5c50f7fb81cc0cf60328259c587d0e6b0f11385bde46"
+checksum = "bee7643696e7fdd74c10f9eb42848a87fe469d35eae9c3323f80aa98f350baac"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -637,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.54.0"
+version = "1.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cf16c0e5853312995505557b876dd3f9fb9941e96d031383528ccef14ace57"
+checksum = "40b7a24700ac548025a47a5c579886f5198895bb1eccd8964dfd71cd66c16912"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -659,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.53.0"
+version = "1.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1605dc0bf9f0a4b05b451441a17fcb0bda229db384f23bf5cead3adbab0664ac"
+checksum = "c54bab121fe1881a74c338c5f723d1592bf3b53167f80268a1274f404e1acc38"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -681,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.54.0"
+version = "1.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f3f73466ff24f6ad109095e0f3f2c830bfb4cd6c8b12f744c8e61ebf4d3ba1"
+checksum = "8c8234fd024f7ac61c4e44ea008029bde934250f371efe7d4a39708397b1080c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -703,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.54.0"
+version = "1.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249b2acaa8e02fd4718705a9494e3eb633637139aa4bb09d70965b0448e865db"
+checksum = "ba60e1d519d6f23a9df712c04fdeadd7872ac911c84b2f62a8bda92e129b7962"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -726,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3820e0c08d0737872ff3c7c1f21ebbb6693d832312d6152bf18ef50a5471c2"
+checksum = "690118821e46967b3c4501d67d7d52dd75106a9c54cf36cefa1985cedbe94e05"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -749,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427cb637d15d63d6f9aae26358e1c9a9c09d5aa490d64b09354c8217cfef0f28"
+checksum = "fa59d1327d8b5053c54bf2eaae63bf629ba9e904434d0835a28ed3c0ed0a614e"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -760,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.11"
+version = "0.60.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
+checksum = "7809c27ad8da6a6a68c454e651d4962479e81472aa19ae99e59f9aba1f9713cc"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -780,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e69cc50921eb913c6b662f8d909131bb3e6ad6cb6090d3a39b66fc5c52095"
+checksum = "623a51127f24c30776c8b374295f2df78d92517386f77ba30773f15a30ce1422"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -799,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.6"
+version = "1.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05dd41a70fc74051758ee75b5c4db2c0ca070ed9229c3df50e9475cda1cb985"
+checksum = "865f7050bbc7107a6c98a397a9fcd9413690c27fa718446967cf03b2d3ac517e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -843,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.11"
+version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ddc9bd6c28aeb303477170ddd183760a956a03e083b3902a990238a7e3792d"
+checksum = "a28f6feb647fb5e0d5b50f0472c19a7db9462b74e2fec01bb0b44eedcc834e97"
 dependencies = [
  "base64-simd",
  "bytes 1.9.0",
@@ -875,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+checksum = "b0df5a18c4f951c645300d365fec53a61418bcf4650f604f85fe2a665bfaa0c2"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -1608,7 +1599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2028,40 +2019,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "syn 2.0.95",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
-dependencies = [
- "darling_core",
- "quote",
- "syn 2.0.95",
-]
-
-[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,12 +2127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deunicode"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
-
-[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,12 +2138,6 @@ dependencies = [
  "thiserror 1.0.69",
  "zeroize",
 ]
-
-[[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "difflib"
@@ -2251,12 +2196,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2272,18 +2211,6 @@ dependencies = [
  "once_cell",
  "os_pipe",
  "shared_child",
-]
-
-[[package]]
-name = "dummy"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ee4e39146145f7dd28e6c85ffdce489d93c0d9c88121063b8aacabbd9858d2"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.95",
 ]
 
 [[package]]
@@ -2468,7 +2395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2538,18 +2465,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "fake"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef603df4ba9adbca6a332db7da6f614f21eafefbaf8e087844e452fdec152d0"
-dependencies = [
- "deunicode",
- "dummy",
- "rand",
- "uuid",
 ]
 
 [[package]]
@@ -2700,12 +2615,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fragile"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "fs2"
@@ -3289,9 +3198,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes 1.9.0",
  "futures-channel",
@@ -3332,7 +3241,7 @@ checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http 1.2.0",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "rustls 0.23.20",
  "rustls-native-certs 0.8.1",
@@ -3348,7 +3257,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3366,7 +3275,7 @@ dependencies = [
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -3514,12 +3423,6 @@ dependencies = [
  "quote",
  "syn 2.0.95",
 ]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3824,9 +3727,9 @@ dependencies = [
 
 [[package]]
 name = "kafka-protocol"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1edaf2fc3ecebe689bbc4fd97a6921cacd4cd09df8ebeda348a8e23c9fd48d4"
+checksum = "8cf55ee60ccc7ec31d65c9567c186144d98e870b513fc7159854f281caa69656"
 dependencies = [
  "anyhow",
  "bytes 1.9.0",
@@ -3899,7 +3802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4210,32 +4113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 2.0.95",
-]
-
-[[package]]
 name = "mockito"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4248,7 +4125,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
  "rand",
@@ -4733,7 +4610,6 @@ dependencies = [
  "colors-transform",
  "dialoguer",
  "either",
- "fake",
  "flexi_logger",
  "futures 0.3.31",
  "gethostname 0.5.0",
@@ -4741,9 +4617,8 @@ dependencies = [
  "home",
  "http-body-util",
  "httparse",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
- "indexmap 2.7.0",
  "indicatif",
  "itertools 0.13.0",
  "jaq-core",
@@ -4751,10 +4626,8 @@ dependencies = [
  "jaq-parse",
  "jaq-std",
  "kafka-protocol",
- "log",
  "miette",
  "minicbor",
- "mockall",
  "multimap",
  "nix 0.29.0",
  "nu-ansi-term 0.50.1",
@@ -4776,8 +4649,6 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "petname",
- "pretty_assertions",
- "proptest",
  "quickcheck",
  "quickcheck_macros",
  "r3bl_rs_utils_core",
@@ -5220,7 +5091,6 @@ version = "0.56.0"
 dependencies = [
  "aws-config",
  "aws-sdk-kms",
- "hex",
  "ockam_core",
  "ockam_macros",
  "ockam_node",
@@ -5726,16 +5596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty_assertions"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
-dependencies = [
- "diff",
- "yansi",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5901,7 +5761,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6209,7 +6069,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-rustls 0.27.5",
  "hyper-util",
  "ipnet",
@@ -6347,7 +6207,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6797,12 +6657,6 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -7529,7 +7383,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7876,7 +7730,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -8256,12 +8110,6 @@ name = "uuid"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
-dependencies = [
- "atomic",
- "getrandom",
- "md-5",
- "sha1_smol",
-]
 
 [[package]]
 name = "valuable"
@@ -8618,7 +8466,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8989,12 +8837,6 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -38,7 +38,6 @@ This file contains attributions for any 3rd-party open source code used in this 
 | async-task | Apache-2.0, MIT | https://crates.io/crates/async-task |
 | async-trait | MIT, Apache-2.0 | https://crates.io/crates/async-trait |
 | atoi | MIT | https://crates.io/crates/atoi |
-| atomic | Apache-2.0, MIT | https://crates.io/crates/atomic |
 | atomic-polyfill | MIT, Apache-2.0 | https://crates.io/crates/atomic-polyfill |
 | atomic-waker | Apache-2.0, MIT | https://crates.io/crates/atomic-waker |
 | atsamd-hal | MIT, Apache-2.0 | https://crates.io/crates/atsamd-hal |
@@ -469,7 +468,6 @@ This file contains attributions for any 3rd-party open source code used in this 
 | serde_spanned | MIT, Apache-2.0 | https://crates.io/crates/serde_spanned |
 | serde_urlencoded | MIT, Apache-2.0 | https://crates.io/crates/serde_urlencoded |
 | sha1 | MIT, Apache-2.0 | https://crates.io/crates/sha1 |
-| sha1_smol | BSD-3-Clause | https://crates.io/crates/sha1_smol |
 | sha2 | MIT, Apache-2.0 | https://crates.io/crates/sha2 |
 | sharded-slab | MIT | https://crates.io/crates/sharded-slab |
 | shared_child | MIT | https://crates.io/crates/shared_child |

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -50,7 +50,7 @@ cfg_aliases = "0.2.1"
 
 [dependencies]
 base64-url = "3.0.0"
-bytes = { version = "1.7.2", default-features = false, features = ["serde"] }
+bytes = { version = "=1.9.0", default-features = false, features = ["serde"] }
 cfg-if = "1.0.0"
 chrono = { version = "0.4" }
 clap = { version = "4.5", default-features = false, features = ["derive"] }
@@ -73,8 +73,7 @@ jaq-core = "1"
 jaq-interpret = "1"
 jaq-parse = "1"
 jaq-std = "1"
-kafka-protocol = "0.13"
-log = "0.4"
+kafka-protocol = "0.14"
 miette = { version = "7.2.0", features = ["fancy-no-backtrace"] }
 minicbor = { version = "0.25.1", default-features = false, features = ["alloc", "derive"] }
 nix = { version = "0.29", features = ["signal"] }
@@ -160,17 +159,12 @@ default-features = false
 
 [dev-dependencies]
 cddl-cat = "0.6.1"
-fake = { version = "3", features = ['derive', 'uuid'] }
 hex = "0.4.3"
-indexmap = "2.6.0"
-mockall = "0.13"
 multimap = "0.10.0"
 ockam_macros = { path = "../ockam_macros", features = ["std"], version = "^0.37.0" }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.101.0" }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", default-features = false, version = "^0.135.0" }
 opentelemetry_sdk = { version = "0.26.0", features = ["logs", "metrics", "trace", "rt-tokio", "testing"], default-features = false }
-pretty_assertions = "1.4.1"
-proptest = "1.5.0"
 quickcheck = "1.0.1"
 quickcheck_macros = "1.0.0"
 serial_test = "3.0.0"

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/outlet/request.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/outlet/request.rs
@@ -50,11 +50,11 @@ impl KafkaMessageRequestInterceptor for OutletInterceptorImpl {
 
         // we only need to keep track of the metadata request/response
         // to dynamically create an outlet for each broker
-        if api_key == ApiKey::MetadataKey {
+        if api_key == ApiKey::Metadata {
             self.request_map.lock().unwrap().insert(
                 header.correlation_id,
                 RequestInfo {
-                    request_api_key: ApiKey::MetadataKey,
+                    request_api_key: ApiKey::Metadata,
                     request_api_version: header.request_api_version,
                 },
             );

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/outlet/response.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/outlet/response.rs
@@ -54,7 +54,7 @@ impl KafkaMessageResponseInterceptor for OutletInterceptorImpl {
 
             // the responses of metadata request contain the list of brokers addresses,
             // we override them with the outlets addresses
-            if request_info.request_api_key == ApiKey::MetadataKey {
+            if request_info.request_api_key == ApiKey::Metadata {
                 let response: MetadataResponse =
                     decode_body(&mut buffer, request_info.request_api_version)?;
 

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/tests.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/tests.rs
@@ -85,12 +85,12 @@ mod test {
                         &RequestHeader::default()
                             .with_request_api_version(api_version)
                             .with_correlation_id(correlation_id)
-                            .with_request_api_key(ApiKey::ApiVersionsKey as i16),
+                            .with_request_api_key(ApiKey::ApiVersions as i16),
                         &ApiVersionsRequest::default()
                             .with_client_software_name(StrBytes::from_static_str("mr. software"))
                             .with_client_software_version(StrBytes::from_static_str("1.0.0")),
                         api_version,
-                        ApiKey::ApiVersionsKey,
+                        ApiKey::ApiVersions,
                     )
                     .unwrap(),
                 )
@@ -107,7 +107,7 @@ mod test {
                         &ResponseHeader::default().with_correlation_id(correlation_id),
                         &ApiVersionsResponse::default(),
                         api_version,
-                        ApiKey::ApiVersionsKey,
+                        ApiKey::ApiVersions,
                     )
                     .unwrap(),
                 )
@@ -128,10 +128,10 @@ mod test {
                         &RequestHeader::default()
                             .with_request_api_version(api_version)
                             .with_correlation_id(correlation_id)
-                            .with_request_api_key(ApiKey::MetadataKey as i16),
+                            .with_request_api_key(ApiKey::Metadata as i16),
                         &MetadataRequest::default(),
                         api_version,
-                        ApiKey::MetadataKey,
+                        ApiKey::Metadata,
                     )
                     .unwrap(),
                 )
@@ -148,7 +148,7 @@ mod test {
                         &ResponseHeader::default().with_correlation_id(correlation_id),
                         &MetadataResponse::default().with_controller_id(BrokerId::from(0_i32)),
                         api_version,
-                        ApiKey::MetadataKey,
+                        ApiKey::Metadata,
                     )
                     .unwrap(),
                 )

--- a/implementations/rust/ockam/ockam_api/src/kafka/tests/interceptor_test.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/tests/interceptor_test.rs
@@ -72,7 +72,7 @@ async fn kafka_portal_worker__pieces_of_kafka_message__message_assembled(
     let mut request_buffer = BytesMut::new();
     encode(
         &mut request_buffer,
-        create_request_header(ApiKey::MetadataKey),
+        create_request_header(ApiKey::Metadata),
         MetadataRequest::default(),
     );
 
@@ -118,12 +118,12 @@ async fn kafka_portal_worker__double_kafka_message__message_assembled(
     let mut request_buffer = BytesMut::new();
     encode(
         &mut request_buffer,
-        create_request_header(ApiKey::MetadataKey),
+        create_request_header(ApiKey::Metadata),
         MetadataRequest::default(),
     );
     encode(
         &mut request_buffer,
-        create_request_header(ApiKey::MetadataKey),
+        create_request_header(ApiKey::Metadata),
         MetadataRequest::default(),
     );
 
@@ -170,7 +170,7 @@ async fn kafka_portal_worker__bigger_than_limit_kafka_message__error(
     let mut request_buffer = BytesMut::new();
     encode(
         &mut request_buffer,
-        create_request_header(ApiKey::MetadataKey),
+        create_request_header(ApiKey::Metadata),
         MetadataRequest::default().with_unknown_tagged_fields(insanely_huge_tag),
     );
 
@@ -220,7 +220,7 @@ async fn kafka_portal_worker__almost_over_limit_than_limit_kafka_message__two_ka
     let mut huge_outgoing_request = BytesMut::new();
     encode(
         &mut huge_outgoing_request,
-        create_request_header(ApiKey::MetadataKey),
+        create_request_header(ApiKey::Metadata),
         MetadataRequest::default().with_unknown_tagged_fields(insanely_huge_tag.clone()),
     );
 
@@ -442,7 +442,7 @@ async fn kafka_portal_worker__metadata_exchange__response_changed(
     // let's create a real kafka request and pass it through the portal
     encode(
         &mut request_buffer,
-        create_request_header(ApiKey::MetadataKey),
+        create_request_header(ApiKey::Metadata),
         MetadataRequest::default(),
     );
 

--- a/implementations/rust/ockam/ockam_api/tests/common/common.rs
+++ b/implementations/rust/ockam/ockam_api/tests/common/common.rs
@@ -1,6 +1,5 @@
 use core::time::Duration;
 
-use log::debug;
 use ockam::identity::models::CredentialSchemaIdentifier;
 use ockam::identity::utils::AttributesBuilder;
 use ockam::identity::{
@@ -20,6 +19,7 @@ use ockam_transport_tcp::TcpTransport;
 use rand::{thread_rng, Rng};
 use std::sync::Arc;
 use tempfile::NamedTempFile;
+use tracing::debug;
 
 // Default Configuration with fake TrustedIdentifier (which can be changed after the call),
 // with freshly created Authority Identifier and temporary files for storage and vault

--- a/implementations/rust/ockam/ockam_api/tests/common/session.rs
+++ b/implementations/rust/ockam/ockam_api/tests/common/session.rs
@@ -1,5 +1,4 @@
 use core::sync::atomic::{AtomicBool, Ordering};
-use log::info;
 use ockam::{route, Address, Context};
 use ockam_api::session::replacer::{
     AdditionalSessionReplacer, CurrentInletStatus, ReplacerOutcome, ReplacerOutputKind,
@@ -10,6 +9,7 @@ use ockam_core::errcode::{Kind, Origin};
 use ockam_core::{async_trait, Any, Error, NeutralMessage, Result, Route, Routed, Worker};
 use std::sync::atomic::AtomicU8;
 use std::time::Duration;
+use tracing::info;
 
 pub struct MockEchoer {
     pub responsive: Arc<AtomicBool>,

--- a/implementations/rust/ockam/ockam_vault_aws/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_aws/Cargo.toml
@@ -56,8 +56,8 @@ aws-lc = ["ockam_vault/aws-lc"]
 rust-crypto = ["ockam_vault/rust-crypto"]
 
 [dependencies]
-aws-config = { version = "1.5.8", default-features = false, features = ["rustls", "rt-tokio"] }
-aws-sdk-kms = { version = "1.47.0", default-features = false, features = ["rustls"] }
+aws-config = { version = "1.5.15", default-features = false, features = ["rustls", "rt-tokio"] }
+aws-sdk-kms = { version = "1.58.0", default-features = false, features = ["rustls"] }
 ockam_core = { path = "../ockam_core", version = "^0.124.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.37.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.137.0", default-features = false }
@@ -68,7 +68,6 @@ thiserror = { version = "1.0.64" }
 tracing = { version = "0.1", default-features = false }
 
 [dev-dependencies]
-hex = { version = "0.4", default-features = false }
 tokio = { version = "1.41", features = ["full"] }
 
 [package.metadata.cargo-machete]


### PR DESCRIPTION
Fixes `bytes = 1.9.0`, as `1.10.0` collides with `kafka-protocol`.