### PR TITLE
address rustsec security reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.7"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -3801,7 +3801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6132,15 +6132,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -431,7 +431,7 @@ This file contains attributions for any 3rd-party open source code used in this 
 | regex-syntax | MIT, Apache-2.0 | https://crates.io/crates/regex-syntax |
 | reqwest | MIT, Apache-2.0 | https://crates.io/crates/reqwest |
 | rfc6979 | Apache-2.0, MIT | https://crates.io/crates/rfc6979 |
-| ring |  | https://crates.io/crates/ring |
+| ring | Apache-2.0, ISC | https://crates.io/crates/ring |
 | riscv | ISC | https://crates.io/crates/riscv |
 | roff | MIT, Apache-2.0 | https://crates.io/crates/roff |
 | rustc-demangle | MIT, Apache-2.0 | https://crates.io/crates/rustc-demangle |

--- a/tools/cargo-deny/deny.toml
+++ b/tools/cargo-deny/deny.toml
@@ -61,6 +61,9 @@ ignore = [
   # yaml-rust is unmaintained. Switching to maintained fork yaml-rust2 is tricky
   # Tracked here https://github.com/build-trust/ockam/issues/7807
   "RUSTSEC-2024-0320",
+  # `paste` is unmainted
+  # it's  pulled in by `aws-lc`, `kafka-protocol`, `binary-layout`, `stm32h7xx-hal` and `atsamd-hal`
+  "RUSTSEC-2024-0436",
 ]
 # Users who require or prefer Git to use SSH cloning instead of HTTPS,
 # such as implemented via "insteadOf" rules in Git config, can still


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2025-0009
Ring has been updated to the latest `.13` to avoid the vulnerability

https://rustsec.org/advisories/RUSTSEC-2024-0436 
The `paste` crate is unmaintained, and it has been ignored since there is no way to remove the dependency since it's too spread across major dependencies such as `aws-lc`.