### PR TITLE
refactor(rust): logic of handling the default node name in `node create`

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -11,7 +11,6 @@ use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
 use miette::{miette, IntoDiagnostic, WrapErr};
-use ockam_api::cli_state::random_name;
 use ockam_api::colors::{color_error, color_primary};
 use ockam_api::nodes::models::transport::Port;
 use ockam_api::terminal::notification::NotificationHandler;
@@ -291,34 +290,6 @@ impl CreateCommand {
             self.name = DEFAULT_NODE_NAME.to_string();
         }
 
-        self.name = {
-            let mut name = if let Ok(node_config) = self.parse_node_config().await {
-                node_config.node.name().unwrap_or(self.name.clone())
-            } else {
-                self.name.clone()
-            };
-            if name == DEFAULT_NODE_NAME {
-                name = random_name();
-            }
-            name
-        };
-
-        // FIXME: Avoid this check to avoid parent process needing db to create a background node
-        if !self.skip_is_running_check
-            && opts
-                .state
-                .get_node(&self.name)
-                .await
-                .ok()
-                .map(|n| n.is_running())
-                .unwrap_or(false)
-        {
-            return Err(miette!(
-                "Node {} is already running",
-                color_primary(&self.name)
-            ));
-        }
-
         if self.http_server {
             print_warning_for_deprecated_flag_no_effect(opts, "http-server")?;
         }
