### PR TITLE
handle spaces in file names when finding markdown files

### DIFF
--- a/tools/docs/update_md.sh
+++ b/tools/docs/update_md.sh
@@ -18,9 +18,9 @@ cargo -q install --path .
 popd &>/dev/null || exit
 
 # Look for md files from this directory
-for FILE_NAME in $(find "$DOCS_HOME" -type f -name "*.md"); do
+while IFS= read -r FILE_NAME; do
   echo "==> $FILE_NAME"
   TMP=$(mktemp)
   EXAMPLES_DIR="$OCKAM_HOME/examples/rust/get_started" example_blocks "$FILE_NAME" >"$TMP"
   cat "$TMP" >"$FILE_NAME"
-done
+done < <(find "$DOCS_HOME" -type f -name "*.md")


### PR DESCRIPTION
handle spaces in file names when finding markdown files. Fixes https://github.com/build-trust/ockam-documentation/actions/runs/13640215897/job/38129061293