### PR TITLE
fix(rust): fix the parsing of responses

### DIFF
--- a/implementations/rust/ockam/ockam_core/src/api.rs
+++ b/implementations/rust/ockam/ockam_core/src/api.rs
@@ -696,6 +696,10 @@ impl<T> Response<T> {
     pub fn has_body(&self) -> bool {
         self.header.has_body()
     }
+
+    pub fn get_error(&self) -> Option<Error> {
+        self.error.clone()
+    }
 }
 
 impl<T: Encodable> Response<T> {

--- a/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_client.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_client.rs
@@ -190,7 +190,10 @@ impl SecureClient {
         } else {
             let status = response.header().status();
             Ok(Reply::Failed(
-                Error::from_failed_request(&request_header, &response.parse_err_msg()),
+                response.get_error().unwrap_or(Error::from_failed_request(
+                    &request_header,
+                    "no error message",
+                )),
                 status,
             ))
         }


### PR DESCRIPTION
This PR fixes an error occurring when enrolling with a ticket:
```
ockam enroll
ockam project ticket > ticket
ockam node create --enrollment-ticket ticket
```