### PR TITLE
fix(rust): protect the start of a grpc forwarder against an incorrect configuration

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
@@ -325,14 +325,30 @@ impl Authority {
                 .add_consumer(&address.into(), secure_channel_flow_control_id);
 
             let url = telemetry_endpoint_url.to_string();
-            let uri = url
+            if let Ok(uri) = url
                 .parse::<Uri>()
-                .map_err(|e| Error::new(Origin::Ockam, Kind::Invalid, e))?;
-            debug!("start a grpc forwarder at '{uri}'");
-            ctx.start_worker(
-                address,
-                GrpcForwarder::new(uri).await.map_err(ApiError::core)?,
-            )?
+                .map_err(|e| Error::new(Origin::Ockam, Kind::Invalid, e))
+            {
+                debug!("Start a grpc forwarder at '{uri}'");
+                match GrpcForwarder::new(uri.clone())
+                    .await
+                    .map_err(ApiError::core)
+                {
+                    Ok(grpc_forwarder) => match ctx.start_worker(address, grpc_forwarder) {
+                        Ok(_) => {
+                            debug!("Started a grpc forwarder at '{uri}'");
+                        }
+                        Err(e) => {
+                            error!("Cannot start the grpc forwarder at '{uri}': {e:?}")
+                        }
+                    },
+                    Err(e) => {
+                        error!("Cannot start the grpc forwarder: {e:?}")
+                    }
+                }
+            } else {
+                error!("Cannot start the grpc forwarder, can't parse the opentelemetry endpoint: {url}")
+            }
         };
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_api/src/logs/grpc_forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/grpc_forwarder.rs
@@ -6,6 +6,7 @@ use ockam_core::errcode::{Kind, Origin};
 use ockam_core::{async_trait, Routed, Worker};
 use ockam_node::Context;
 use std::future;
+use std::time::Duration;
 use tonic::body::BoxBody;
 use tonic::client::GrpcService;
 use tonic::transport::Channel;
@@ -28,6 +29,7 @@ impl GrpcForwarder {
                     "cannot create a TLS config for the HttpForwarder channel at {uri:?}: {e:?}"
                 ))
             })?
+            .connect_timeout(Duration::from_secs(5))
             .connect()
             .await
             .map_err(|e| ApiError::message(format!("cannot connect to {uri:?}: {e:?}")))?;


### PR DESCRIPTION
That service is not essential to the start of an authority node, so an incorrect configuration should just be logged.
I tested this by starting the authority node locality with an inaccessible URL.