### PR TITLE
feat(rust): don't create a default node for the telemetry secure client

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/secure_channels.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/secure_channels.rs
@@ -6,11 +6,24 @@ use crate::cli_state::CliState;
 use crate::cli_state::Result;
 
 impl CliState {
-    pub async fn secure_channels(&self, node_name: &str) -> Result<Arc<SecureChannels>> {
-        debug!("create the secure channels service");
+    pub async fn secure_channels_for_node(&self, node_name: &str) -> Result<Arc<SecureChannels>> {
+        debug!("create the secure channels service for node {node_name}");
         let named_vault = self.get_node_vault(node_name).await?;
         let vault = self.make_vault(named_vault).await?;
         let identities = Identities::create_with_node(self.database(), node_name)
+            .with_vault(vault)
+            .build();
+        Ok(SecureChannels::from_identities(
+            identities,
+            SecureChannelSqlxDatabase::make_repository(self.database()),
+        ))
+    }
+
+    pub async fn secure_channels(&self) -> Result<Arc<SecureChannels>> {
+        debug!("create the secure channels service");
+        let named_vault = self.get_or_create_default_named_vault().await?;
+        let vault = self.make_vault(named_vault).await?;
+        let identities = Identities::create(self.database())
             .with_vault(vault)
             .build();
         Ok(SecureChannels::from_identities(

--- a/implementations/rust/ockam/ockam_api/src/logs/exporting_configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/exporting_configuration.rs
@@ -1,4 +1,3 @@
-use crate::cli_state::random_name;
 use crate::config::UrlVar;
 use crate::logs::default_values::*;
 use crate::logs::env_variables::*;
@@ -509,14 +508,20 @@ async fn make_secure_client(
     let project_route = TransportRouteResolver::default()
         .allow_tcp()
         .resolve(&route)?;
-    let default_node = if let Ok(node) = cli_state.get_default_node().await {
-        node
+    let (secure_channels, node_identifier) = if let Ok(node) = cli_state.get_default_node().await {
+        (
+            cli_state.secure_channels_for_node(&node.name()).await?,
+            node.identifier(),
+        )
     } else {
-        cli_state
-            .create_node_with_optional_identity(&random_name(), &None)
-            .await?
+        (
+            cli_state.secure_channels().await?,
+            cli_state
+                .get_or_create_default_named_identity()
+                .await?
+                .identifier(),
+        )
     };
-    let secure_channels = cli_state.secure_channels(&default_node.name()).await?;
 
     Ok(SecureClient::new(
         secure_channels,
@@ -524,7 +529,7 @@ async fn make_secure_client(
         TcpTransport::get_or_create(ctx)?,
         project_route,
         Arc::new(TrustIdentifierPolicy::new(identifier)),
-        &default_node.identifier(),
+        &node_identifier,
         get_default_timeout(),
         get_default_timeout(),
     ))

--- a/implementations/rust/ockam/ockam_api/src/logs/ockam_tonic_traces_client.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/ockam_tonic_traces_client.rs
@@ -170,7 +170,7 @@ pub(crate) mod tests {
         cli_state
             .create_named_vault(None, None, UseAwsKms::No)
             .await?;
-        Ok(cli_state.secure_channels("default").await?)
+        Ok(cli_state.secure_channels_for_node("default").await?)
     }
 
     /// Create an arbitrary batch of spans

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
@@ -87,7 +87,7 @@ impl NodeManager {
             .store_default_resource_type_policies()
             .await?;
 
-        let secure_channels = cli_state.secure_channels(&node_name).await?;
+        let secure_channels = cli_state.secure_channels_for_node(&node_name).await?;
 
         let project_member_credential_retriever_creator: Option<
             Arc<dyn CredentialRetrieverCreator>,


### PR DESCRIPTION
This PR just creates a default identity with the default vault when creating a secure channel client to send telemetry data.
