### PR TITLE
Control API Fixes - timeout and inlets

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/control_api/backend/inlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/backend/inlet.rs
@@ -10,6 +10,7 @@ use crate::nodes::NodeManager;
 use http::{Method, StatusCode};
 use ockam_abac::{Action, Expr, PolicyExpression, ResourceName};
 use ockam_core::compat::rand::random_string;
+use ockam_core::errcode::Kind;
 use ockam_core::Route;
 use ockam_multiaddr::MultiAddr;
 use ockam_node::Context;
@@ -61,6 +62,7 @@ The creation will be asynchronous and the initial status will be `down`.",
     tags = ["Portals"],
     responses(
         (status = CREATED, description = "Successfully created", body = InletStatus),
+        (status = CONFLICT, description = "TCP Inlet with the same name or port already exists", body = ErrorResponse),
     ),
     params(
         ("node" = NodeName,),
@@ -181,10 +183,14 @@ async fn handle_tcp_inlet_create(
         )?),
         Err(error) => {
             // TODO: specialize errors
-            // name already exists
-            // port already bound
             warn!("Failed to create tcp inlet: {:?}", error);
-            ControlApiHttpResponse::internal_error("Failed to create tcp inlet")
+            let code = error.code();
+            match code.kind {
+                Kind::AlreadyExists => ControlApiHttpResponse::conflict(
+                    "TCP Inlet with the same name or port already exists",
+                ),
+                _ => ControlApiHttpResponse::internal_error("Failed to create tcp inlet"),
+            }
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/control_api/frontend.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/frontend.rs
@@ -63,25 +63,34 @@ impl Processor for HttpControlNodeApiFrontend {
             }
         };
 
-        let service = service_fn(|request| {
-            let context = context.clone();
-            Self::route_request(
-                request,
-                context,
-                self.node_manager.clone(),
-                self.node_resolution.clone(),
-                self.authentication_token.clone(),
-                self.incoming_access_control.clone(),
-                self.outgoing_access_control.clone(),
-            )
-        });
+        let service = {
+            let node_manager = self.node_manager.clone();
+            let node_resolution = self.node_resolution.clone();
+            let authentication_token = self.authentication_token.clone();
+            let incoming_access_control = self.incoming_access_control.clone();
+            let outgoing_access_control = self.outgoing_access_control.clone();
 
-        if let Err(err) = http1::Builder::new()
-            .serve_connection(TokioIo::new(stream), service)
-            .await
-        {
-            error!("HTTP server error: {:?}", err);
-        }
+            service_fn(move |request| {
+                Self::route_request(
+                    request,
+                    context.clone(),
+                    node_manager.clone(),
+                    node_resolution.clone(),
+                    authentication_token.clone(),
+                    incoming_access_control.clone(),
+                    outgoing_access_control.clone(),
+                )
+            })
+        };
+
+        tokio::spawn(async move {
+            if let Err(err) = http1::Builder::new()
+                .serve_connection(TokioIo::new(stream), service)
+                .await
+            {
+                error!("HTTP server error: {:?}", err);
+            }
+        });
 
         Ok(true)
     }

--- a/implementations/rust/ockam/ockam_api/src/control_api/http.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/http.rs
@@ -87,6 +87,16 @@ impl ControlApiHttpResponse {
         .into())
     }
 
+    pub fn conflict<T>(message: &str) -> Result<T, ControlApiError> {
+        Err(Self::with_body(
+            StatusCode::CONFLICT,
+            ErrorResponse {
+                message: message.to_string(),
+            },
+        )?
+        .into())
+    }
+
     pub fn internal_error<T>(error: &str) -> Result<T, ControlApiError> {
         Err(Self::with_body(
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/node_control_api.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/node_control_api.bats
@@ -97,6 +97,42 @@ teardown() {
   assert_output "[]"
 }
 
+@test "node control api - timeout doesn't block other requests" {
+  ticket=$($OCKAM project ticket \
+    --usage-count 5 \
+    --attribute node_control_api_backend \
+    --attribute node_control_api_frontend)
+  api_port="$(random_port)"
+
+  setup_home_dir
+  run_success "$OCKAM" project enroll "${ticket}"
+
+  run_success "$OCKAM" node create "
+    services:
+      control-api:
+        authentication-token: token
+        backend: true
+        frontend: true
+        http-bind-address: 127.0.0.1:${api_port}
+  "
+  wait_for_port $api_port
+
+  curl -vf \
+    -H 'Authorization: Bearer token' \
+    -o inlet-list.json \
+    --max-time 2 \
+    "http://localhost:${api_port}/non-existing-node/tcp-inlets" &
+
+  run_success curl -vf \
+    -H 'Authorization: Bearer token' \
+    --connect-timeout 2 \
+    --max-time 2 \
+    -o inlet-list.json \
+    "http://localhost:${api_port}/self/tcp-inlets"
+  run_success cat inlet-list.json
+  assert_output "[]"
+}
+
 @test "node control api - portals" {
   ticket=$($OCKAM project ticket \
     --usage-count 5 \
@@ -198,6 +234,47 @@ teardown() {
     "http://localhost:${api_port}/self/tcp-inlets"
   run_success sh -c "cat inlet-list.json | jq -rc ."
   assert_output "[]"
+}
+
+@test "node control api - inlet with same name" {
+  ticket=$($OCKAM project ticket \
+    --usage-count 5 \
+    --attribute node_control_api_backend \
+    --attribute node_control_api_frontend)
+  api_port="$(random_port)"
+
+  setup_home_dir
+  run_success "$OCKAM" project enroll "${ticket}"
+
+  run_success "$OCKAM" node create "
+    services:
+      control-api:
+        authentication-token: token
+        backend: true
+        frontend: true
+        http-bind-address: 127.0.0.1:${api_port}
+        node-resolution-relay-node: ''
+  "
+  wait_for_port $api_port
+
+  # create inlet
+  run_success curl -vf \
+    -X POST \
+    -H 'Authorization: Bearer token' \
+    -d "{\"from\":{\"hostname\":\"127.0.0.1\",\"port\":0},\"kind\":\"regular\",\"name\":\"my-inlet\",\"to\":\"/secure/api/service/my-outlet\"}" \
+    -o inlet-creation.json \
+    "http://localhost:${api_port}/self/tcp-inlets"
+  inlet_port=$(cat inlet-creation.json | jq -rc '."bind-address".port')
+  wait_for_port $inlet_port
+
+  run_success curl -v \
+    -X POST \
+    -H 'Authorization: Bearer token' \
+    -d "{\"from\":{\"hostname\":\"127.0.0.1\",\"port\":${inlet_port}},\"kind\":\"regular\",\"name\":\"my-inlet\",\"to\":\"/secure/api/service/my-outlet\"}" \
+    -o error-output.json \
+    "http://localhost:${api_port}/self/tcp-inlets"
+  run_success cat error-output.json
+  assert_output --partial "name or port already exists"
 }
 
 @test "node control api - relay" {


### PR DESCRIPTION
When request timeouts, every other request is queued in the meantime, causing outages.
This PR fixes it by spawning a dedicated task for each connection.
Another unrelated paper-cut is to return an explicit error when the inlet name or port are already in-use.