### PR TITLE
feat(rust): add env var to configure the orchestrator ui url

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/orchestrator/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/orchestrator/space.rs
@@ -13,7 +13,7 @@ use crate::nodes::InMemoryNode;
 use crate::orchestrator::email_address::EmailAddress;
 use crate::orchestrator::project::models::AdminInfo;
 use crate::orchestrator::project::{Project, ProjectsOrchestratorApi};
-use crate::orchestrator::subscription::{Subscription, SUBSCRIPTION_PAGE};
+use crate::orchestrator::subscription::{subscription_page, Subscription};
 use crate::orchestrator::{ControllerClient, HasSecureClient};
 use crate::output::{comma_separated, Output};
 use crate::terminal::fmt;
@@ -98,7 +98,7 @@ impl Space {
             }
             if subscription.is_free_trial {
                 writeln!(f)?;
-                writeln!(f, "{}", fmt_log!("Please go to {} and subscribe before the trial ends to avoid any service interruptions.", color_uri(SUBSCRIPTION_PAGE)))?;
+                writeln!(f, "{}", fmt_log!("Please go to {} and subscribe before the trial ends to avoid any service interruptions.", color_uri(subscription_page()?)))?;
                 writeln!(f, "{}", fmt_log!("{}", color_warn("If you don't subscribe in that time, your Space and all associated Projects will be permanently deleted.")))?;
             }
         } else {

--- a/implementations/rust/ockam/ockam_api/src/orchestrator/subscription.rs
+++ b/implementations/rust/ockam/ockam_api/src/orchestrator/subscription.rs
@@ -3,11 +3,13 @@ use crate::date::UtcDateTime;
 use crate::orchestrator::{ControllerClient, HasSecureClient};
 use crate::output::Output;
 use crate::terminal::fmt;
+use crate::{ApiError, ParseError};
 use colorful::{Colorful, RGB};
 use miette::IntoDiagnostic;
 use minicbor::{decode, encode, CborLen, Decode, Decoder, Encode};
 use ockam::Message;
 use ockam_core::api::{Reply, Request};
+use ockam_core::env::get_env_with_default;
 use ockam_core::{
     self, async_trait, cbor_encode_preallocate, Decodable, Encodable, Encoded, Result,
 };
@@ -16,10 +18,21 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter, Write};
 use std::str::FromStr;
 use strum::{Display, EnumString};
+use url::Url;
 
 const API_SERVICE: &str = "subscriptions";
 
-pub const SUBSCRIPTION_PAGE: &str = "https://orchestrator.ockam.io";
+/// The URL of the Ockam's Orchestrator UI
+const OCKAM_ORCHESTRATOR_UI_URL: &str = "OCKAM_ORCHESTRATOR_UI_URL";
+const DEFAULT_OCKAM_ORCHESTRATOR_UI_URL: &str = "https://orchestrator.ockam.io/";
+
+pub fn subscription_page() -> crate::Result<Url> {
+    Url::from_str(&get_env_with_default(
+        OCKAM_ORCHESTRATOR_UI_URL,
+        DEFAULT_OCKAM_ORCHESTRATOR_UI_URL.to_string(),
+    )?)
+    .map_err(|e| ApiError::Parse(ParseError::Url(e)))
+}
 
 #[derive(Encode, Decode, CborLen, Debug, Message)]
 #[cfg_attr(test, derive(Clone))]
