### PR TITLE
feat(rust): add `--env` parameter to write environment variables before parsing command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/arguments.rs
+++ b/implementations/rust/ockam/ockam_command/src/arguments.rs
@@ -1,3 +1,5 @@
+use miette::miette;
+
 /// Return true if the list of arguments contains a help flag
 pub fn has_help_flag(input: &[String]) -> bool {
     input.contains(&"-h".to_string()) || input.contains(&"--help".to_string())
@@ -6,6 +8,41 @@ pub fn has_help_flag(input: &[String]) -> bool {
 /// Return true if the list of arguments contains a version flag
 pub fn has_version_flag(input: &[String]) -> bool {
     input.contains(&"-V".to_string()) || input.contains(&"--version".to_string())
+}
+
+/// Return a list of every `--env KEY=VALUE` attribute parameter in the list of arguments
+/// and a list of the remaining arguments
+#[allow(clippy::type_complexity)]
+pub fn get_env_attributes(
+    input: &[String],
+) -> miette::Result<Option<(Vec<(String, String)>, Vec<String>)>> {
+    let mut attributes = Vec::new();
+    let mut remaining = Vec::new();
+    let mut iter = input.iter();
+
+    while let Some(arg) = iter.next() {
+        if arg == "--env" {
+            let key_value = iter
+                .next()
+                .ok_or_else(|| miette!("Missing value for --env, expected KEY=VALUE"))?;
+            let mut key_value = key_value.split('=');
+            let key = key_value
+                .next()
+                .ok_or_else(|| miette!("Missing key for --env, expected KEY=VALUE"))?;
+            let value = key_value
+                .next()
+                .ok_or_else(|| miette!("Missing value for --env, expected KEY=VALUE"))?;
+            attributes.push((key.to_string(), value.to_string()));
+        } else {
+            remaining.push(arg.to_string());
+        }
+    }
+
+    if attributes.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some((attributes, remaining)))
+    }
 }
 
 /// Replaces the '-' placeholder character with a string value coming from stdin
@@ -45,5 +82,47 @@ pub fn replace_hyphen_with_stdin(s: String) -> String {
         s.replace("-/", &args_from_stdin)
     } else {
         s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    pub fn environment_attributes_replaced() {
+        let input = vec![
+            "ockam".to_string(),
+            "--env".to_string(),
+            "KEY1=VALUE1".to_string(),
+            "command".to_string(),
+            "arg1".to_string(),
+            "arg2".to_string(),
+            "--env".to_string(),
+            "KEY2=VALUE2".to_string(),
+        ];
+
+        let (attributes, remaining) = super::get_env_attributes(&input).unwrap().unwrap();
+
+        assert_eq!(attributes.len(), 2);
+        assert_eq!(attributes[0], ("KEY1".to_string(), "VALUE1".to_string()));
+        assert_eq!(attributes[1], ("KEY2".to_string(), "VALUE2".to_string()));
+
+        assert_eq!(remaining.len(), 4);
+        assert_eq!(remaining[0], "ockam".to_string());
+        assert_eq!(remaining[1], "command".to_string());
+        assert_eq!(remaining[2], "arg1".to_string());
+        assert_eq!(remaining[3], "arg2".to_string());
+    }
+
+    #[test]
+    pub fn environment_attributes_not_replaced() {
+        let input = vec![
+            "ockam".to_string(),
+            "command".to_string(),
+            "arg1".to_string(),
+            "arg2".to_string(),
+        ];
+
+        let result = super::get_env_attributes(&input).unwrap();
+        assert!(result.is_none());
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/entry_point.rs
+++ b/implementations/rust/ockam/ockam_command/src/entry_point.rs
@@ -5,8 +5,8 @@ use miette::IntoDiagnostic;
 
 use crate::branding::BrandingCompileEnvVars;
 use crate::{
-    add_command_error_event, has_help_flag, has_version_flag, pager, replace_hyphen_with_stdin,
-    util::exitcode, version::Version, OckamCommand,
+    add_command_error_event, get_env_attributes, has_help_flag, has_version_flag, pager,
+    replace_hyphen_with_stdin, util::exitcode, version::Version, OckamCommand,
 };
 use ockam_api::cli_state::{CliState, CliStateMode};
 use ockam_api::logs::{
@@ -41,6 +41,19 @@ pub fn run() -> miette::Result<()> {
     if has_version_flag(&input) {
         print_version_and_exit();
     }
+
+    // allows environment variables to be set via command line as a workaround for the lack of
+    // environment variable support in kubernetes probes
+    let input = if let Some((attributes, remaining_arguments)) = get_env_attributes(&input)? {
+        for (key, value) in attributes {
+            // set the environment variable while we are still single-threaded
+            // and before the arguments are parsed
+            std::env::set_var(key, value);
+        }
+        remaining_arguments
+    } else {
+        input
+    };
 
     let command_res = OckamCommand::try_parse_from(&input);
 


### PR DESCRIPTION
Kubernetes livenessprobe and readinessprobe do not support environment parameters, as a workaround I've added the `--env` to environment variables before ockam command gets parsed.