### PR TITLE
fix(rust): command subprocess read child's pipes instead of copying them

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/ui/terminal/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/terminal/mod.rs
@@ -62,6 +62,14 @@ impl<T: TerminalWriter + Debug, W> Terminal<T, W> {
             }
         }
     }
+
+    pub fn stdout(&self) -> T {
+        self.stdout.clone()
+    }
+
+    pub fn stderr(&self) -> T {
+        self.stderr.clone()
+    }
 }
 
 /// A small wrapper around the `Write` trait, enriched with CLI
@@ -300,7 +308,7 @@ impl<W: TerminalWriter + Debug> Terminal<W, ToStdErr> {
         Ok(output)
     }
 
-    pub fn stdout(self) -> Terminal<W, ToStdOut> {
+    pub fn to_stdout(self) -> Terminal<W, ToStdOut> {
         Terminal {
             stdout: self.stdout,
             stderr: self.stderr,

--- a/implementations/rust/ockam/ockam_api/src/ui/terminal/term.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/terminal/term.rs
@@ -77,7 +77,7 @@ mod tests {
         sut.write("1").unwrap();
         sut.rewrite("1-r\n").unwrap();
         sut.write_line("2".red().to_string()).unwrap();
-        sut.stdout()
+        sut.to_stdout()
             .plain("This is a human message")
             .machine("This is a machine message")
             .write_line()

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -18,7 +18,7 @@ use ockam_core::compat::collections::BTreeMap;
 use ockam_core::compat::fmt;
 
 use crate::node::node_callback::NodeCallback;
-use crate::node::util::run_ockam;
+use crate::node::util::{run_ockam, wait_while_draining_output};
 use crate::util::foreground_args::{wait_for_exit_signal, ForegroundArgs};
 use crate::util::parsers::internet_address_parser;
 use crate::{branding, docs, CommandGlobalOpts, Result};
@@ -221,10 +221,10 @@ impl CreateCommand {
         args.push("--tcp-callback-port".to_string());
         args.push(node_callback.callback_port().to_string());
 
-        let handle = run_ockam(args, opts.global_args.quiet)?;
+        let handle = run_ockam(args)?;
 
         tokio::select! {
-            _ = handle.wait_with_output() => { std::process::exit(1) }
+            _ = wait_while_draining_output(opts, handle) => { std::process::exit(1) }
             _ = node_callback.wait_for_signal() => {}
         }
 

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -88,7 +88,7 @@ impl IssueCommand {
             .encode_value(&CredentialAndPurposeKeyDisplay(credential.clone()))?;
         let output = CredentialOutput::from_credential(credential)?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(output.item()?)
             .json_obj(output)?
             .machine(machine)

--- a/implementations/rust/ockam/ockam_command/src/credential/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/list.rs
@@ -52,7 +52,7 @@ impl ListCommand {
         )?;
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(list)
             .json_obj(credentials)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/credential/store.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/store.rs
@@ -118,7 +118,7 @@ impl StoreCommand {
         let (credential, _) = try_join!(send_req, progress_output)?;
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .machine(credential.clone())
             .json(serde_json::json!(
                 {

--- a/implementations/rust/ockam/ockam_command/src/credential/verify.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/verify.rs
@@ -52,7 +52,7 @@ impl VerifyCommand {
         };
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .json(serde_json::json!({ "is_valid": is_valid }))
             .machine(is_valid.to_string())

--- a/implementations/rust/ockam/ockam_command/src/enroll/oidc_service.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/oidc_service.rs
@@ -63,7 +63,7 @@ impl OidcServiceExt for OidcService {
         if opts.terminal.is_quiet() {
             opts.terminal
                 .clone()
-                .stdout()
+                .to_stdout()
                 .plain(device_code.user_code.to_string())
                 .write_line()?;
         }

--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -83,7 +83,7 @@ impl CreateCommand {
             .await?;
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(
                 fmt_ok!(
                     "Identity {} \n",
@@ -131,7 +131,7 @@ impl CreateCommand {
             .await?;
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "Identity imported successfully with name {}",
                 color_primary(&self.name)

--- a/implementations/rust/ockam/ockam_command/src/identity/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/default.rs
@@ -35,7 +35,7 @@ impl DefaultCommand {
                 } else {
                     opts.state.set_as_default_identity(name).await?;
                     opts.terminal
-                        .stdout()
+                        .to_stdout()
                         .plain(fmt_ok!("The identity named '{}' is now the default", &name))
                         .machine(name)
                         .write_line()?;
@@ -44,7 +44,7 @@ impl DefaultCommand {
             None => {
                 let identity = opts.state.get_or_create_default_named_identity().await?;
                 opts.terminal
-                    .stdout()
+                    .to_stdout()
                     .plain(fmt_ok!(
                         "The name of the default identity is '{}'",
                         identity.name()

--- a/implementations/rust/ockam/ockam_command/src/identity/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/delete.rs
@@ -87,7 +87,7 @@ impl DeleteCommandTui for DeleteTui {
         let state = &self.opts.state;
         state.delete_identity_by_name(item_name).await?;
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "The identity named {} has been deleted",
                 color_primary(item_name)

--- a/implementations/rust/ockam/ockam_command/src/identity/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/list.rs
@@ -45,7 +45,7 @@ impl ListCommand {
             .build_list(&identities_list, "No identities found on this system.")?;
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(list)
             .json(json!(&identities))
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -58,7 +58,7 @@ impl ShowCommand {
         match identities_names.len() {
             0 => {
                 opts.terminal
-                    .stdout()
+                    .to_stdout()
                     .plain("There are no identities to show")
                     .write_line()?;
             }
@@ -79,7 +79,7 @@ impl ShowCommand {
 
                 if selected_names.is_empty() {
                     opts.terminal
-                        .stdout()
+                        .to_stdout()
                         .plain("No identities selected")
                         .write_line()?;
                     return Ok(());
@@ -127,7 +127,7 @@ impl ShowCommand {
 
         opts.terminal
             .clone()
-            .stdout()
+            .to_stdout()
             .plain(&plain)
             .json(json.into_diagnostic()?)
             .machine(&plain)
@@ -157,7 +157,7 @@ impl ShowCommand {
 
         opts.terminal
             .clone()
-            .stdout()
+            .to_stdout()
             .plain(list)
             .json(json!(&identities))
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/influxdb/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/inlet/create.rs
@@ -253,7 +253,7 @@ impl Command for CreateCommand {
         };
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .machine(inlet_status.bind_addr.to_string())
             .json_obj(&inlet_status)?

--- a/implementations/rust/ockam/ockam_command/src/influxdb/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/outlet/create.rs
@@ -137,7 +137,7 @@ impl Command for CreateCommand {
         };
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "Created a new InfluxDB Outlet in the Node {} at {} bound to {}\n\n",
                 color_primary(node.node_name()),

--- a/implementations/rust/ockam/ockam_command/src/kafka/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/inlet/create.rs
@@ -203,7 +203,7 @@ impl Command for CreateCommand {
         };
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(inlet.item()?)
             .json_obj(inlet)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/kafka/inlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/inlet/delete.rs
@@ -112,7 +112,7 @@ impl DeleteCommandTui for DeleteTui {
             .await?;
         let node_name = self.node.node_name();
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "Kafka Inlet with address {} on Node {} has been deleted",
                 color_primary(item_name),

--- a/implementations/rust/ockam/ockam_command/src/kafka/inlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/inlet/list.rs
@@ -38,7 +38,7 @@ impl Command for ListCommand {
             &format!("No Kafka Inlets found on {}", node.node_name()),
         )?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .json_obj(&services)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/kafka/inlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/inlet/show.rs
@@ -100,7 +100,7 @@ impl<'a> ShowCommandTui for ShowTui<'a> {
             .find(|i| i.addr == item_name)
             .ok_or_else(|| miette!("Kafka Inlet not found"))?;
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(inlet.item()?)
             .json_obj(&inlet)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
@@ -99,7 +99,7 @@ impl Command for CreateCommand {
         };
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(outlet.item()?)
             .json_obj(outlet)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/kafka/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/outlet/delete.rs
@@ -109,7 +109,7 @@ impl DeleteCommandTui for DeleteTui {
             .await?;
         let node_name = self.node.node_name();
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "Kafka Outlet with address {} on Node {} has been deleted",
                 color_primary(item_name),

--- a/implementations/rust/ockam/ockam_command/src/kafka/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/outlet/list.rs
@@ -36,7 +36,7 @@ impl Command for ListCommand {
             &format!("No Kafka Outlets found on {}", node.node_name()),
         )?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .json_obj(&services)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/kafka/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/outlet/show.rs
@@ -100,7 +100,7 @@ impl<'a> ShowCommandTui for ShowTui<'a> {
             .find(|i| i.addr == item_name)
             .ok_or_else(|| miette!("Kafka Outlet not found"))?;
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(outlet.item()?)
             .json_obj(&outlet)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/lease/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/create.rs
@@ -59,7 +59,7 @@ impl Command for CreateCommand {
             + &fmt_log!("and will expire at {}", color_primary(res.expires_at()?));
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .machine(&res.token)
             .plain(plain)
             .json_obj(res)?

--- a/implementations/rust/ockam/ockam_command/src/lease/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/list.rs
@@ -54,7 +54,7 @@ impl Command for ListCommand {
         let plain = &opts.terminal.build_list(&res, "No tokens found")?;
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .json_obj(res)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
@@ -58,7 +58,7 @@ impl Command for RevokeCommand {
         node.revoke_token(ctx, &at, &cmd.token_id).await?;
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "Token with id {} has been revoked.",
                 color_primary(&cmd.token_id)

--- a/implementations/rust/ockam/ockam_command/src/lease/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/show.rs
@@ -57,7 +57,7 @@ impl Command for ShowCommand {
         let res = node.get_token(ctx, &at, &cmd.token_id).await?;
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .machine(res.token.to_string())
             .plain(res.item()?)
             .json_obj(res)?

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -134,7 +134,7 @@ impl Command for SendCommand {
                 .context("Received content is not a valid utf8 string")?
         };
 
-        opts.terminal.stdout().plain(result).write_line()?;
+        opts.terminal.to_stdout().plain(result).write_line()?;
         Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/migrate_database/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/migrate_database/mod.rs
@@ -42,7 +42,7 @@ impl MigrateDatabaseCommand {
                 };
 
                 let status = migrator.migration_status(&db.pool).await?;
-                opts.terminal.stdout().plain(&status).json_obj(&status)?.machine(status.up_to_date()).write_line()?;
+                opts.terminal.to_stdout().plain(&status).json_obj(&status)?.machine(status.up_to_date()).write_line()?;
 
                 Ok(())
             },

--- a/implementations/rust/ockam/ockam_command/src/node/create/background.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/background.rs
@@ -6,7 +6,7 @@ use ockam_api::logs::CurrentSpan;
 use ockam_core::OpenTelemetryContext;
 
 use crate::node::node_callback::NodeCallback;
-use crate::node::util::spawn_node;
+use crate::node::util::{spawn_node, wait_while_draining_output};
 use crate::node::CreateCommand;
 use crate::CommandGlobalOpts;
 
@@ -41,7 +41,7 @@ impl CreateCommand {
         let handle = spawn_node(&opts, cmd)?;
 
         tokio::select! {
-            _ = handle.wait_with_output() => { std::process::exit(1) }
+            _ = wait_while_draining_output(&opts, handle) => { std::process::exit(1) }
             _ = node_callback.wait_for_signal() => {}
         }
 

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -133,7 +133,7 @@ impl CreateCommand {
         let node_resources = in_memory_node.get_node_resources().await?;
         opts.terminal
             .clone()
-            .stdout()
+            .to_stdout()
             .plain(self.plain_output(&opts, &node_name).await?)
             .machine(&node_name)
             .json_obj(&node_resources)?

--- a/implementations/rust/ockam/ockam_command/src/node/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/default.rs
@@ -38,7 +38,7 @@ impl DefaultCommand {
             } else {
                 opts.state.set_default_node(node_name).await?;
                 opts.terminal
-                    .stdout()
+                    .to_stdout()
                     .plain(fmt_ok!("The node '{node_name}' is now the default"))
                     .machine(node_name)
                     .write_line()?;
@@ -47,7 +47,7 @@ impl DefaultCommand {
             let default_node_name = opts.state.get_default_node().await?.name();
             let _ = opts
                 .terminal
-                .stdout()
+                .to_stdout()
                 .plain(fmt_ok!("The default node is '{default_node_name}'"))
                 .write_line();
         }

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -98,7 +98,7 @@ impl DeleteCommandTui for DeleteTui {
     async fn delete_single(&self, item_name: &str) -> miette::Result<()> {
         self.opts.state.delete_node(item_name).await?;
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "The node with name {} has been deleted",
                 color_primary(item_name)

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -92,7 +92,7 @@ pub fn print_nodes_info(
 
     opts.terminal
         .clone()
-        .stdout()
+        .to_stdout()
         .plain(plain)
         .json(json)
         .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/node/logs.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/logs.rs
@@ -33,7 +33,7 @@ impl LogCommand {
             .name();
         let log_path = opts.state.stdout_logs(&node_name)?.display().to_string();
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!("The path for the log file is: {log_path}"))
             .machine(&log_path)
             .json(serde_json::json!({ "path": log_path }))

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -103,7 +103,7 @@ impl ShowCommandTui for ShowTui {
         self.opts
             .terminal
             .clone()
-            .stdout()
+            .to_stdout()
             .plain(&node_resources)
             .json(serde_json::to_string(&node_resources).into_diagnostic()?)
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -10,7 +10,7 @@ use ockam_node::Context;
 
 use crate::node::node_callback::NodeCallback;
 use crate::node::show::get_node_resources;
-use crate::node::util::spawn_node;
+use crate::node::util::{spawn_node, wait_while_draining_output};
 use crate::node::CreateCommand;
 use crate::{docs, CommandGlobalOpts};
 
@@ -50,7 +50,7 @@ impl StartCommand {
         match inactive_nodes.len() {
             0 => {
                 opts.terminal
-                    .stdout()
+                    .to_stdout()
                     .plain(fmt_info!(
                         "All the nodes are already started, nothing to do. Exiting gratefully"
                     ))
@@ -66,7 +66,7 @@ impl StartCommand {
                 match selected_nodes.len() {
                     0 => {
                         opts.terminal
-                            .stdout()
+                            .to_stdout()
                             .plain(fmt_info!("No node selected, exiting gratefully!"))
                             .write_line()?;
                     }
@@ -77,7 +77,7 @@ impl StartCommand {
                             &selected_nodes.join(", ")
                         )) {
                             opts.terminal
-                                .stdout()
+                                .to_stdout()
                                 .plain(fmt_info!("No node selected, exiting gratefully!"))
                                 .write_line()?;
                             return Ok(());
@@ -87,7 +87,7 @@ impl StartCommand {
                             start_multiple_nodes(ctx, &opts, &selected_nodes).await?;
 
                         opts.terminal
-                            .stdout()
+                            .to_stdout()
                             .plain(formatted_starts_result.join("\n"))
                             .write_line()?;
                     }
@@ -111,7 +111,7 @@ async fn start_single_node(
     // Abort if node is already running
     if node_info.is_running() {
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(fmt_err!(
                 "The node '{node_name}' is already running. If you want to restart it you can \
                     call `ockam node stop {node_name}` and then `ockam node start {node_name}`"
@@ -123,7 +123,7 @@ async fn start_single_node(
     let mut node = run_node(node_name, ctx, &opts).await?;
     let node_status = get_node_resources(ctx, &opts.state, &mut node).await?;
     opts.terminal
-        .stdout()
+        .to_stdout()
         .plain(&node_status)
         .json(serde_json::to_string(&node_status).into_diagnostic()?)
         .write_line()?;
@@ -182,7 +182,7 @@ async fn run_node(
     let handle = spawn_node(opts, cmd)?;
 
     tokio::select! {
-        _ = handle.wait_with_output() => { std::process::exit(1) }
+        _ = wait_while_draining_output(opts, handle) => { std::process::exit(1) }
         _ = node_callback.wait_for_signal() => {}
     }
 

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -47,7 +47,7 @@ impl StopCommand {
             .collect::<Vec<String>>();
         if running_nodes.is_empty() {
             opts.terminal
-                .stdout()
+                .to_stdout()
                 .plain(fmt_info!("There are no nodes running"))
                 .write_line()?;
             return Ok(());
@@ -85,7 +85,7 @@ impl StopCommand {
                 match selected_item_names.len() {
                     0 => {
                         opts.terminal
-                            .stdout()
+                            .to_stdout()
                             .plain(fmt_info!("No nodes selected to stop"))
                             .write_line()?;
                     }
@@ -118,6 +118,6 @@ async fn stop_node(opts: CommandGlobalOpts, node_name: &str) -> miette::Result<(
             color!(node_name, OckamColor::PrimaryResource)
         )
     };
-    opts.terminal.stdout().plain(output).write_line()?;
+    opts.terminal.to_stdout().plain(output).write_line()?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -1,16 +1,19 @@
 use crate::branding::BrandingCompileEnvVars;
 use crate::node::CreateCommand;
-use crate::run::parser::resource::utils::subprocess_stdio;
 use crate::shared_args::TrustOpts;
 use crate::{branding, Command as CommandTrait, CommandGlobalOpts};
+use console::Term;
 use miette::IntoDiagnostic;
 use miette::{miette, Context as _};
+use ockam_api::terminal::{TerminalStream, TerminalWriter};
 use ockam_core::env::get_env_with_default;
 use ockam_node::Context;
 use rand::random;
 use std::env::current_exe;
-use std::process::Stdio;
+use std::process::{ExitStatus, Stdio};
+use tokio::io::{self, AsyncBufReadExt, AsyncRead};
 use tokio::process::{Child, Command as TokioCommand};
+use tokio::try_join;
 use tracing::info;
 
 pub struct NodeManagerDefaults {
@@ -192,11 +195,11 @@ pub fn spawn_node(opts: &CommandGlobalOpts, cmd: CreateCommand) -> miette::Resul
 
     args.push(name.to_owned());
 
-    run_ockam(args, opts.global_args.quiet)
+    run_ockam(args)
 }
 
 /// Run the ockam command line with specific arguments
-pub fn run_ockam(args: Vec<String>, quiet: bool) -> miette::Result<Child> {
+pub fn run_ockam(args: Vec<String>) -> miette::Result<Child> {
     info!("spawning a new process");
 
     // On systems with non-obvious path setups (or during
@@ -211,8 +214,8 @@ pub fn run_ockam(args: Vec<String>, quiet: bool) -> miette::Result<Child> {
     unsafe {
         TokioCommand::new(ockam_exe)
             .args(args)
-            .stdout(subprocess_stdio(quiet))
-            .stderr(subprocess_stdio(quiet))
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .stdin(Stdio::null())
             // This unsafe block will only panic if the closure panics, which shouldn't happen
             .pre_exec(|| {
@@ -224,4 +227,43 @@ pub fn run_ockam(args: Vec<String>, quiet: bool) -> miette::Result<Child> {
             .into_diagnostic()
             .context("failed to spawn node")
     }
+}
+
+pub async fn wait_while_draining_output(
+    opts: &CommandGlobalOpts,
+    mut handle: Child,
+) -> miette::Result<ExitStatus> {
+    async fn drain<Reader: AsyncRead + Unpin>(
+        mut writer: TerminalStream<Term>,
+        reader: Option<Reader>,
+        quiet: bool,
+    ) -> io::Result<()> {
+        if quiet {
+            // If we're running in quiet mode, we supress the child output
+            return Ok(());
+        }
+
+        if let Some(reader) = reader {
+            let reader = io::BufReader::new(reader);
+            let mut lines = reader.lines();
+            while let Some(line) = lines.next_line().await? {
+                let _ = writer.write(line);
+            }
+        }
+
+        Ok(())
+    }
+
+    let parent_stdout = opts.terminal.stdout();
+    let parent_stderr = opts.terminal.stderr();
+
+    let child_stdout = handle.stdout.take();
+    let child_stderr = handle.stderr.take();
+
+    let stdout_fut = drain(parent_stdout, child_stdout, opts.global_args.quiet);
+    let stderr_fut = drain(parent_stderr, child_stderr, opts.global_args.quiet);
+
+    let (status, _, _) = try_join!(handle.wait(), stdout_fut, stderr_fut).into_diagnostic()?;
+
+    Ok(status)
 }

--- a/implementations/rust/ockam/ockam_command/src/policy/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/create.rs
@@ -71,7 +71,7 @@ impl Command for CreateCommand {
         node.add_policy(ctx, &resource, &Action::HandleMessage, &self.allow)
             .await?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "Policy created at node {}",
                 color_primary(node.node_name())

--- a/implementations/rust/ockam/ockam_command/src/policy/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/delete.rs
@@ -119,7 +119,7 @@ impl DeleteCommandTui for DeleteTui {
             ResourceTypeOrName::Name(_) => "resource",
         };
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "Policy for {resource_kind} {} has been deleted",
                 color_primary(resource.to_string())

--- a/implementations/rust/ockam/ockam_command/src/policy/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/list.rs
@@ -56,7 +56,7 @@ impl ListCommand {
                 policies.resource_type_policies(),
                 &format!("No policies on Node {}", &node.node_name()),
             )?;
-            opts.terminal.stdout().plain(list).write_line()?;
+            opts.terminal.to_stdout().plain(list).write_line()?;
             return Ok(());
         }
 
@@ -78,7 +78,7 @@ impl ListCommand {
             plain
         };
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .json(json)
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/policy/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/show.rs
@@ -115,7 +115,7 @@ impl ShowCommandTui for ShowTui {
             ResourceTypeOrName::Name(_) => "resource",
         };
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "Policy for {resource_kind} {} is {}",
                 color_primary(policy.resource().to_string()),

--- a/implementations/rust/ockam/ockam_command/src/project/addon/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/list.rs
@@ -43,7 +43,7 @@ impl AddonListSubcommand {
             &addons,
             &format!("No addons enabled for project {project_name}"),
         )?;
-        opts.terminal.stdout().plain(output).write_line()?;
+        opts.terminal.to_stdout().plain(output).write_line()?;
         Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -48,7 +48,7 @@ impl CreateCommand {
         let project = check_for_project_completion(&opts, ctx, &node, project).await?;
         let project = check_project_readiness(&opts, ctx, &node, project).await?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(project.item()?)
             .json(serde_json::json!(&project))
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -50,7 +50,7 @@ impl DeleteCommand {
             node.delete_project_by_name(ctx, &self.space_name, &self.project_name)
                 .await?;
             opts.terminal
-                .stdout()
+                .to_stdout()
                 .plain(fmt_ok!(
                     "Project with name '{}' has been deleted.",
                     &self.project_name

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -167,7 +167,7 @@ impl Command for EnrollCommand {
         let output = ProjectEnrollOutput::new(identity, project_name, credential);
         opts.terminal
             .clone()
-            .stdout()
+            .to_stdout()
             .plain(output.item()?)
             .json_obj(output)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/project/import.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/import.rs
@@ -38,7 +38,7 @@ impl ImportCommand {
             .await?;
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!("Successfully imported project {}", &project.name))
             .write_line()?;
 

--- a/implementations/rust/ockam/ockam_command/src/project/info.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/info.rs
@@ -30,7 +30,7 @@ impl InfoCommand {
         let node = InMemoryNode::start(ctx, &opts.state).await?;
         let project = node.get_project_by_name(ctx, &self.name).await?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(project.item()?)
             .json(serde_json::to_string(&project).into_diagnostic()?)
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -51,7 +51,7 @@ impl ListCommand {
         let json = serde_json::to_string(&projects).into_diagnostic()?;
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .json(json)
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -116,7 +116,7 @@ impl ShowCommandTui for ShowTui {
             .map_err(Error::Retry)?;
 
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(project.item()?)
             .json_obj(project)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -207,7 +207,7 @@ impl Command for TicketCommand {
         )?;
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(format!("\n{encoded_ticket}"))
             .machine(encoded_ticket)
             .json(as_json)

--- a/implementations/rust/ockam/ockam_command/src/project/version.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/version.rs
@@ -45,7 +45,7 @@ impl VersionCommand {
         );
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .machine(project_version)
             .json(json)

--- a/implementations/rust/ockam/ockam_command/src/project_admin/add.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_admin/add.rs
@@ -47,7 +47,7 @@ impl Command for AddCommand {
             .await?;
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "Email {} added as an admin to project {}",
                 color_primary(self.email.to_string()),

--- a/implementations/rust/ockam/ockam_command/src/project_admin/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_admin/delete.rs
@@ -124,7 +124,7 @@ impl DeleteCommandTui for DeleteTui {
             )
             .await?;
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "Admin with email {} has been deleted from project {}",
                 color_primary(item_name),

--- a/implementations/rust/ockam/ockam_command/src/project_admin/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_admin/list.rs
@@ -38,7 +38,7 @@ impl Command for ListCommand {
 
         let list = &opts.terminal.build_list(&admins, "No admins found")?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(list)
             .json_obj(admins)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/project_member/add.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/add.rs
@@ -90,7 +90,7 @@ impl Command for AddCommand {
         };
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(output.to_string())
             .json_obj(&output)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/project_member/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/delete.rs
@@ -137,7 +137,7 @@ impl Command for DeleteCommand {
         }
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(output.to_string())
             .json_obj(&output)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/project_member/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/list.rs
@@ -57,7 +57,7 @@ impl Command for ListCommand {
             .terminal
             .build_list(&members, "No members found on the Authority node")?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .json_obj(&members)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/project_member/list_ids.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/list_ids.rs
@@ -46,7 +46,7 @@ impl Command for ListIdsCommand {
             .terminal
             .build_list(&member_ids, "No members found on the Authority node")?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .json_obj(&member_ids)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/project_member/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/show.rs
@@ -107,7 +107,7 @@ impl ShowCommandTui for ShowTui {
             .await?;
         let member = MemberOutput::new(identifier, attributes);
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(member.item()?)
             .json_obj(&member)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -130,7 +130,7 @@ impl Command for CreateCommand {
                     fmt_ok!("Relay will be created automatically from {from} → {to} as soon as a connection can be established.")
                 };
                 opts.terminal
-                    .stdout()
+                    .to_stdout()
                     .plain(plain)
                     .json_obj(relay_info)?
                     .write_line()?;
@@ -159,7 +159,7 @@ impl Command for CreateCommand {
                     };
 
                     opts.terminal
-                        .stdout()
+                        .to_stdout()
                         .plain(plain)
                         .machine(remote_address.to_string())
                         .json_obj(relay_info)?
@@ -172,7 +172,7 @@ impl Command for CreateCommand {
                             + &fmt_info!("It will automatically connect to the Relay as soon as it is available")
                     };
                     opts.terminal
-                        .stdout()
+                        .to_stdout()
                         .plain(plain)
                         .json_obj(relay_info)?
                         .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/relay/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/delete.rs
@@ -108,7 +108,7 @@ impl DeleteCommandTui for DeleteTui {
             )
             .await?;
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "Relay with name {} on Node {} has been deleted",
                 color!(relay_name, OckamColor::PrimaryResource),

--- a/implementations/rust/ockam/ockam_command/src/relay/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/list.rs
@@ -49,7 +49,7 @@ impl ListCommand {
             &format!("No Relays found on node {}", node.node_name()),
         )?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .json_obj(relays)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/relay/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/show.rs
@@ -108,7 +108,7 @@ impl ShowCommandTui for ShowTui {
             .await?;
         let relay = RelayShowOutput::from(relay);
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(relay.item()?)
             .machine(item_name)
             .json(serde_json::to_string(&relay).into_diagnostic()?)

--- a/implementations/rust/ockam/ockam_command/src/reset/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/reset/mod.rs
@@ -89,7 +89,7 @@ impl ResetCommand {
         ockam::tcp::TcpTransport::detach_all_ockam_ebpfs_globally();
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!("Local Ockam configuration deleted"))
             .write_line()?;
         Ok(())

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/utils.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/utils.rs
@@ -1,7 +1,6 @@
 use clap::Parser;
 use miette::IntoDiagnostic;
 use once_cell::sync::Lazy;
-use std::process::Stdio;
 
 use crate::{OckamCommand, OckamSubcommand};
 
@@ -26,16 +25,4 @@ pub fn parse_cmd_from_args(cmd: &str, args: &[String]) -> miette::Result<OckamSu
     Ok(OckamCommand::try_parse_from(args)
         .into_diagnostic()?
         .subcommand)
-}
-
-pub fn subprocess_stdio(quiet: bool) -> Stdio {
-    if quiet {
-        // If we're running in quiet mode, we don't need to propagate
-        // the stdout/stderr to the child process
-        Stdio::null()
-    } else {
-        // Otherwise, we need to inherit the stdout/stderr of the current process
-        // to see the output written in the spawned process
-        Stdio::inherit()
-    }
 }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -148,7 +148,7 @@ impl CreateCommand {
 
         let from = format!("/node/{}", node.node_name());
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(
                 fmt_ok!(
                     "Secure Channel at {} created successfully\n",

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
@@ -118,7 +118,7 @@ impl ListCommand {
             &responses,
             &format!("No secure channels found on {}", node.node_name()),
         )?;
-        opts.terminal.stdout().plain(list).write_line()?;
+        opts.terminal.to_stdout().plain(list).write_line()?;
 
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -62,7 +62,7 @@ impl CreateCommand {
             Ok(_) => {
                 let address = format!("/service/{}", self.address.address());
                 opts.terminal
-                    .stdout()
+                    .to_stdout()
                     .plain(
                         fmt_ok!(
                             "Secure Channel Listener at {} created successfully\n",

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
@@ -40,7 +40,7 @@ impl DeleteCommand {
         let response: DeleteSecureChannelListenerResponse = node.ask(ctx, req).await?;
         let addr = response.addr;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "Deleted secure-channel listener with address '{addr}' on node '{}'",
                 node.node_name()

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
@@ -63,7 +63,7 @@ impl ListCommand {
                 node.node_name()
             ),
         )?;
-        opts.terminal.stdout().plain(list).write_line()?;
+        opts.terminal.to_stdout().plain(list).write_line()?;
 
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/show.rs
@@ -39,7 +39,7 @@ impl ShowCommand {
         let req = api::show_secure_channel_listener(address);
         node.tell(ctx, req).await?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(format!("/service/{}", self.address.address()))
             .write_line()?;
         Ok(())

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
@@ -43,7 +43,7 @@ impl ShowCommand {
         let response: ShowSecureChannelResponse =
             node.ask(ctx, api::show_secure_channel(address)).await?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(response.item()?)
             .json(serde_json::to_string(&response).into_diagnostic()?)
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/service/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/list.rs
@@ -50,7 +50,7 @@ impl ListCommand {
         )?;
         let json = serde_json::to_string(&services).into_diagnostic()?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .json(json)
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/share/accept.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/accept.rs
@@ -50,7 +50,7 @@ impl AcceptCommand {
         );
         let json = serde_json::to_string(&accepted).into_diagnostic()?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .json(json)
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/share/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/create.rs
@@ -78,7 +78,7 @@ impl CreateCommand {
         );
         let json = serde_json::to_string(&sent).into_diagnostic()?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .json(json)
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/share/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/list.rs
@@ -52,7 +52,7 @@ impl ListCommand {
             let plain = opts.terminal.build_list(sent, "No sent shares found.")?;
             let json = serde_json::to_string(sent).into_diagnostic()?;
             opts.terminal
-                .stdout()
+                .to_stdout()
                 .plain(plain)
                 .json(json)
                 .write_line()?;
@@ -65,7 +65,7 @@ impl ListCommand {
                 .build_list(received, "No received shares found.")?;
             let json = serde_json::to_string(received).into_diagnostic()?;
             opts.terminal
-                .stdout()
+                .to_stdout()
                 .plain(plain)
                 .json(json)
                 .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/share/service.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/service.rs
@@ -89,7 +89,7 @@ impl ServiceCreateCommand {
         );
         let json = serde_json::to_string(&sent).into_diagnostic()?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .json(json)
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/share/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/show.rs
@@ -52,7 +52,7 @@ impl ShowCommand {
         let plain = fmt_ok!("Invite {}", response.invitation.id);
         let json = serde_json::to_string(&response).into_diagnostic()?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .json(json)
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -68,7 +68,7 @@ impl Command for CreateCommand {
             opts.terminal.write_line(msg)?;
         }
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(space.item()?)
             .json_obj(&space)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -108,7 +108,7 @@ impl DeleteCommandTui for DeleteTui {
         self.node.delete_space_by_name(&self.ctx, item_name).await?;
 
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "The space with name {} has been deleted",
                 color!(item_name, OckamColor::PrimaryResource)

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -45,7 +45,7 @@ impl Command for ListCommand {
         )?;
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .json_obj(&spaces)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -99,7 +99,7 @@ impl<'a> ShowCommandTui for ShowTui<'a> {
     async fn show_single(&self, item_name: &str) -> miette::Result<()> {
         let space = self.node.get_space_by_name(self.ctx, item_name).await?;
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(space.item()?)
             .json_obj(&space)?
             .machine(&space.name)

--- a/implementations/rust/ockam/ockam_command/src/space_admin/add.rs
+++ b/implementations/rust/ockam/ockam_command/src/space_admin/add.rs
@@ -39,7 +39,7 @@ impl Command for AddCommand {
             .await?;
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "Email {} added as an admin to space {}",
                 color_primary(self.email.to_string()),

--- a/implementations/rust/ockam/ockam_command/src/space_admin/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space_admin/delete.rs
@@ -153,7 +153,7 @@ impl DeleteCommandTui for DeleteTui {
             )
             .await?;
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "Admin with email {} has been deleted from space {}",
                 color_primary(item_name),

--- a/implementations/rust/ockam/ockam_command/src/space_admin/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space_admin/list.rs
@@ -30,7 +30,7 @@ impl Command for ListCommand {
 
         let list = &opts.terminal.build_list(&admins, "No admins found")?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(list)
             .json_obj(admins)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/status/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/status/mod.rs
@@ -58,7 +58,7 @@ impl Command for StatusCommand {
         let status =
             StatusData::from_parts(orchestrator_version, spaces, identities_details, nodes)?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(&status)
             .json(serde_json::to_string(&status).into_diagnostic()?)
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -53,7 +53,7 @@ impl Command for CreateCommand {
         );
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(output.item()?)
             .machine(output.address.to_string())
             .json(serde_json::to_string(&output).into_diagnostic()?)

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
@@ -42,7 +42,7 @@ impl DeleteCommand {
                 .body(models::transport::DeleteTransport::new(address.clone()));
             node.tell(ctx, req).await?;
             opts.terminal
-                .stdout()
+                .to_stdout()
                 .plain(fmt_ok!(
                     "TCP connection {address} has been successfully deleted"
                 ))

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -58,7 +58,7 @@ impl ListCommand {
             ),
         )?;
 
-        opts.terminal.stdout().plain(list).write_line()?;
+        opts.terminal.to_stdout().plain(list).write_line()?;
 
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
@@ -42,7 +42,7 @@ impl ShowCommand {
             .await?;
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(
                 fmt_ok!("TCP Connection:\n")
                     + &fmt_log!(

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -283,7 +283,7 @@ impl Command for CreateCommand {
         }
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .machine(inlet_status.bind_addr.to_string())
             .json(serde_json::json!(&inlet_status))

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
@@ -109,7 +109,7 @@ impl DeleteCommandTui for DeleteTui {
         let node_name = self.node.node_name();
         self.node.delete_inlet(&self.ctx, item_name).await?;
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "TCP Inlet with alias {} on Node {} has been deleted",
                 color_primary(item_name),

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
@@ -41,7 +41,7 @@ impl ListCommand {
             &format!("No TCP Inlets found on {}", node.node_name()),
         )?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .json_obj(&inlets)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
@@ -109,7 +109,7 @@ impl ShowCommandTui for ShowTui {
             .ask(&self.ctx, Request::get(format!("/node/inlet/{item_name}")))
             .await?;
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(inlet_status.item()?)
             .json_obj(inlet_status)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -53,7 +53,7 @@ impl CreateCommand {
         multiaddr.push_back(Tcp::new(port)).into_diagnostic()?;
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(
                 fmt_ok!("Tcp listener created! You can send messages to it via this route:\n")
                     + &fmt_log!("{multiaddr}"),

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
@@ -59,7 +59,7 @@ impl DeleteCommand {
             node.tell(ctx, req).await?;
 
             opts.terminal
-                .stdout()
+                .to_stdout()
                 .plain(fmt_ok!(
                     "TCP listener with address {address} on Node {} has been deleted",
                     node.node_name()

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
@@ -57,7 +57,7 @@ impl ListCommand {
                 node.node_name().color(OckamColor::PrimaryResource.color())
             ),
         )?;
-        opts.terminal.stdout().plain(list).write_line()?;
+        opts.terminal.to_stdout().plain(list).write_line()?;
         Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
@@ -39,7 +39,7 @@ impl ShowCommand {
             )
             .await?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(&transport_status)
             .json(serde_json::to_string(&transport_status).into_diagnostic()?)
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -135,7 +135,7 @@ impl Command for CreateCommand {
         }
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(msg)
             .machine(worker_route)
             .json(serde_json::to_string(&outlet_status).into_diagnostic()?)

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -122,7 +122,7 @@ impl DeleteCommandTui for DeleteTui {
             )
             .await?;
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "TCP Outlet with alias {} on node {} has been deleted",
                 color_primary(item_name),

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
@@ -76,7 +76,7 @@ impl ListCommand {
             .collect();
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(list)
             .json(serde_json::json!(json))
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -141,7 +141,7 @@ impl ShowCommandTui for ShowTui {
             to: outlet_status.to.to_string(),
         };
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(info.item()?)
             .json_obj(info)?
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/terminal/tui.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/tui.rs
@@ -28,7 +28,7 @@ pub trait ShowCommandTui {
         let items_names = self.list_items_names().await?;
         if items_names.is_empty() {
             terminal
-                .stdout()
+                .to_stdout()
                 .plain(fmt_info!(
                     "There are no {} to show{}",
                     Self::ITEM_NAME.plural(),
@@ -71,7 +71,7 @@ pub trait ShowCommandTui {
                 match selected_item_names.len() {
                     0 => {
                         terminal
-                            .stdout()
+                            .to_stdout()
                             .plain(fmt_info!(
                                 "No {} selected to show",
                                 Self::ITEM_NAME.plural()
@@ -86,7 +86,7 @@ pub trait ShowCommandTui {
                         for item_name in selected_item_names {
                             if self.show_single(&item_name).await.is_err() {
                                 self.terminal()
-                                    .stdout()
+                                    .to_stdout()
                                     .plain(fmt_warn!(
                                         "Failed to show {} {}",
                                         Self::ITEM_NAME.singular(),
@@ -133,7 +133,7 @@ where
         for item_name in items_names {
             if self.delete_single(&item_name).await.is_err() {
                 self.terminal()
-                    .stdout()
+                    .to_stdout()
                     .plain(fmt_warn!(
                         "Failed to delete {} {}",
                         Self::ITEM_NAME.singular(),
@@ -155,7 +155,7 @@ where
                     if _self.delete_single(&item_name).await.is_err() {
                         _self
                             .terminal()
-                            .stdout()
+                            .to_stdout()
                             .plain(fmt_warn!(
                                 "Failed to delete {} {}",
                                 Self::ITEM_NAME.singular(),
@@ -177,7 +177,7 @@ where
 
         if items_names.is_empty() {
             terminal
-                .stdout()
+                .to_stdout()
                 .plain(fmt_info!(
                     "There are no {} to delete",
                     Self::ITEM_NAME.plural()
@@ -250,7 +250,7 @@ where
                 match selected_item_names.len() {
                     0 => {
                         terminal
-                            .stdout()
+                            .to_stdout()
                             .plain(fmt_info!(
                                 "No {} selected to delete",
                                 Self::ITEM_NAME.plural()

--- a/implementations/rust/ockam/ockam_command/src/vault/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/create.rs
@@ -47,7 +47,7 @@ impl Command for CreateCommand {
             .await?;
 
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!("Vault created with name '{}'!", vault.name()))
             .machine(vault.name())
             .json(serde_json::json!({ "name": &vault.name() }))

--- a/implementations/rust/ockam/ockam_command/src/vault/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/delete.rs
@@ -86,7 +86,7 @@ impl DeleteCommandTui for DeleteTui {
     async fn delete_single(&self, item_name: &str) -> miette::Result<()> {
         self.opts.state.delete_named_vault(item_name).await?;
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(fmt_ok!(
                 "Vault with name {} has been deleted",
                 color!(item_name, OckamColor::PrimaryResource)

--- a/implementations/rust/ockam/ockam_command/src/vault/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/list.rs
@@ -33,7 +33,7 @@ impl ListCommand {
         let plain = opts.terminal.build_list(&vaults, "No Vaults found")?;
         let json = serde_json::to_string(&vaults).into_diagnostic()?;
         opts.terminal
-            .stdout()
+            .to_stdout()
             .plain(plain)
             .json(json)
             .write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/vault/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/show.rs
@@ -89,7 +89,7 @@ impl ShowCommandTui for ShowTui {
     async fn show_single(&self, item_name: &str) -> miette::Result<()> {
         let vault = VaultOutput::new(&self.opts.state.get_named_vault(item_name).await?);
         self.terminal()
-            .stdout()
+            .to_stdout()
             .plain(vault.item()?)
             .json(serde_json::to_string(&vault).into_diagnostic()?)
             .machine(vault.name())

--- a/implementations/rust/ockam/ockam_command/src/worker/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/worker/list.rs
@@ -58,7 +58,7 @@ impl ListCommand {
             &workers.list,
             &format!("No workers found on {}.", node.node_name()),
         )?;
-        opts.terminal.stdout().plain(list).write_line()?;
+        opts.terminal.to_stdout().plain(list).write_line()?;
 
         Ok(())
     }


### PR DESCRIPTION
Inheriting pipes in a subprocess leads to problems when the parent process exits before the subprocess does. 

This PR [changes](https://github.com/build-trust/ockam/pull/8793/files#diff-deeb48b9384ebf5f6a7f9a4d1782fdf2ebb58cedd036d2a57c4e86bd7c6dacdcR232) that behavior so that the pipes from the child and parent processes are detached and the parent drains/consumes the child's pipes directly from the main process.