@@ -451,6 +464,7 @@ pub mod tests {
     use super::*;
     use crate::schema::tests::validate_with_schema;
     use quickcheck::{quickcheck, Arbitrary, Gen, TestResult};
+    use serial_test::serial;
     use std::str::FromStr;
 
     quickcheck! {
@@ -538,5 +552,17 @@ pub mod tests {
             assert_eq!(SubscriptionName::from_str(from_str).unwrap(), expected);
             assert_eq!(expected.to_string(), to_string);
         }
+    }
+
+    #[test]
+    #[serial]
+    fn test_orchestrator_url_env() {
+        std::env::remove_var(OCKAM_ORCHESTRATOR_UI_URL);
+        let url = subscription_page().unwrap();
+        assert_eq!(url.as_str(), DEFAULT_OCKAM_ORCHESTRATOR_UI_URL);
+
+        std::env::set_var(OCKAM_ORCHESTRATOR_UI_URL, "https://example.com/");
+        let url = subscription_page().unwrap();
+        assert_eq!(url.as_str(), "https://example.com/");
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -30,7 +30,7 @@ use ockam_api::orchestrator::enroll::auth0::*;
 use ockam_api::orchestrator::project::Project;
 use ockam_api::orchestrator::project::ProjectsOrchestratorApi;
 use ockam_api::orchestrator::space::{Space, Spaces};
-use ockam_api::orchestrator::subscription::SUBSCRIPTION_PAGE;
+use ockam_api::orchestrator::subscription::subscription_page;
 use ockam_api::orchestrator::ControllerClient;
 use ockam_api::terminal::notification::NotificationHandler;
 use ockam_api::{fmt_err, fmt_log, fmt_ok, fmt_warn};
@@ -422,6 +422,8 @@ async fn get_user_space(
         node.get_spaces(ctx).await?
     };
 
+    let subscription_page = subscription_page()?.to_string();
+
     let space = match spaces.first() {
         // If the identity has no spaces, create one
         None => {
@@ -430,7 +432,7 @@ async fn get_user_space(
                 .write_line(fmt_log!("No Spaces are accessible to your account.\n"))?;
             opts.terminal.write_line(fmt_log!(
                 "Please go to {} and subscribe to create a new Space.",
-                color_uri(SUBSCRIPTION_PAGE)
+                color_uri(&subscription_page)
             ))?;
 
             if skip_orchestrator_resources_creation {
@@ -453,7 +455,7 @@ async fn get_user_space(
                     ))?;
                     opts.terminal.write_line(fmt_log!(
                         "Please go to {} and subscribe to use your Space.",
-                        color_uri(SUBSCRIPTION_PAGE)
+                        color_uri(&subscription_page)
                     ))?;
                     ask_user_to_subscribe_and_wait_for_space_to_be_ready(opts, ctx, node).await?
                 }
@@ -467,7 +469,7 @@ async fn get_user_space(
                         ))?;
                         opts.terminal.write_line(fmt_log!(
                             "Please go to {} and subscribe to one of our paid plans to use your Space.",
-                            color_uri(SUBSCRIPTION_PAGE)
+                            color_uri(&subscription_page)
                         ))?;
                         if let Some(grace_period_end_date) = subscription.grace_period_end_date()? {
                             let date = grace_period_end_date.format_human().into_diagnostic()?;
@@ -493,7 +495,7 @@ async fn get_user_space(
         // At this point, the space should have a subscription, but just in case
         miette!(
             "Please go to {} and try again",
-            color_uri(SUBSCRIPTION_PAGE)
+            color_uri(&subscription_page)
         )
         .wrap_err("The Space does not have a subscription plan attached.")
     })?;
@@ -512,12 +514,14 @@ async fn ask_user_to_subscribe_and_wait_for_space_to_be_ready(
     ctx: &Context,
     node: &InMemoryNode,
 ) -> Result<Space> {
+    let subscription_page = subscription_page()?.to_string();
+
     opts.terminal.write_line("")?;
     if opts.terminal.can_ask_for_user_input() {
         opts.terminal.write(fmt_log!(
             "Press {} to open {} in your browser.",
             " ENTER ↵ ".bg_white().black().blink(),
-            color_uri(SUBSCRIPTION_PAGE)
+            color_uri(&subscription_page)
         ))?;
 
         let mut input = String::new();
@@ -533,10 +537,10 @@ async fn ask_user_to_subscribe_and_wait_for_space_to_be_ready(
             }
         }
     }
-    if open::that(SUBSCRIPTION_PAGE).is_err() {
+    if open::that(&subscription_page).is_err() {
         opts.terminal.write_line(fmt_err!(
             "Couldn't open your browser from the terminal. Please open {} manually.",
-            color_uri(SUBSCRIPTION_PAGE)
+            color_uri(&subscription_page)
         ))?;
     }
 

--- a/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
+++ b/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
@@ -63,6 +63,7 @@ Devs Usage
 - OCKAM_CONTROLLER_ADDR: a `string` that overrides the default address of the controller.
 - OCKAM_CONTROLLER_IDENTITY_ID: a `string` that overrides the default identifier of the controller.
 - OCKAM_AUTHENTICATOR_ENDPOINT: a `string` that overrides the default endpoint of the authenticator. Defaults to `https://account.ockam.io`.
+- OCKAM_ORCHESTRATOR_UI_URL: a `string` that overrides the default URL of the orchestrator UI. Defaults to `https://orchestrator.ockam.io`.
 - OCKAM_DEVELOPER: a `boolean` specifying if the current user is an Ockam developer (for more accurate metrics).
 - OCKAM_OPENTELEMETRY_EXPORT_DEBUG: a `boolean` specifying if debug messages must be printed to the console when the OpenTelemetry export is configured.
 - OCKAM_TELEMETRY_EXPORT_VIA_PROJECT: a `boolean` specifying if traces must be exported via a secure channel to the project node (when it exists)


### PR DESCRIPTION
Useful when testing the command with a local/dev orchestrator. The custom URL is used in the `enroll` command, when the user is asked to subscribe and create a space.

![image](https://github.com/user-attachments/assets/9a49f3db-a47c-47d1-b430-87721ff9b620)