@@ -412,7 +383,6 @@ mod tests {
     use ockam_api::output::{OutputBranding, OutputFormat};
     use ockam_api::terminal::Terminal;
     use ockam_api::CliState;
-    use std::sync::Arc;
 
     #[test]
     fn command_can_be_parsed_from_name() {
@@ -536,62 +506,60 @@ mod tests {
         assert!(!cmd.should_run_config());
     }
 
-    #[test]
-    fn get_default_node_name_no_previous_state() {
-        let rt = Arc::new(tokio::runtime::Runtime::new().unwrap());
-        rt.block_on(async {
-            let opts = CommandGlobalOpts {
-                state: CliState::test().await.unwrap(),
-                terminal: Terminal::new(
-                    false,
-                    false,
-                    false,
-                    true,
-                    false,
-                    OutputFormat::Plain,
-                    OutputBranding::default(),
-                ),
-                global_args: GlobalArgs::default(),
-            };
-            let mut cmd = CreateCommand::default();
-            cmd.parse_args(&opts).await.unwrap();
-            assert_ne!(cmd.name, DEFAULT_NODE_NAME);
+    #[tokio::test]
+    async fn get_default_node_name_no_previous_state() {
+        let opts = CommandGlobalOpts {
+            state: CliState::test().await.unwrap(),
+            terminal: Terminal::new(
+                false,
+                false,
+                false,
+                true,
+                false,
+                OutputFormat::Plain,
+                OutputBranding::default(),
+            ),
+            global_args: GlobalArgs::default(),
+        };
+        let mut cmd = CreateCommand::default();
+        cmd.parse_args(&opts).await.unwrap();
+        // The default name is changed if needed when parsing the config
+        assert_eq!(cmd.name, DEFAULT_NODE_NAME);
 
-            let mut cmd = CreateCommand {
-                name: r#"{tcp-outlet: {to: "5500"}}"#.to_string(),
-                ..Default::default()
-            };
-            cmd.parse_args(&opts).await.unwrap();
-            assert_ne!(cmd.name, DEFAULT_NODE_NAME);
+        let mut cmd = CreateCommand {
+            name: r#"{tcp-outlet: {to: "5500"}}"#.to_string(),
+            ..Default::default()
+        };
+        cmd.parse_args(&opts).await.unwrap();
+        assert_eq!(cmd.name, DEFAULT_NODE_NAME);
 
-            let mut cmd = CreateCommand {
-                config_args: ConfigArgs {
-                    configuration: Some(r#"{tcp-outlet: {to: "5500"}}"#.to_string()),
-                    ..Default::default()
-                },
+        let mut cmd = CreateCommand {
+            config_args: ConfigArgs {
+                configuration: Some(r#"{tcp-outlet: {to: "5500"}}"#.to_string()),
                 ..Default::default()
-            };
-            cmd.parse_args(&opts).await.unwrap();
-            assert_ne!(cmd.name, DEFAULT_NODE_NAME);
+            },
+            ..Default::default()
+        };
+        cmd.parse_args(&opts).await.unwrap();
+        assert_eq!(cmd.name, DEFAULT_NODE_NAME);
 
-            let mut cmd = CreateCommand {
-                name: "n1".to_string(),
-                ..Default::default()
-            };
-            cmd.parse_args(&opts).await.unwrap();
-            assert_eq!(cmd.name, "n1");
+        let mut cmd = CreateCommand {
+            name: "n1".to_string(),
+            ..Default::default()
+        };
+        cmd.parse_args(&opts).await.unwrap();
+        assert_eq!(cmd.name, "n1");
 
-            let mut cmd = CreateCommand {
-                name: "n1".to_string(),
-                config_args: ConfigArgs {
-                    configuration: Some(r#"{tcp-outlet: {to: "5500"}}"#.to_string()),
-                    ..Default::default()
-                },
+        let mut cmd = CreateCommand {
+            name: "n1".to_string(),
+            config_args: ConfigArgs {
+                configuration: Some(r#"{tcp-outlet: {to: "5500"}}"#.to_string()),
                 ..Default::default()
-            };
-            cmd.parse_args(&opts).await.unwrap();
-            assert_eq!(cmd.name, "n1");
-        });
+            },
+            ..Default::default()
+        };
+        cmd.parse_args(&opts).await.unwrap();
+        assert_eq!(cmd.name, "n1");
     }
 
     #[ockam::test]

--- a/implementations/rust/ockam/ockam_command/src/node/create/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/config.rs
@@ -3,11 +3,12 @@ use crate::node::CreateCommand;
 use crate::run::parser::config::ConfigParser;
 use crate::run::parser::resource::*;
 use crate::run::parser::Version;
-use crate::value_parsers::{parse_config_or_path_or_url, parse_key_val};
+use crate::value_parsers::{parse_key_val, read_config_contents_from_path_or_url_or_inline};
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use miette::{miette, IntoDiagnostic};
 use ockam_api::cli_state::journeys::APPLICATION_EVENT_COMMAND_CONFIGURATION_FILE;
+use ockam_api::cli_state::random_name;
 use ockam_core::{OpenTelemetryContext, TryClone};
 use ockam_node::Context;
 use serde::{Deserialize, Serialize};
@@ -47,7 +48,7 @@ impl CreateCommand {
     pub async fn run_config(self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
         debug!("running node create with a node config");
         let mut node_config = self.parse_node_config().await?;
-        node_config.merge(&self).await?;
+        node_config.merge(&self)?;
         trace!(?node_config, "merged node config with command args");
         let node_name = node_config.node.name().ok_or(miette!(
             "Node name should be set to the command's default value"
@@ -73,7 +74,7 @@ impl CreateCommand {
     pub(super) async fn get_node_config_contents(&self) -> miette::Result<String> {
         match self.config_args.configuration.clone() {
             Some(contents) => Ok(contents),
-            None => match parse_config_or_path_or_url::<NodeConfig>(&self.name).await {
+            None => match read_config_contents_from_path_or_url_or_inline(&self.name).await {
                 Ok(contents) => Ok(contents),
                 Err(err) => {
                     // If just the enrollment ticket is passed, create a minimal configuration
@@ -93,7 +94,7 @@ impl CreateCommand {
     ///  - an inline configuration
     /// or read the `configuration` argument
     #[instrument(skip_all, fields(app.event.command.configuration_file))]
-    pub(super) async fn parse_node_config(&self) -> miette::Result<NodeConfig> {
+    async fn parse_node_config(&self) -> miette::Result<NodeConfig> {
         let contents = self.get_node_config_contents().await?;
         // Set environment variables from the cli command args
         // This needs to be done before parsing the configuration
@@ -147,7 +148,7 @@ impl NodeConfig {
 
     /// Merge the arguments of the node defined in the config with the arguments from the
     /// "create" command, giving precedence to the command args.
-    async fn merge(&mut self, cmd: &CreateCommand) -> miette::Result<()> {
+    fn merge(&mut self, cmd: &CreateCommand) -> miette::Result<()> {
         // Set environment variables from the cli command again
         // to override the duplicate entries from the config file.
         for (key, value) in &cmd.config_args.variables {
@@ -158,9 +159,6 @@ impl NodeConfig {
         }
 
         // Set default values to the config, if not present
-        if self.node.name.is_none() {
-            self.node.name = Some(cmd.name.clone().into());
-        }
         if self.node.opentelemetry_context.is_none() {
             self.node.opentelemetry_context = Some(
                 serde_json::to_string(&OpenTelemetryContext::current())
@@ -171,8 +169,13 @@ impl NodeConfig {
 
         // Override config values with passed command args
         let default_cmd_args = CreateCommand::default();
-        if cmd.name.ne(&default_cmd_args.name) && cmd.name_arg_is_a_node_name() {
+        // If the command defines a node name, it should override the inline config
+        if cmd.name_arg_is_a_node_name() && cmd.name.ne(&default_cmd_args.name) {
             self.node.name = Some(cmd.name.clone().into());
+        }
+        // If the node name was not assigned, generate a random one
+        if self.node.name.is_none() && cmd.name.eq(&default_cmd_args.name) {
+            self.node.name = Some(random_name().into());
         }
         if let Some(ticket) = &cmd.config_args.enrollment_ticket {
             self.project_enroll.ticket = Some(ticket.clone());
@@ -354,6 +357,7 @@ impl NodeConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::node::create::DEFAULT_NODE_NAME;
     use ockam_api::cli_state::ExportedEnrollmentTicket;
 
     #[tokio::test]
@@ -446,7 +450,7 @@ mod tests {
             ..Default::default()
         };
         let mut config = cmd.parse_node_config().await.unwrap();
-        config.merge(&cmd).await.unwrap();
+        config.merge(&cmd).unwrap();
         assert_eq!(config.node.name, Some("n1".into()));
 
         // Same with inline config
@@ -458,7 +462,7 @@ mod tests {
             ..Default::default()
         };
         let mut config = cmd.parse_node_config().await.unwrap();
-        config.merge(&cmd).await.unwrap();
+        config.merge(&cmd).unwrap();
         assert_eq!(config.node.name, Some("n1".into()));
 
         // If the command defines a node name, it should override the inline config
@@ -471,16 +475,16 @@ mod tests {
             ..Default::default()
         };
         let mut config = cmd.parse_node_config().await.unwrap();
-        config.merge(&cmd).await.unwrap();
+        config.merge(&cmd).unwrap();
         assert_eq!(config.node.name, Some("n2".into()));
     }
 
-    #[tokio::test]
-    async fn merge_config_with_cli() {
+    #[test]
+    fn merge_config_with_cli() {
         let cli_enrollment_ticket = ExportedEnrollmentTicket::new_test();
         let cli_enrollment_ticket_encoded = cli_enrollment_ticket.to_string();
 
-        let cli_args = CreateCommand {
+        let cmd = CreateCommand {
             tcp_listener_address: "127.0.0.1:1234".to_string(),
             config_args: ConfigArgs {
                 enrollment_ticket: Some(cli_enrollment_ticket_encoded.clone()),
@@ -492,7 +496,7 @@ mod tests {
         // No node config, cli args should be used
         let contents = String::new();
         let mut config = NodeConfig::parse(contents).unwrap();
-        config.merge(&cli_args).await.unwrap();
+        config.merge(&cmd).unwrap();
         let node = config.node.into_parsed_commands().unwrap().pop().unwrap();
         assert_eq!(node.tcp_listener_address, "127.0.0.1:1234");
         assert_eq!(
@@ -512,13 +516,46 @@ mod tests {
         "#
         .to_string();
         let mut config = NodeConfig::parse(contents).unwrap();
-        config.merge(&cli_args).await.unwrap();
+        config.merge(&cmd).unwrap();
         let node = config.node.into_parsed_commands().unwrap().pop().unwrap();
         assert_eq!(node.name, "n1");
-        assert_eq!(node.tcp_listener_address, cli_args.tcp_listener_address);
+        assert_eq!(node.tcp_listener_address, cmd.tcp_listener_address);
         assert_eq!(
             config.project_enroll.ticket,
             Some(cli_enrollment_ticket_encoded.clone())
         );
+    }
+
+    #[test]
+    fn merge_config_with_cli_node_name() {
+        let cases = [
+            (CreateCommand::default(), "relay: r1", None), // random
+            (CreateCommand::default(), "name: n1", Some("n1")),
+            (
+                CreateCommand {
+                    name: "n2".into(),
+                    ..Default::default()
+                },
+                "name: n1",
+                Some("n2"), // command has priority
+            ),
+            (
+                CreateCommand {
+                    name: "n2".into(),
+                    ..Default::default()
+                },
+                "relay: r1",
+                Some("n2"), // command has priority
+            ),
+        ];
+        for (cmd, config, expected) in cases.into_iter() {
+            let mut config = NodeConfig::parse(config.to_string()).unwrap();
+            config.merge(&cmd).unwrap();
+            let node = config.node.into_parsed_commands().unwrap().pop().unwrap();
+            match expected {
+                Some(expected) => assert_eq!(node.name, expected),
+                None => assert_ne!(node.name, DEFAULT_NODE_NAME),
+            }
+        }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -1,3 +1,4 @@
+use crate::node::create::DEFAULT_NODE_NAME;
 use crate::node::node_callback::NodeCallback;
 use crate::node::CreateCommand;
 use crate::util::foreground_args::wait_for_exit_signal;
@@ -8,6 +9,8 @@ use ockam::tcp::{TcpListenerOptions, TcpTransport};
 use ockam::udp::{UdpBindArguments, UdpBindOptions, UdpTransport};
 use ockam::Address;
 use ockam::Context;
+use ockam_api::cli_state::random_name;
+use ockam_api::colors::color_primary;
 use ockam_api::fmt_log;
 use ockam_api::nodes::service::{NodeManagerTransport, SecureChannelType};
 use ockam_api::nodes::InMemoryNode;
@@ -16,7 +19,6 @@ use ockam_api::nodes::{
     NodeManagerWorker, NODEMANAGER_ADDR,
 };
 use ockam_api::terminal::notification::NotificationHandler;
-
 use ockam_core::LOCAL;
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
@@ -25,10 +27,11 @@ use tracing::{debug, info, instrument};
 impl CreateCommand {
     #[instrument(skip_all, fields(node_name = self.name))]
     pub(super) async fn foreground_mode(
-        &self,
+        &mut self,
         ctx: &Context,
         opts: CommandGlobalOpts,
     ) -> miette::Result<()> {
+        self.check_foreground_args(&opts).await?;
         let node_name = self.name.clone();
         debug!("creating node in foreground mode");
 
@@ -152,6 +155,37 @@ impl CreateCommand {
 
         // Clean up and exit
         let _ = opts.state.stop_node(&node_name).await;
+
+        Ok(())
+    }
+
+    /// Checks that the arguments specific to foreground nodes are valid.
+    async fn check_foreground_args(&mut self, opts: &CommandGlobalOpts) -> miette::Result<()> {
+        if !self.skip_is_running_check
+            && opts
+                .state
+                .get_node(&self.name)
+                .await
+                .ok()
+                .map(|n| n.is_running())
+                .unwrap_or(false)
+        {
+            return Err(miette!(
+                "Node {} is already running",
+                color_primary(&self.name)
+            ));
+        }
+
+        // return error if trying to create an in-memory node in background mode
+        if !self.foreground_args.foreground && opts.state.is_using_in_memory_database()? {
+            return Err(miette!("Only foreground nodes can be created in-memory",));
+        }
+
+        // if the default node name is used
+        if self.name == DEFAULT_NODE_NAME {
+            // initialize it with a random name
+            self.name = random_name();
+        }
 
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/value_parsers.rs
+++ b/implementations/rust/ockam/ockam_command/src/value_parsers.rs
@@ -1,8 +1,9 @@
+use crate::node::config::NodeConfig;
 use crate::util::parsers::hostname_parser;
 use crate::CommandGlobalOpts;
 use miette::{miette, Context, IntoDiagnostic};
 use ockam_api::cli_state::{EnrollmentTicket, ExportedEnrollmentTicket, LegacyEnrollmentTicket};
-use serde::Deserialize;
+use ockam_api::colors::color_primary;
 use std::str::FromStr;
 use tracing::{trace, warn};
 use url::Url;
@@ -30,7 +31,7 @@ pub async fn parse_enrollment_ticket(
     value: &str,
 ) -> miette::Result<EnrollmentTicket> {
     trace!(%value, "parsing enrollment ticket");
-    let contents = parse_string_or_path_or_url(value).await?;
+    let contents = read_contents_from_string_or_path_or_url(value).await?;
 
     // Try to parse it using the old format
     if let Ok(ticket) = LegacyEnrollmentTicket::from_str(&contents) {
@@ -42,32 +43,34 @@ pub async fn parse_enrollment_ticket(
         .await?)
 }
 
-pub(crate) async fn parse_config_or_path_or_url<'de, T: Deserialize<'de>>(
-    value: &'de str,
+pub(crate) async fn read_config_contents_from_path_or_url_or_inline(
+    value: &str,
 ) -> miette::Result<String> {
-    match parse_path_or_url(value).await {
-        Ok(contents) => Ok(contents),
-        Err(_) => {
-            if serde_yaml::from_str::<T>(value).is_ok() {
-                Ok(value.to_string())
-            } else {
-                Err(miette!(
-                    "Failed to parse value {} as a path, URL or inline configuration",
-                    value
-                ))
-            }
-        }
+    let contents = match read_contents_from_path_or_url(value).await {
+        Ok(contents) => contents,
+        Err(_) => value.to_string(),
+    };
+    let parsed = serde_yaml::from_str::<NodeConfig>(&contents);
+    if !contents.is_empty() && parsed.is_ok() {
+        Ok(contents)
+    } else {
+        Err(miette!(
+            "Failed to parse configuration from value {} as a path, URL or inline contents",
+            color_primary(value)
+        ))
     }
 }
 
-pub(crate) async fn parse_string_or_path_or_url(value: &str) -> miette::Result<String> {
-    parse_path_or_url(value).await.or_else(|err| {
+pub(crate) async fn read_contents_from_string_or_path_or_url(
+    value: &str,
+) -> miette::Result<String> {
+    read_contents_from_path_or_url(value).await.or_else(|err| {
         warn!(%value, %err, "Couldn't parse value as a path or URL. Returning plain value to be processed as inline contents");
         Ok(value.to_string())
     })
 }
 
-pub(crate) async fn parse_path_or_url(value: &str) -> miette::Result<String> {
+pub(crate) async fn read_contents_from_path_or_url(value: &str) -> miette::Result<String> {
     // If the URL is valid, download the contents
     if let Some(url) = is_url(value) {
         reqwest::get(url)
@@ -87,7 +90,10 @@ pub(crate) async fn parse_path_or_url(value: &str) -> miette::Result<String> {
             .context("Failed to read contents from file")
     } else {
         warn!(%value, "Couldn't parse value as a path or URL");
-        Err(miette!("Couldn't parse value '{}' as a path or URL", value))
+        Err(miette!(
+            "Couldn't parse value {} as a path or URL",
+            color_primary(value)
+        ))
     }
 }
 


### PR DESCRIPTION
Move the logic of handling the node name between the `name` arg and the `name` field in the config out of the `CreateCommand::parse_args` function. 

Instead, this is now handled either when merging the config file with the command args or in the foreground node.