### PR TITLE
fix(rust): add worker address to the output of `tcp-connection create`

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -82,14 +82,19 @@ impl Output for TcpConnection {
             output,
             "{}",
             fmt_ok!(
-                "A TCP connection was created at the node {}",
-                color_primary(&self.from)
+                "A TCP connection with worker address {}",
+                color_primary(self.address.to_string()),
             ),
         )?;
         writeln!(
             output,
             "{}",
-            fmt_log!("to the address {}", color_primary(self.to.to_string()))
+            fmt_log!("was created at the Node {}", color_primary(&self.from)),
+        )?;
+        writeln!(
+            output,
+            "{}",
+            fmt_log!("bound to {}", color_primary(self.to.to_string()))
         )?;
         Ok(output)
     }

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
@@ -47,8 +47,7 @@ impl DeleteCommand {
                     "TCP connection {address} has been successfully deleted"
                 ))
                 .json(serde_json::json!({ "address": address }))
-                .write_line()
-                .unwrap();
+                .write_line()?;
         }
         Ok(())
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5079bc16-3c3c-4ede-b24e-06414054e89b)