### PR TITLE
feat(rust): polishing node control api

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -572,6 +572,43 @@ impl NodeInfo {
         self.tcp_listener_address.clone()
     }
 
+    /// Extract a connection address given the tcp listener address.
+    /// A binding address can coincide with the connection address, but not
+    /// in case the tcp listener binds to a specific network range.
+    /// Since extracting the right IP address to use in these cases is error-prone, we
+    /// just handle the unspecified bind `0.0.0.0` IP here.
+    pub fn tcp_connect_address(&self) -> Option<InternetAddress> {
+        if let Some(tcp_listener_address) = &self.tcp_listener_address {
+            match tcp_listener_address {
+                InternetAddress::Dns(_, _) => self.tcp_listener_address.clone(),
+                InternetAddress::V4(address) => {
+                    if address.ip().is_unspecified() {
+                        Some(InternetAddress::V4(std::net::SocketAddrV4::new(
+                            std::net::Ipv4Addr::LOCALHOST,
+                            address.port(),
+                        )))
+                    } else {
+                        self.tcp_listener_address.clone()
+                    }
+                }
+                InternetAddress::V6(address) => {
+                    if address.ip().is_unspecified() {
+                        Some(InternetAddress::V6(std::net::SocketAddrV6::new(
+                            std::net::Ipv6Addr::LOCALHOST,
+                            address.port(),
+                            address.flowinfo(),
+                            address.scope_id(),
+                        )))
+                    } else {
+                        self.tcp_listener_address.clone()
+                    }
+                }
+            }
+        } else {
+            None
+        }
+    }
+
     pub fn tcp_listener_multi_address(&self) -> Result<MultiAddr> {
         Ok(self
             .tcp_listener_address

--- a/implementations/rust/ockam/ockam_api/src/control_api/backend/entrypoint.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/backend/entrypoint.rs
@@ -103,10 +103,10 @@ impl Worker for HttpControlNodeApiBackend {
                 self.handle_relay(context, method, resource_id, request.body)
                     .await
             }
-            Some(ResourceKind::Tickets) => Ok(self
-                .handle_ticket(context, method, resource_id, request.body)
-                .await
-                .unwrap()),
+            Some(ResourceKind::Tickets) => {
+                self.handle_ticket(context, method, resource_id, request.body)
+                    .await
+            }
             Some(ResourceKind::AuthorityMembers) => {
                 self.handle_authority_member(context, method, resource_id, request.body)
                     .await

--- a/implementations/rust/ockam/ockam_api/src/control_api/backend/ticket.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/backend/ticket.rs
@@ -137,25 +137,52 @@ async fn create_encoded_ticket(
     let authority_change_history;
     let authority_route;
 
+    let overridden_project_route;
+    let overridden_authority_route;
+
     let project = match &project_information {
-        Project::Existing { name: Some(name) } => Some(
-            node_manager
-                .cli_state
-                .projects()
-                .get_project_by_name(name)
-                .await?,
-        ),
-        Project::Existing { name: None } => Some(
-            node_manager
-                .cli_state
-                .projects()
-                .get_default_project()
-                .await?,
-        ),
-        _ => None,
+        Project::Existing {
+            name: Some(name),
+            project_route,
+            authority_route,
+        } => {
+            overridden_project_route = project_route;
+            overridden_authority_route = authority_route;
+            Some(
+                node_manager
+                    .cli_state
+                    .projects()
+                    .get_project_by_name(name)
+                    .await?,
+            )
+        }
+        Project::Existing {
+            name: None,
+            project_route,
+            authority_route,
+        } => {
+            overridden_project_route = project_route;
+            overridden_authority_route = authority_route;
+            Some(
+                node_manager
+                    .cli_state
+                    .projects()
+                    .get_default_project()
+                    .await?,
+            )
+        }
+        _ => {
+            overridden_project_route = &None;
+            overridden_authority_route = &None;
+            None
+        }
     };
     if let Some(project) = project {
-        project_route = ProjectRoute::new(project.project_multiaddr().cloned()?)?;
+        project_route = if let Some(project_route) = overridden_project_route {
+            ProjectRoute::new(project_route.parse()?)?
+        } else {
+            ProjectRoute::new(project.project_multiaddr().cloned()?)?
+        };
         project_identifier = if let Some(identifier) = project.project_identifier() {
             identifier
         } else {
@@ -184,7 +211,11 @@ async fn create_encoded_ticket(
                 "Project has no authority identity",
             ));
         };
-        authority_route = project.authority_multiaddr().cloned()?;
+        authority_route = if let Some(authority_route) = overridden_authority_route {
+            authority_route.parse()?
+        } else {
+            project.authority_multiaddr().cloned()?
+        };
     } else if let Project::Provided {
         project_name: provided_project_name,
         authority_route: provided_authority_route,
@@ -223,17 +254,13 @@ async fn create_encoded_ticket(
     post,
     operation_id = "project_enroll",
     summary = "Enroll to a Project using a Ticket",
-    description =
-"This API enrolls a node to a Project using the provided Ticket.
-Note that this API imports the Project in the node database, but the node won't be able to use
-it until it restarts.
-The easiest way to use a ticket is to specify the ticket directly during the node creation.",
+    description = "This API enrolls a node to a Project using the provided Ticket.",
     path = "/{node}/tickets/enroll",
     tags = ["Tickets"],
     responses(
-        (status = CREATED, description = "Successfully enrolled, new credential can be used right away", body = AuthorityInformation),
+        (status = CREATED, description = "Successfully enrolled", body = AuthorityInformation),
         (status = OK, description = "The node was already enrolled, no change in state", body = AuthorityInformation),
-        (status = ACCEPTED, description = "Enrolled, but the node needs a restart", body = AuthorityInformation),
+        (status = ACCEPTED, description = "Enrolled, but the project's authority does not match the node's authority.", body = AuthorityInformation),
     ),
     params(
         ("node" = NodeName,),
@@ -311,13 +338,13 @@ async fn handle_ticket_enroll(
     match result {
         Ok(status) => match status {
             EnrollStatus::EnrolledSuccessfully => {
-                let needs_restart =
+                let different_authority =
                     if let Some(current_authority) = node_manager.project_authority() {
                         current_authority != authority_identifier
                     } else {
                         true
                     };
-                if needs_restart {
+                if different_authority {
                     // enrolled, but the authority is not being used
                     Ok(ControlApiHttpResponse::with_body(
                         StatusCode::ACCEPTED,

--- a/implementations/rust/ockam/ockam_api/src/control_api/frontend.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/frontend.rs
@@ -13,6 +13,7 @@ use ockam_core::{
     async_trait, cbor_encode_preallocate, AllowAll, Error, IncomingAccessControl, NeutralMessage,
     OutgoingAccessControl, Processor, Routed, TryClone,
 };
+use ockam_multiaddr::MultiAddr;
 use ockam_node::{Context, MessageSendReceiveOptions};
 use ockam_transport_core::TransportError;
 use std::net::SocketAddr;
@@ -218,9 +219,9 @@ impl HttpControlNodeApiFrontend {
             format!("/secure/api/service/{}", DefaultAddress::CONTROL_API)
         } else {
             match &node_resolution {
-                NodeResolution::Relay => {
+                NodeResolution::Relay { relay_node } => {
                     format!(
-                        "/service/forward_to_{node_name}/secure/api/service/{}",
+                        "{relay_node}/service/forward_to_{node_name}/secure/api/service/{}",
                         DefaultAddress::CONTROL_API
                     )
                 }
@@ -373,7 +374,7 @@ impl HttpControlNodeApiFrontend {
 
 #[derive(Clone)]
 pub enum NodeResolution {
-    Relay,
+    Relay { relay_node: MultiAddr },
     DirectConnection { pattern: String, port: u16 },
 }
 
@@ -436,6 +437,7 @@ mod test {
     use http::{Request, Response};
     use http_body_util::{BodyExt, Full};
     use hyper_util::rt::TokioIo;
+    use ockam_multiaddr::MultiAddr;
     use ockam_node::Context;
     use serde::de::DeserializeOwned;
     use serde::Serialize;
@@ -482,7 +484,9 @@ mod test {
             .create_control_api_frontend(
                 context,
                 SocketAddr::from(([127, 0, 0, 1], 0)),
-                NodeResolution::Relay,
+                NodeResolution::Relay {
+                    relay_node: MultiAddr::default(),
+                },
                 "token".to_str(),
                 None,
             )
@@ -552,7 +556,9 @@ mod test {
             .create_control_api_frontend(
                 context,
                 SocketAddr::from(([127, 0, 0, 1], 0)),
-                NodeResolution::Relay,
+                NodeResolution::Relay {
+                    relay_node: MultiAddr::default(),
+                },
                 "token".to_str(),
                 None,
             )
@@ -588,7 +594,9 @@ mod test {
             .create_control_api_frontend(
                 context,
                 SocketAddr::from(([127, 0, 0, 1], 0)),
-                NodeResolution::Relay,
+                NodeResolution::Relay {
+                    relay_node: MultiAddr::default(),
+                },
                 "token".to_str(),
                 None,
             )

--- a/implementations/rust/ockam/ockam_api/src/control_api/openapi.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/openapi.rs
@@ -47,13 +47,12 @@ configuration or via environment variable, it's then passed in the `Authorizatio
 The easiest way to get development started is to use this API with the Ockam command and run a single node acting both as a frontend and backend.
 ```sh
 ockam node create --foreground -vv --configuration '{
-  "start_default_services": true,
   "services": {
-    "control_api": {
-      "authentication_token": "my-secret-token",
+    "control-api": {
+      "authentication-token": "my-secret-token",
       "backend": true,
       "frontend": true,
-      "http_bind_address": "127.0.0.1:8080"
+      "http-bind-address": "127.0.0.1:8080"
     }
   }
 }'

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/common.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/common.rs
@@ -111,6 +111,20 @@ pub enum Project {
         /// Name of the project
         /// When omitted, the default project will be used
         name: Option<String>,
+        /// Multiaddress to the node that will be used as an authority;
+        /// The Multiaddress will only be embedded in the ticket, but not used
+        /// for the actual connection;
+        /// When omitted, the existing authority route will be used
+        #[serde(default)]
+        #[schema(example = "/dnsaddr/my-authority.example.com/tcp/4001/secure/api")]
+        authority_route: Option<String>,
+        /// Multiaddress to the node that will be used as a project;
+        /// The Multiaddress will only be embedded in the ticket, but not used
+        /// for the actual connection;
+        /// When omitted, the existing project route will be used
+        #[serde(default)]
+        #[schema(example = "/dnsaddr/my-project.example.com/tcp/4000/service/api")]
+        project_route: Option<String>,
     },
     Provided {
         /// Name of the project;
@@ -134,13 +148,17 @@ pub enum Project {
 }
 
 pub fn default_project_information() -> Project {
-    Project::Existing { name: None }
+    Project::Existing {
+        name: None,
+        project_route: None,
+        authority_route: None,
+    }
 }
 
 impl Project {
     pub async fn to_project_authority(&self) -> ockam_core::Result<Authority> {
         match self {
-            Project::Existing { name } => Ok(Authority::Project { name: name.clone() }),
+            Project::Existing { name, .. } => Ok(Authority::Project { name: name.clone() }),
             Project::Provided {
                 authority_route,
                 authority_change_history,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/background_node_client.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/background_node_client.rs
@@ -211,7 +211,7 @@ impl BackgroundNodeClient {
     ) -> miette::Result<TcpConnection> {
         let node_info = self.cli_state.get_node(&self.node_name).await?;
         let tcp_listener_address = node_info
-            .tcp_listener_address()
+            .tcp_connect_address()
             .ok_or(miette!(
                 "an api transport should have been started for node {:?}",
                 &node_info

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
@@ -374,6 +374,15 @@ impl NodeManager {
         ))
     }
 
+    pub async fn default_project_name(&self) -> ockam_core::Result<String> {
+        Ok(self
+            .cli_state
+            .projects()
+            .get_default_project()
+            .await
+            .map(|project| project.name().to_string())?)
+    }
+
     pub fn identifier(&self) -> Identifier {
         self.node_identifier.clone()
     }

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -21,6 +21,7 @@ use ockam_api::nodes::{
 };
 use ockam_api::terminal::notification::NotificationHandler;
 use ockam_core::LOCAL;
+use ockam_multiaddr::MultiAddr;
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 use tracing::{debug, error, info, instrument};
@@ -94,10 +95,7 @@ impl CreateCommand {
             NodeManagerGeneralOptions::new(
                 opts.state.clone(),
                 node_name.clone(),
-                self.services
-                    .as_ref()
-                    .map(|c| c.start_default_services)
-                    .unwrap_or(true),
+                true,
                 self.status_endpoint_port(),
                 true,
             ),
@@ -233,7 +231,20 @@ impl CreateCommand {
                             .write_line(fmt_log!("Starting control API Frontend..."))?;
 
                         let node_resolution = match &config.node_resolution {
-                            ControlApiNodeResolution::Relay => NodeResolution::Relay,
+                            ControlApiNodeResolution::Relay => {
+                                let relay_node = if let Some(node_resolution_relay_node) =
+                                    &config.node_resolution_relay_node
+                                {
+                                    node_resolution_relay_node.parse()?
+                                } else if let Ok(default_project_name) =
+                                    node_manager.default_project_name().await
+                                {
+                                    format!("/project/{default_project_name}").parse()?
+                                } else {
+                                    MultiAddr::default()
+                                };
+                                NodeResolution::Relay { relay_node }
+                            }
                             ControlApiNodeResolution::DirectConnection => {
                                 NodeResolution::DirectConnection {
                                     pattern: config.node_resolution_pattern.clone(),
@@ -248,7 +259,7 @@ impl CreateCommand {
                                 config.http_bind_address,
                                 node_resolution,
                                 authentication_token,
-                                Some(config.frontend_policy.clone()),
+                                Some(config.backend_policy.clone()),
                             )
                             .await?;
                     }
@@ -257,8 +268,10 @@ impl CreateCommand {
                         opts.terminal
                             .write_line(fmt_log!("Starting control API Backend..."))?;
 
-                        node_manager
-                            .create_control_api_backend(ctx, Some(config.backend_policy.clone()))?;
+                        node_manager.create_control_api_backend(
+                            ctx,
+                            Some(config.frontend_policy.clone()),
+                        )?;
                     }
                 }
             }

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
@@ -85,7 +85,7 @@ impl Resource<CreateCommand> for Node {
         if let Some(services) = self.services {
             // Because the services is flattened, `self.services` will be Some even if it's not
             // defined in the config, so we need to check if the inner fields are defined first.
-            if services.services.is_some() || services.start_default_services.is_some() {
+            if services.services.is_some() {
                 if let Ok(services) = services.into_arg() {
                     if let Ok(services) = serde_json::to_string(&services) {
                         args.insert("services".into(), services.into());
@@ -166,20 +166,15 @@ impl Node {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct Services {
-    #[serde(alias = "start-default-services")]
-    pub start_default_services: Option<ArgValue>,
     pub services: Option<NamedResources>,
 }
 
 impl Services {
     /// Parse the services fields into a `ServicesConfig` struct
     pub fn into_arg(self) -> Result<ServicesConfig> {
-        let mut as_json = serde_json::json!({
+        let as_json = serde_json::json!({
             "services": self.services,
         });
-        if let Some(start_default_services) = self.start_default_services {
-            as_json["start-default-services"] = serde_json::json!(start_default_services);
-        }
         serde_json::from_value(as_json).into_diagnostic()
     }
 
@@ -246,7 +241,6 @@ mod tests {
         assert_eq!(cmd.name, "n1");
         assert_eq!(cmd.tcp_listener_address, "127.0.0.1:3333");
         let services = cmd.services.unwrap();
-        assert!(&services.start_default_services);
         assert_eq!(
             services
                 .services
@@ -293,14 +287,6 @@ mod tests {
             arg
         };
 
-        // Start default services
-        let config = r#"
-        start-default-services: true
-        "#;
-        let parsed = get_parsed_config(config);
-        assert!(parsed.start_default_services);
-        assert!(parsed.services.is_none());
-
         // Single service
         let config = r#"
         services:
@@ -308,7 +294,6 @@ mod tests {
             address: api
         "#;
         let parsed = get_parsed_config(config);
-        assert!(!parsed.start_default_services);
         let services = parsed.services.unwrap();
         let secure_channel_listener = services.secure_channel_listener.unwrap();
         assert_eq!(secure_channel_listener.address, "api");
@@ -321,7 +306,6 @@ mod tests {
             node-resolution: direct-connection
         "#;
         let parsed = get_parsed_config(config);
-        assert!(!parsed.start_default_services);
         let services = parsed.services.unwrap();
         let control_api = services.control_api.unwrap();
         assert_eq!(control_api.authentication_token.unwrap(), "token");
@@ -333,7 +317,6 @@ mod tests {
 
         // Multiple services
         let config = r#"
-        start-default-services: true
         services:
           secure-channel-listener:
             address: api
@@ -344,7 +327,6 @@ mod tests {
             node-resolution: direct-connection
         "#;
         let parsed = get_parsed_config(config);
-        assert!(parsed.start_default_services);
 
         let services = parsed.services.unwrap();
         let secure_channel_listener = services.secure_channel_listener.unwrap();

--- a/implementations/rust/ockam/ockam_command/src/service/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/config.rs
@@ -13,8 +13,6 @@ use ockam_api::nodes::service::default_address::DefaultAddress;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct ServicesConfig {
-    #[serde(alias = "start-default-services")]
-    pub(crate) start_default_services: bool,
     #[serde(
         alias = "startup_services",
         alias = "startup-services",
@@ -118,7 +116,7 @@ pub struct ControlApiConfig {
     #[serde(alias = "frontend-policy", default = "default_frontend_policy")]
     pub(crate) frontend_policy: PolicyExpression,
 
-    #[serde(alias = "backend_policy", default = "default_backend_policy")]
+    #[serde(alias = "backend-policy", default = "default_backend_policy")]
     pub(crate) backend_policy: PolicyExpression,
 
     /// How to reach nodes.
@@ -147,6 +145,15 @@ pub struct ControlApiConfig {
         default = "default_node_resolution_pattern"
     )]
     pub(crate) node_resolution_pattern: String,
+
+    /// During node resolution, the frontend expects the relays in the provided node.
+    /// By default, relays are expected in the default project.
+    /// To use local relay, use an empty string.
+    #[serde(
+        alias = "node-resolution-relay-node",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub(crate) node_resolution_relay_node: Option<String>,
 
     /// Authentication token for the control API.
     /// When undefined, the environment variable `OCKAM_CONTROL_API_AUTHENTICATION_TOKEN` will be used.

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -67,7 +67,7 @@ pub async fn clean_nodes_multiaddr(
                 let alias = p.cast::<Node>().expect("Failed to parse node name");
                 let node_info = cli_state.get_node(&alias).await?;
                 let addr = node_info
-                    .tcp_listener_address()
+                    .tcp_connect_address()
                     .ok_or(miette!("No transport API has been set on the node"))?;
                 match &addr {
                     InternetAddress::Dns(dns, _) => new_ma.push_back(DnsAddr::new(dns))?,

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/node_control_api.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/node_control_api.bats
@@ -25,27 +25,26 @@ teardown() {
   setup_home_dir
   run_success "$OCKAM" project enroll "${ticket}"
 
-  run_success "$OCKAM" node create "{\
-  tcp-listener-address: \"127.0.0.1:${frontend_node_port}\",
-  start-default-services: true,
-  services: {
-    control-api: {
-      authentication-token: token,
-      backend: true,
-      frontend: true,
-      http-bind-address: \"127.0.0.1:${api_port}\",
-      node-resolution: relay
-  }}}"
+  run_success "$OCKAM" node create "
+    tcp-listener-address: 127.0.0.1:${frontend_node_port}
+    services:
+      control-api:
+        authentication-token: token
+        backend: true
+        frontend: true
+        http-bind-address: 127.0.0.1:${api_port}
+        node-resolution: relay
+        node-resolution-relay-node: ''
+  "
   wait_for_port $api_port
 
   # create a node with a relay in the api node
-  run_success "$OCKAM" node create red --configuration "{\
-  start-default-services: true,
-  services: {
-    control-api: {
-      backend: true,
-      node-resolution: direct-connection
-  }}}"
+  run_success "$OCKAM" node create red "
+    services:
+      control-api:
+        backend: true
+        node-resolution: direct-connection
+    "
   run_success "$OCKAM" relay create --to red --at "/ip4/127.0.0.1/tcp/${frontend_node_port}/secure/api" ${relay}
 
   # verify that it can be accessed via control node api
@@ -67,22 +66,26 @@ teardown() {
 
   api_port="$(random_port)"
   expected_connection_port="$(random_port)"
-  run_success "$OCKAM" node create \
-    --launch-configuration \
-    "{\"start_default_services\": true, \"startup_services\":{ \
-      \"control_api\":{\"authentication_token\": \"token\", \"backend\":false, \"frontend\":true, \"http_bind_address\":\"127.0.0.1:${api_port}\", \
-      \"node_resolution\":\"direct-connection\", \
-      \"connection_node_port\":${expected_connection_port} \
-    }}}"
+  run_success "$OCKAM" node create "
+    services:
+      control-api:
+        frontend: true
+        backend: true
+        authentication-token: token
+        http-bind-address: 127.0.0.1:${api_port}
+        node-resolution: direct-connection
+        connection-node-port: ${expected_connection_port}
+  "
   wait_for_port $api_port
 
   # create a node with listening on the expected port
-  run_success "$OCKAM" node create \
-    --tcp-listener-address "127.0.0.1:${expected_connection_port}" \
-    --launch-configuration \
-    "{\"start_default_services\": true, \"startup_services\":{ \
-      \"control_api\":{ \"backend\":true,\"node_resolution\":\"direct-connection\" \
-    }}}"
+  run_success "$OCKAM" node create "
+    tcp-listener-address: 127.0.0.1:${expected_connection_port}
+    services:
+      control-api:
+        backend: true
+        node-resolution: direct-connection
+    "
   wait_for_port ${expected_connection_port}
 
   # verify that it can be accessed via control node api
@@ -104,11 +107,15 @@ teardown() {
   setup_home_dir
   run_success "$OCKAM" project enroll "${ticket}"
 
-  run_success "$OCKAM" node create \
-    --launch-configuration \
-    "{\"start_default_services\": true, \"startup_services\":{ \
-      \"control_api\":{\"authentication_token\": \"token\", \"backend\":true, \"frontend\":true, \"http_bind_address\":\"127.0.0.1:${api_port}\" \
-    }}}"
+  run_success "$OCKAM" node create "
+    services:
+      control-api:
+        authentication-token: token
+        backend: true
+        frontend: true
+        http-bind-address: 127.0.0.1:${api_port}
+        node-resolution-relay-node: ''
+  "
   wait_for_port $api_port
 
   # create outlet
@@ -204,11 +211,15 @@ teardown() {
   setup_home_dir
   run_success "$OCKAM" project enroll "${ticket}"
 
-  run_success "$OCKAM" node create \
-    --launch-configuration \
-    "{\"start_default_services\": true, \"startup_services\":{ \
-      \"control_api\":{\"authentication_token\": \"token\", \"backend\":true, \"frontend\":true, \"http_bind_address\":\"127.0.0.1:${api_port}\" \
-    }}}"
+  run_success "$OCKAM" node create "
+    services:
+      control-api:
+        authentication-token: token
+        backend: true
+        frontend: true
+        http-bind-address: 127.0.0.1:${api_port}
+        node-resolution-relay-node: ''
+    "
   wait_for_port $api_port
 
   # create relay
@@ -278,11 +289,15 @@ teardown() {
   setup_home_dir
   run_success "$OCKAM" project enroll "${ticket}"
 
-  run_success "$OCKAM" node create \
-    --launch-configuration \
-    "{\"start_default_services\": true, \"startup_services\":{ \
-      \"control_api\":{\"authentication_token\": \"token\", \"backend\":true, \"frontend\":true, \"http_bind_address\":\"127.0.0.1:${api_port}\" \
-    }}}"
+  run_success "$OCKAM" node create "
+    services:
+      control-api:
+        authentication-token: token
+        backend: true
+        frontend: true
+        http-bind-address: 127.0.0.1:${api_port}
+        node-resolution-relay-node: ''
+    "
   wait_for_port $api_port
 
   # create ticket
@@ -319,11 +334,15 @@ teardown() {
   setup_home_dir
   run_success "$OCKAM" project enroll "${ticket}"
 
-  run_success "$OCKAM" node create \
-    --launch-configuration \
-    "{\"start_default_services\": true, \"startup_services\":{ \
-      \"control_api\":{\"authentication_token\": \"token\", \"backend\":true, \"frontend\":true, \"http_bind_address\":\"127.0.0.1:${api_port}\" \
-    }}}"
+  run_success "$OCKAM" node create "
+    services:
+      control-api:
+        authentication-token: token
+        backend: true
+        frontend: true
+        http-bind-address: 127.0.0.1:${api_port}
+        node-resolution-relay-node: ''
+    "
   wait_for_port $api_port
 
   default_identifier=$($OCKAM identity show --output json | jq -rc .identifier)
@@ -391,11 +410,15 @@ EOF
   setup_home_dir
   run_success "$OCKAM" project enroll "${ticket}"
 
-  run_success "$OCKAM" node create \
-    --launch-configuration \
-    "{\"start_default_services\": true, \"startup_services\":{ \
-      \"control_api\":{\"authentication_token\": \"token\", \"backend\":true, \"frontend\":true, \"http_bind_address\":\"127.0.0.1:${api_port}\" \
-    }}}"
+  run_success "$OCKAM" node create "
+    services:
+      control-api:
+        authentication-token: token
+        backend: true
+        frontend: true
+        http-bind-address: 127.0.0.1:${api_port}
+        node-resolution-relay-node: ''
+    "
   wait_for_port $api_port
 
   # add member


### PR DESCRIPTION
Fixes some paper cuts found during deployment:
 - frontend and backend policies are now reversed (frontend checks for backend and vice-versa)
 - now by default frontend looks for nodes within the default project rather than locally
 - start-default-services option has been removed and assumed always true
 - it's now possible to override authority and project route when creating a ticket given an existing project
 - documentation about enrollment API has been updated
 - when a node is binding to `0.0.0.0`, use `127.0.0.1` to connect to it rather than `0.0.0.0`