### PR TITLE
feat(rust): add support for "launch-configuration" in node's config

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/control_api/openapi.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/openapi.rs
@@ -46,9 +46,9 @@ configuration or via environment variable, it's then passed in the `Authorizatio
 ## Getting Started
 The easiest way to get development started is to use this API with the Ockam command and run a single node acting both as a frontend and backend.
 ```sh
-ockam node create --foreground -vv --launch-configuration '{
+ockam node create --foreground -vv --configuration '{
   "start_default_services": true,
-  "startup_services": {
+  "services": {
     "control_api": {
       "authentication_token": "my-secret-token",
       "backend": true,

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -1,7 +1,7 @@
 use crate::node::config::NodeConfig;
 use crate::node::create::config::ConfigArgs;
 use crate::node::util::NodeManagerDefaults;
-use crate::service::config::Config;
+use crate::service::config::ServicesConfig;
 use crate::shared_args::TrustOpts;
 use crate::util::foreground_args::ForegroundArgs;
 use crate::util::print_warning_for_deprecated_flag_no_effect;
@@ -120,8 +120,8 @@ pub struct CreateCommand {
     /// A configuration in JSON format to set up the node services.
     /// Node configuration is run asynchronously and may take several
     /// seconds to complete.
-    #[arg(hide = true, long, visible_alias = "launch-config", value_parser = parse_launch_config)]
-    pub launch_configuration: Option<Config>,
+    #[arg(hide = true, long, visible_alias = "launch-configuration", visible_alias = "launch-config", value_parser = parse_launch_config)]
+    pub services: Option<ServicesConfig>,
 
     #[arg(long = "identity", value_name = "IDENTITY_NAME")]
     #[arg(help = docs::about("\
@@ -175,7 +175,7 @@ impl Default for CreateCommand {
             no_status_endpoint: false,
             status_endpoint_port: None,
             udp: false,
-            launch_configuration: None,
+            services: None,
             identity: None,
             trust_opts: node_manager_defaults.trust_opts,
             opentelemetry_context: None,
@@ -375,14 +375,14 @@ impl CreateCommand {
     }
 }
 
-fn parse_launch_config(config_or_path: &str) -> Result<Config> {
-    match serde_json::from_str::<Config>(config_or_path) {
+fn parse_launch_config(config_or_path: &str) -> Result<ServicesConfig> {
+    match serde_json::from_str::<ServicesConfig>(config_or_path) {
         Ok(c) => Ok(c),
         Err(_) => {
             let path = PathBuf::from_str(config_or_path)
                 .into_diagnostic()
                 .wrap_err(format!("Invalid path {config_or_path}"))?;
-            Config::read(path)
+            ServicesConfig::from_file(path)
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/create/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/config.rs
@@ -210,12 +210,8 @@ impl NodeConfig {
         if let Some(project) = &cmd.trust_opts.project_name {
             self.node.project = Some(project.clone().into());
         }
-        if let Some(launch_config) = &cmd.launch_configuration {
-            self.node.launch_config = Some(
-                serde_json::to_string(launch_config)
-                    .into_diagnostic()?
-                    .into(),
-            );
+        if let Some(services) = &cmd.services {
+            self.node.services = Some(Services::from_arg(services)?);
         }
         if let Some(context) = &cmd.opentelemetry_context {
             self.node.opentelemetry_context =
@@ -421,8 +417,8 @@ mod tests {
         assert_eq!(res.project_enroll.ticket, Some(ticket_encoded));
     }
 
-    #[test]
-    fn parse_demo_config_files() {
+    #[tokio::test]
+    async fn parse_demo_config_files() {
         let demo_files_dir = std::env::current_dir()
             .unwrap()
             .join("src")
@@ -434,8 +430,44 @@ mod tests {
             let file = file.unwrap();
             let path = file.path();
             let contents = std::fs::read_to_string(&path).unwrap();
-            let res = NodeConfig::parse(contents);
-            res.unwrap();
+
+            let mut config1 = NodeConfig::parse(contents.clone()).unwrap();
+
+            let cmd = CreateCommand {
+                name: contents,
+                ..Default::default()
+            };
+            let config2 = cmd.parse_node_config().await.unwrap();
+            assert_eq!(config1, config2);
+
+            config1.merge(&cmd).unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn parse_err_demo_config_files() {
+        let demo_files_dir = std::env::current_dir()
+            .unwrap()
+            .join("src")
+            .join("node")
+            .join("create")
+            .join("err_demo_config_files");
+        let files = std::fs::read_dir(demo_files_dir).unwrap();
+        for file in files {
+            let file = file.unwrap();
+            let path = file.path();
+            let file_name = path.file_name().unwrap().to_str().unwrap();
+            let contents = std::fs::read_to_string(&path).unwrap();
+
+            let res = NodeConfig::parse(contents.clone());
+            assert!(res.is_err(), "{file_name} should fail to be parsed");
+
+            let cmd = CreateCommand {
+                name: contents,
+                ..Default::default()
+            };
+            let res = cmd.parse_node_config().await;
+            assert!(res.is_err(), "{file_name} should fail to be parsed");
         }
     }
 

--- a/implementations/rust/ockam/ockam_command/src/node/create/demo_config_files/1.portal.single-machine.json
+++ b/implementations/rust/ockam/ockam_command/src/node/create/demo_config_files/1.portal.single-machine.json
@@ -1,0 +1,15 @@
+{
+  "name": "n1",
+  "tcp-listener-address": "127.0.0.1:1234",
+  "relay": "default",
+  "tcp-outlet": {
+    "db-outlet": {
+      "to": 1235
+    }
+  },
+  "tcp-inlet": {
+    "web-inlet": {
+      "from": 1236
+    }
+  }
+}

--- a/implementations/rust/ockam/ockam_command/src/node/create/demo_config_files/3.node.services.yaml
+++ b/implementations/rust/ockam/ockam_command/src/node/create/demo_config_files/3.node.services.yaml
@@ -1,0 +1,7 @@
+name: n1
+tcp-listener-address: 127.0.0.1:3333
+services:
+  control-api:
+    authentication-token: token
+    backend: true
+    node-resolution: direct-connection

--- a/implementations/rust/ockam/ockam_command/src/node/create/err_demo_config_files/1.missing-colon.json
+++ b/implementations/rust/ockam/ockam_command/src/node/create/err_demo_config_files/1.missing-colon.json
@@ -1,0 +1,12 @@
+{
+  "name": "n1",
+  "tcp-listener-address": "127.0.0.1:3333",
+  "start_default_services" true,
+  "services": {
+    "control_api": {
+      "authentication_token": "token",
+      "backend": true,
+      "node_resolution": "direct-connection"
+    }
+  }
+}

--- a/implementations/rust/ockam/ockam_command/src/node/create/err_demo_config_files/1.missing-colon.yaml
+++ b/implementations/rust/ockam/ockam_command/src/node/create/err_demo_config_files/1.missing-colon.yaml
@@ -1,0 +1,8 @@
+name: n1
+tcp-listener-address: 127.0.0.1:3333
+start_default_services: true
+services:
+  control_api:
+    authentication_token token
+    backend: true
+    node_resolution: direct-connection

--- a/implementations/rust/ockam/ockam_command/src/node/create/err_demo_config_files/2.missing-comma.json
+++ b/implementations/rust/ockam/ockam_command/src/node/create/err_demo_config_files/2.missing-comma.json
@@ -1,0 +1,12 @@
+{
+  "name": "n1",
+  "tcp-listener-address": "127.0.0.1:3333",
+  "start_default_services": true
+  "services": {
+    "control_api": {
+      "authentication_token": "token",
+      "backend": true,
+      "node_resolution": "direct-connection"
+    }
+  }
+}

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -94,7 +94,7 @@ impl CreateCommand {
             NodeManagerGeneralOptions::new(
                 opts.state.clone(),
                 node_name.clone(),
-                self.launch_configuration
+                self.services
                     .as_ref()
                     .map(|c| c.start_default_services)
                     .unwrap_or(true),
@@ -200,8 +200,8 @@ impl CreateCommand {
         node_manager: Arc<NodeManager>,
         opts: &CommandGlobalOpts,
     ) -> miette::Result<()> {
-        if let Some(config) = &self.launch_configuration {
-            if let Some(startup_services) = &config.startup_services {
+        if let Some(config) = &self.services {
+            if let Some(startup_services) = &config.services {
                 if let Some(cfg) = startup_services.secure_channel_listener.as_ref() {
                     if !cfg.disabled {
                         opts.terminal
@@ -218,9 +218,9 @@ impl CreateCommand {
                     }
                 }
 
-                if let Some(configuration) = &startup_services.control_api {
-                    if configuration.frontend {
-                        let authentication_token = match &configuration.authentication_token {
+                if let Some(config) = &startup_services.control_api {
+                    if config.frontend {
+                        let authentication_token = match &config.authentication_token {
                             Some(token) => token.clone(),
                             None => std::env::var("OCKAM_CONTROL_API_AUTHENTICATION_TOKEN")
                                 .map_err(|_| {
@@ -232,12 +232,12 @@ impl CreateCommand {
                         opts.terminal
                             .write_line(fmt_log!("Starting control API Frontend..."))?;
 
-                        let node_resolution = match &configuration.node_resolution {
+                        let node_resolution = match &config.node_resolution {
                             ControlApiNodeResolution::Relay => NodeResolution::Relay,
                             ControlApiNodeResolution::DirectConnection => {
                                 NodeResolution::DirectConnection {
-                                    pattern: configuration.node_resolution_pattern.clone(),
-                                    port: configuration.connection_node_port,
+                                    pattern: config.node_resolution_pattern.clone(),
+                                    port: config.connection_node_port,
                                 }
                             }
                         };
@@ -245,22 +245,20 @@ impl CreateCommand {
                         node_manager
                             .create_control_api_frontend(
                                 ctx,
-                                configuration.http_bind_address,
+                                config.http_bind_address,
                                 node_resolution,
                                 authentication_token,
-                                Some(configuration.frontend_policy.clone()),
+                                Some(config.frontend_policy.clone()),
                             )
                             .await?;
                     }
 
-                    if configuration.backend {
+                    if config.backend {
                         opts.terminal
                             .write_line(fmt_log!("Starting control API Backend..."))?;
 
-                        node_manager.create_control_api_backend(
-                            ctx,
-                            Some(configuration.backend_policy.clone()),
-                        )?;
+                        node_manager
+                            .create_control_api_backend(ctx, Some(config.backend_policy.clone()))?;
                     }
                 }
             }

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -69,7 +69,7 @@ pub fn spawn_node(opts: &CommandGlobalOpts, cmd: CreateCommand) -> miette::Resul
         no_status_endpoint,
         status_endpoint_port,
         udp,
-        launch_configuration,
+        services,
         identity,
         trust_opts,
         opentelemetry_context,
@@ -148,8 +148,8 @@ pub fn spawn_node(opts: &CommandGlobalOpts, cmd: CreateCommand) -> miette::Resul
         args.push("--udp".to_string());
     }
 
-    if let Some(config) = launch_configuration {
-        args.push("--launch-config".to_string());
+    if let Some(config) = services {
+        args.push("--services".to_string());
         args.push(serde_json::to_string(&config).unwrap());
     }
 

--- a/implementations/rust/ockam/ockam_command/src/run/parser/building_blocks.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/building_blocks.rs
@@ -31,7 +31,7 @@ pub trait ArgsToCommands: Sized {
     }
 
     /// Similar to [`into_commands`](Self::into_commands), but passing the name of the argument
-    /// in the configuration file that will be used as the name of the resource in relative the command.
+    /// in the configuration file that will be used as the name of the resource in the relative the command.
     fn into_commands_with_name_arg<C, F>(
         self,
         _get_subcommand: F,

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/mod.rs
@@ -3,7 +3,7 @@ pub use influxdb_inlets::InfluxDBInlets;
 pub use influxdb_outlets::InfluxDBOutlets;
 pub use kafka_inlet::KafkaInlet;
 pub use kafka_outlet::KafkaOutlet;
-pub use node::Node;
+pub use node::{Node, Services};
 pub use nodes::Nodes;
 pub use policies::Policies;
 pub use project_enroll::ProjectEnroll;

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
@@ -1,14 +1,15 @@
 use std::collections::BTreeMap;
 
-use miette::{miette, Result};
+use miette::{miette, IntoDiagnostic, Result};
 use ockam_api::colors::color_primary;
 use serde::{Deserialize, Serialize};
 
 use crate::node::CreateCommand;
-use crate::run::parser::building_blocks::{as_command_args, ArgKey, ArgValue};
+use crate::run::parser::building_blocks::{as_command_args, ArgKey, ArgValue, NamedResources};
 
 use crate::run::parser::resource::utils::parse_cmd_from_args;
 use crate::run::parser::resource::Resource;
+use crate::service::config::ServicesConfig;
 use crate::{node, Command, OckamSubcommand};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -31,8 +32,8 @@ pub struct Node {
     pub status_endpoint_port: Option<ArgValue>,
     pub identity: Option<ArgValue>,
     pub project: Option<ArgValue>,
-    #[serde(alias = "launch-config")]
-    pub launch_config: Option<ArgValue>,
+    #[serde(flatten, alias = "launch-config")]
+    pub services: Option<Services>,
     #[serde(alias = "opentelemetry-context")]
     pub opentelemetry_context: Option<ArgValue>,
     pub udp: Option<ArgValue>,
@@ -81,8 +82,12 @@ impl Resource<CreateCommand> for Node {
         if let Some(project) = self.project {
             args.insert("project".into(), project);
         }
-        if let Some(launch_config) = self.launch_config {
-            args.insert("launch-config".into(), launch_config);
+        if let Some(services) = self.services {
+            if let Ok(services) = services.into_arg() {
+                if let Ok(services) = serde_json::to_string(&services) {
+                    args.insert("services".into(), services.into());
+                }
+            }
         }
         if let Some(opentelemetry_context) = self.opentelemetry_context {
             args.insert("opentelemetry-context".into(), opentelemetry_context);
@@ -155,9 +160,44 @@ impl Node {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct Services {
+    #[serde(alias = "start-default-services")]
+    pub start_default_services: Option<ArgValue>,
+    pub services: Option<NamedResources>,
+}
+
+impl Services {
+    /// Parse the services fields into a `ServicesConfig` struct
+    pub fn into_arg(self) -> Result<ServicesConfig> {
+        let mut as_json = serde_json::json!({
+            "services": self.services,
+        });
+        if let Some(start_default_services) = self.start_default_services {
+            as_json["start-default-services"] = serde_json::json!(start_default_services);
+        }
+        serde_json::from_value(as_json).into_diagnostic()
+    }
+
+    pub fn from_arg(arg: &ServicesConfig) -> Result<Self> {
+        Self::from_string(&arg.to_string()?)
+    }
+
+    fn from_string(contents: &str) -> Result<Self> {
+        if let Ok(c) = serde_yaml::from_str(contents) {
+            return Ok(c);
+        }
+        if let Ok(c) = serde_json::from_str(contents) {
+            return Ok(c);
+        }
+        Err(miette!(format!("invalid services config {:?}", contents)))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::config::ControlApiNodeResolution;
 
     #[test]
     fn node_config() {
@@ -177,25 +217,111 @@ mod tests {
 
         // Multiple arguments
         let config = r#"
-            name: n1
-            tcp-listener-address: 127.0.0.1:1234
-            skip-is-running-check: true
+        name: n1
+        tcp-listener-address: 127.0.0.1:1234
+        skip-is-running-check: true
+        "#;
+        test(config);
+
+        // Services
+        let config = r#"
+        name: n1
+        tcp-listener-address: 127.0.0.1:3333
+        start_default_services: true
+        services:
+          startup_services:
+            control_api:
+              authentication_token: token
+              backend: true
+              node_resolution: direct-connection
         "#;
         test(config);
 
         // With other sections
         let config = r#"
-            relays: r1
+        relays: r1
 
-            name: n1
-            tcp-listener-address: 127.0.0.1:1234
-            skip-is-running-check: true
+        name: n1
+        tcp-listener-address: 127.0.0.1:1234
+        skip-is-running-check: true
 
-            tcp_inlets:
-              ti1:
-                from: 6060
-                at: n
+        tcp_inlets:
+          ti1:
+            from: 6060
+            at: n
         "#;
         test(config);
+    }
+
+    #[test]
+    fn services_config() {
+        let test = |c: &str| {
+            // Convert yaml yo struct representation
+            let parsed: Services = serde_yaml::from_str(c).unwrap();
+            // Convert yaml struct to command argument representation
+            let arg = parsed.clone().into_arg().unwrap();
+            // Convert command argument representation back to yaml struct representation
+            let parsed_again = Services::from_arg(&arg).unwrap();
+            // Convert yaml struct representation back to command argument representation to compare
+            let arg_again = parsed_again.clone().into_arg().unwrap();
+            // We compare the `ServicesConfig` struct as it's easier to compare basic types (bools, strings, etc)
+            // than comparing the `Services` struct which has a `NamedResources` field and the types can be dynamic
+            assert_eq!(arg, arg_again);
+        };
+
+        // Start default services
+        let config = r#"
+        start-default-services: true
+        "#;
+        test(config);
+
+        // Single service
+        let config = r#"
+        services:
+          secure-channel-listener:
+            address: api
+        "#;
+        test(config);
+
+        let config = r#"
+        services:
+          control-api:
+            authentication-token: token
+            backend: true
+            node-resolution: direct-connection
+        "#;
+        test(config);
+
+        // Multiple services
+        let config = r#"
+        start-default-services: true
+        services:
+          secure-channel-listener:
+            address: api
+            disabled: true
+          control-api:
+            authentication-token: token
+            backend: true
+            node-resolution: direct-connection
+        "#;
+        test(config);
+
+        // Check values
+        let parsed: Services = serde_yaml::from_str(config).unwrap();
+        let arg = parsed.clone().into_arg().unwrap();
+        assert!(arg.start_default_services);
+
+        let services = arg.services.unwrap();
+        let secure_channel_listener = services.secure_channel_listener.unwrap();
+        assert_eq!(secure_channel_listener.address, "api");
+        assert!(secure_channel_listener.disabled);
+
+        let control_api = services.control_api.unwrap();
+        assert_eq!(control_api.authentication_token.unwrap(), "token");
+        assert!(control_api.backend);
+        assert_eq!(
+            control_api.node_resolution,
+            ControlApiNodeResolution::DirectConnection
+        );
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/service/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/config.rs
@@ -1,4 +1,4 @@
-use miette::{Context as _, IntoDiagnostic};
+use miette::{miette, Context as _, IntoDiagnostic};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::path::Path;
@@ -10,43 +10,72 @@ use ockam_abac::PolicyExpression::BooleanExpression;
 use ockam_abac::{BooleanExpr, PolicyExpression};
 use ockam_api::nodes::service::default_address::DefaultAddress;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct Config {
-    #[serde(default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct ServicesConfig {
+    #[serde(alias = "start-default-services")]
     pub(crate) start_default_services: bool,
-    pub(crate) startup_services: Option<ServiceConfigs>,
+    #[serde(
+        alias = "startup_services",
+        alias = "startup-services",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub(crate) services: Option<ServiceConfigs>,
 }
 
-impl Config {
-    pub(crate) fn read<P: AsRef<Path>>(path: P) -> Result<Self> {
+impl ServicesConfig {
+    pub(crate) fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let s = std::fs::read_to_string(path.as_ref())
             .into_diagnostic()
-            .context(format!("failed to read {:?}", path.as_ref()))?;
-        let c = serde_json::from_str(&s)
-            .into_diagnostic()
-            .context(format!("invalid config {:?}", path.as_ref()))?;
-        Ok(c)
+            .context(format!(
+                "failed to read services config from {:?}",
+                path.as_ref()
+            ))?;
+        Self::from_string(&s)
+    }
+
+    pub(crate) fn from_string(contents: &str) -> Result<Self> {
+        if let Ok(c) = serde_yaml::from_str(contents) {
+            return Ok(c);
+        }
+        if let Ok(c) = serde_json::from_str(contents) {
+            return Ok(c);
+        }
+        Err(miette!(format!("invalid config {:?}", contents)))
+    }
+
+    pub(crate) fn to_string(&self) -> Result<String> {
+        serde_json::to_string(&self).into_diagnostic()
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(default)]
 pub struct ServiceConfigs {
+    #[serde(
+        alias = "secure-channel-listener",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub(crate) secure_channel_listener: Option<SecureChannelListenerConfig>,
+    #[serde(alias = "control-api", skip_serializing_if = "Option::is_none")]
     pub(crate) control_api: Option<ControlApiConfig>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(default)]
 pub struct SecureChannelListenerConfig {
-    #[serde(default = "sec_listener_default_addr")]
+    #[serde(default = "default_secure_listener_address")]
     pub(crate) address: String,
 
-    #[serde(default)]
+    #[serde(
+        alias = "authorized-identifiers",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub(crate) authorized_identifiers: Option<Vec<Identifier>>,
 
-    #[serde(default)]
     pub(crate) disabled: bool,
 
-    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) identity: Option<String>,
 }
 
@@ -86,35 +115,48 @@ pub struct ControlApiConfig {
     #[serde(default)]
     pub(crate) backend: bool,
 
-    #[serde(default = "default_frontend_policy")]
+    #[serde(alias = "frontend-policy", default = "default_frontend_policy")]
     pub(crate) frontend_policy: PolicyExpression,
 
-    #[serde(default = "default_backend_policy")]
+    #[serde(alias = "backend_policy", default = "default_backend_policy")]
     pub(crate) backend_policy: PolicyExpression,
 
     /// How to reach nodes.
-    #[serde(default)]
+    #[serde(alias = "node-resolution", default)]
     pub(crate) node_resolution: ControlApiNodeResolution,
 
-    #[serde(default = "default_control_api_bind_address")]
+    #[serde(
+        alias = "http-bind-address",
+        default = "default_control_api_bind_address"
+    )]
     pub(crate) http_bind_address: SocketAddr,
 
     /// Port to use when connecting to nodes.
-    #[serde(default = "default_connection_node_port")]
+    #[serde(
+        alias = "connection-node-port",
+        default = "default_connection_node_port"
+    )]
     pub(crate) connection_node_port: u16,
 
     /// Pattern to use when connecting to nodes.
     /// {name} will be replaced with the node name.
     /// When `name` is "node1", and the pattern is "my-{name}.example.com", the resulting address
     /// will be "my-node1.example.com".
-    #[serde(default = "default_node_resolution_pattern")]
+    #[serde(
+        alias = "node-resolution-pattern",
+        default = "default_node_resolution_pattern"
+    )]
     pub(crate) node_resolution_pattern: String,
 
     /// Authentication token for the control API.
     /// When undefined, the environment variable `OCKAM_CONTROL_API_AUTHENTICATION_TOKEN` will be used.
+    #[serde(
+        alias = "authentication-token",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub(crate) authentication_token: Option<String>,
 }
 
-fn sec_listener_default_addr() -> String {
+fn default_secure_listener_address() -> String {
     DefaultAddress::SECURE_CHANNEL_LISTENER.to_string()
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
@@ -264,3 +264,19 @@ EOF
   # stop the node
   run_success kill -9 $pid
 }
+
+@test "node - create with invalid configuration" {
+  # Note that passing an invalid inline yaml configuration will not fail when not using strict json syntax.
+  # This is inherent to the yaml parser used by the command, not the command logic itself.
+  # For example, a configuration like "{name: n, tcp-listener-address 127.0.0.1:3333}" will parse the "name"
+  # field correctly, but will ignore the fact that it couldn't parse the "tcp-listener-address" field.
+  run_failure "$OCKAM" node create --configuration "{\"name\": \"n\", \"tcp-listener-address\" \"127.0.0.1:3333\"}"
+  run_failure "$OCKAM" node create "{\"name\": \"n\", \"tcp-listener-address\" \"127.0.0.1:3333\"}"
+  run_failure "$OCKAM" node create "{\"name\": \"n\" \"tcp-listener-address\": \"127.0.0.1:3333\"}"
+
+  cat <<EOF >"$OCKAM_HOME/node.yaml"
+name: n1
+tcp-listener-address 127.0.0.1:3333
+EOF
+  run_failure "$OCKAM" node create "$OCKAM_HOME/node.yaml"
+}

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/README.md
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/README.md
@@ -1,2 +1,3 @@
-This suite includes tests to exercise the functionalities of the orchestrator. Tests that only require the orchestrator
-to generate enrollment tickets and enroll identities are in the `orchestrator_enroll` suite.
+This suite includes tests to exercise the functionalities of the orchestrator.
+
+Tests that only require the orchestrator to generate enrollment tickets and enroll identities are in the `orchestrator_enroll` suite.

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/node_control_api.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/node_control_api.bats
@@ -24,21 +24,27 @@ teardown() {
   setup_home_dir
   run_success "$OCKAM" project enroll "${ticket}"
 
-  run_success "$OCKAM" node create \
-    --tcp-listener-address "127.0.0.1:${frontend_node_port}" \
-    --launch-configuration \
-    "{\"start_default_services\": true, \"startup_services\":{ \
-      \"control_api\":{\"authentication_token\": \"token\", \"backend\":true, \"frontend\":true, \"http_bind_address\":\"127.0.0.1:${api_port}\", \
-      \"node_resolution\":\"relay\" \
-    }}}"
+  run_success "$OCKAM" node create "{\
+  tcp-listener-address: \"127.0.0.1:${frontend_node_port}\",
+  start-default-services: true,
+  services: {
+    control-api: {
+      authentication-token: token,
+      backend: true,
+      frontend: true,
+      http-bind-address: \"127.0.0.1:${api_port}\",
+      node-resolution: relay
+  }}}"
   wait_for_port $api_port
 
   # create a node with a relay in the api node
-  run_success "$OCKAM" node create red \
-    --launch-configuration \
-    "{\"start_default_services\": true, \"startup_services\":{ \
-      \"control_api\":{ \"backend\":true,\"node_resolution\":\"direct-connection\" \
-    }}}"
+  run_success "$OCKAM" node create red --configuration "{\
+  start-default-services: true,
+  services: {
+    control-api: {
+      backend: true,
+      node-resolution: direct-connection
+  }}}"
   run_success "$OCKAM" relay create --to red --at "/ip4/127.0.0.1/tcp/${frontend_node_port}/secure/api" red
 
   # verify that it can be accessed via control node api


### PR DESCRIPTION
Adds support to pass the `launch-configuration` (now renamed to `services`) as part of the node configuration:

```bash
ockam node create '{
  name: n1,
  tcp-listener-address: "127.0.0.1:14001",
  start-default-services: true,
  services: {
    control-api: {
      authentication-token: token,
      backend: true,
      frontend: true,
      http-bind-address: "127.0.0.1:14002",
      node-resolution: relay
  }}}'
```