### PR TITLE
fix(rust): in `node create`, detach background process

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -208,22 +208,14 @@ pub fn run_ockam(args: Vec<String>, quiet: bool) -> miette::Result<Child> {
             .into()
     });
 
-    unsafe {
-        TokioCommand::new(ockam_exe)
-            .args(args)
-            .stdout(subprocess_stdio(quiet))
-            .stderr(subprocess_stdio(quiet))
-            .stdin(Stdio::null())
-            // This unsafe block will only panic if the closure panics, which shouldn't happen
-            .pre_exec(|| {
-                // Detach the process from the parent
-                nix::unistd::setsid().map_err(std::io::Error::from)?;
-                Ok(())
-            })
-            .spawn()
-            .into_diagnostic()
-            .context("failed to spawn node")
-    }
+    TokioCommand::new(ockam_exe)
+        .args(args)
+        .stdout(subprocess_stdio(quiet))
+        .stderr(subprocess_stdio(quiet))
+        .stdin(Stdio::null())
+        .spawn()
+        .into_diagnostic()
+        .context("failed to spawn node")
 }
 
 fn subprocess_stdio(quiet: bool) -> Stdio {

--- a/implementations/rust/ockam/ockam_command/src/util/foreground_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/foreground_args.rs
@@ -31,6 +31,16 @@ pub async fn wait_for_exit_signal(
 ) -> miette::Result<()> {
     let (tx, mut rx) = tokio::sync::mpsc::channel(2);
 
+    // When running a background node, at this point we don't expect any further output to be written to the
+    // parent process, so we close stdin, stdout, and stderr to fully detach the child process.
+    // This avoids blocking issues in the parent process when the command is run in environments where the
+    // terminal session remains open until all subprocesses exit (e.g. through ssh).
+    if args.child_process {
+        let _ = nix::unistd::close(0).map_err(std::io::Error::from); // stdin
+        let _ = nix::unistd::close(1).map_err(std::io::Error::from); // stdout
+        let _ = nix::unistd::close(2).map_err(std::io::Error::from); // stderr
+    }
+
     // Register a handler for SIGINT, SIGTERM, SIGHUP
     {
         let tx = tx.clone();
@@ -71,7 +81,7 @@ pub async fn wait_for_exit_signal(
 
     debug!("waiting for exit signal");
 
-    if !args.child_process && opts.terminal.is_tty() {
+    if opts.terminal.is_tty() {
         opts.terminal.write_line("")?;
         opts.terminal.write(fmt_log!("{}", msg))?;
     }


### PR DESCRIPTION
Prevents blocking issues in the parent process when the `ockam node create` is run in environments where the terminal session remains open until all subprocesses exit (e.g. through ssh).