### PR TITLE
fix(rust): echo service initialization

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
@@ -278,21 +278,21 @@ impl NodeManager {
         ctx: &Context,
         start_default_services: bool,
     ) -> ockam_core::Result<()> {
+        // Always start the echoer service as ockam_api::Session assumes it will be
+        // started unconditionally on every node. It's used for liveliness checks.
+        self.start_echoer_service(ctx, DefaultAddress::ECHO_SERVICE.into())
+            .await?;
+        for api_flow_control_id in &self.api_transport_flow_control_ids {
+            ctx.flow_controls()
+                .add_consumer(&DefaultAddress::ECHO_SERVICE.into(), api_flow_control_id);
+        }
+
         if start_default_services {
             self.api_sc_listener = Some(
                 self.initialize_default_services(ctx, &self.api_transport_flow_control_ids)
                     .await?,
             );
         }
-
-        // Always start the echoer service as ockam_api::Session assumes it will be
-        // started unconditionally on every node. It's used for liveliness checks.
-        for api_flow_control_id in &self.api_transport_flow_control_ids {
-            ctx.flow_controls()
-                .add_consumer(&DefaultAddress::ECHO_SERVICE.into(), api_flow_control_id);
-        }
-        self.start_echoer_service(ctx, DefaultAddress::ECHO_SERVICE.into())
-            .await?;
 
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/nodes.bats
@@ -72,6 +72,7 @@ EOF
     --variable SERVICE_PORT="$PYTHON_SERVER_PORT" &
   sleep 10
   run_success "$OCKAM" message send hello --timeout 2 --to "/node/n1/secure/api/service/echo"
+  run_success "$OCKAM" message send hello --timeout 5 --to "/project/default/service/forward_to_$RELAY_NAME/secure/api/service/echo"
   run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$CLIENT_PORT"
 }
 
@@ -85,6 +86,7 @@ EOF
 
   # node created with expected name
   run_success "$OCKAM" message send --timeout 5 hello --to "/node/n1/secure/api/service/echo"
+  run_success "$OCKAM" message send --timeout 5 hello --to "/project/default/service/forward_to_$RELAY_NAME/secure/api/service/echo"
   # tcp-listener-address set to expected port
   run_success "$OCKAM" message send --timeout 5 hello --to "/dnsaddr/127.0.0.1/tcp/$NODE_PORT/secure/api/service/echo"
   # portal is working: inlet -> relay -> outlet -> python server
@@ -121,6 +123,7 @@ EOF
 
   # node created with expected name
   run_success "$OCKAM" message send --timeout 5 hello --to "/node/n1/secure/api/service/echo"
+  run_success "$OCKAM" message send --timeout 5 hello --to "/project/default/service/forward_to_$RELAY_NAME/secure/api/service/echo"
   # tcp-listener-address set to expected port
   run_success "$OCKAM" message send --timeout 5 hello --to "/dnsaddr/127.0.0.1/tcp/$NODE_PORT/secure/api/service/echo"
   # portal is working: inlet -> relay -> outlet -> python server

--- a/implementations/rust/ockam/ockam_node/src/router/record.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/record.rs
@@ -119,6 +119,8 @@ impl InternalMap {
             })?
             .clone();
 
+        debug!(%address, %primary_address, "Stopping address");
+
         self.flow_controls.cleanup_address(&primary_address);
 
         let record = if let Some(record) = records.remove(&primary_address) {

--- a/implementations/rust/ockam/ockam_node/src/router/record.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/record.rs
@@ -119,7 +119,7 @@ impl InternalMap {
             })?
             .clone();
 
-        debug!(%address, %primary_address, "Stopping address");
+        debug!(%address, %primary_address, "stopping address");
 
         self.flow_controls.cleanup_address(&primary_address);
 

--- a/implementations/rust/ockam/ockam_node/src/router/router.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/router.rs
@@ -135,11 +135,7 @@ impl Router {
 
     /// Stop the worker
     pub fn stop_address(&self, addr: &Address, skip_sending_stop_signal: bool) -> Result<()> {
-        debug!("Stopping address '{}'", addr);
-
-        self.map.stop(addr, skip_sending_stop_signal)?;
-
-        Ok(())
+        self.map.stop(addr, skip_sending_stop_signal)
     }
 
     #[cfg(feature = "std")]


### PR DESCRIPTION
After the recent command optimization changes, we stopped [creating a separated ockam context](https://github.com/build-trust/ockam/blob/8cf003617b0ac670f4adb8af40c7c13a021e5d4c/implementations/rust/ockam/ockam_command/src/node/create/config.rs#L258-L262) when creating a foreground node with configuration.

We've been avoiding that on purpose because we had a known bug that was causing the echo service to stop working correctly if the ockam context was shared.

Turns out that we were recreating the echo service after being set as a consumer for the secure channel listener: 
- start_echoer_service deletes the echoer service and recreates it, so this must be called first; otherwise, we lose the flow controls
- initialize_default_services/create_secure_channel_listener adds the echoer as a consumer