### PR TITLE
feat(rust): unify output of crud tcp-connection commands

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/node.rs
@@ -175,7 +175,14 @@ impl Display for NodeResources {
         } else {
             writeln!(f, "{}{}Transports:", fmt::PADDING, fmt::INDENTATION)?;
             for t in &self.transports {
-                writeln!(f, "{}{}{}", fmt::PADDING, fmt::INDENTATION.repeat(2), t)?;
+                write!(f, "{}{}", fmt::PADDING, fmt::INDENTATION.repeat(2))?;
+                writeln!(
+                    f,
+                    "{}, {} at {}",
+                    t.tt,
+                    t.tm,
+                    color_primary(&t.socket_address)
+                )?;
             }
         }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/transport/response.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/transport/response.rs
@@ -2,6 +2,7 @@ use crate::colors::color_primary;
 use crate::nodes::models::transport::{TransportMode, TransportType};
 use crate::nodes::service::ApiTransport;
 use crate::output::Output;
+use crate::terminal::fmt;
 use minicbor::{CborLen, Decode, Encode};
 use ockam::tcp::{TcpConnection, TcpListener, TcpListenerInfo, TcpSenderInfo};
 use ockam::Message;
@@ -25,9 +26,9 @@ pub struct TransportStatus {
     #[serde(rename = "mode")]
     #[n(2)] pub tm: TransportMode,
     /// Corresponding socket address
-    #[n(3)] pub socket_addr: String,
+    #[n(3)] pub socket_address: String,
     /// Corresponding worker address
-    #[n(4)] pub worker_addr: String,
+    #[n(4)] pub worker_address: String,
     /// Corresponding worker address
     #[n(5)] pub processor_address: String,
     /// Corresponding flow control id
@@ -52,7 +53,7 @@ impl TransportStatus {
     }
 
     pub fn socket_addr(&self) -> Result<SocketAddrV4> {
-        self.socket_addr
+        self.socket_address
             .parse::<SocketAddrV4>()
             .map_err(|err| Error::new(Origin::Transport, Kind::Invalid, err))
     }
@@ -60,9 +61,9 @@ impl TransportStatus {
     pub fn multiaddr(&self) -> Result<MultiAddr> {
         let mut m = MultiAddr::default();
         let worker_address = self
-            .worker_addr
+            .worker_address
             .strip_prefix("0#")
-            .unwrap_or(self.worker_addr.as_ref());
+            .unwrap_or(self.worker_address.as_ref());
         m.push_back(Worker::new(worker_address))?;
 
         Ok(m)
@@ -74,8 +75,8 @@ impl From<ApiTransport> for TransportStatus {
         Self {
             tt: value.tt,
             tm: value.tm,
-            socket_addr: value.socket_address.to_string(),
-            worker_addr: value.worker_address.clone(),
+            socket_address: value.socket_address.to_string(),
+            worker_address: value.worker_address.clone(),
             processor_address: value.processor_address.clone(),
             flow_control_id: value.flow_control_id,
         }
@@ -87,8 +88,8 @@ impl From<TcpSenderInfo> for TransportStatus {
         Self {
             tt: TransportType::Tcp,
             tm: (*value.mode()).into(),
-            socket_addr: value.socket_address().to_string(),
-            worker_addr: value.address().to_string(),
+            socket_address: value.socket_address().to_string(),
+            worker_address: value.address().to_string(),
             processor_address: value.receiver_address().to_string(),
             flow_control_id: value.flow_control_id().clone(),
         }
@@ -100,8 +101,8 @@ impl From<TcpListenerInfo> for TransportStatus {
         Self {
             tt: TransportType::Tcp,
             tm: TransportMode::Listen,
-            socket_addr: value.socket_address().to_string(),
-            worker_addr: "<none>".into(),
+            socket_address: value.socket_address().to_string(),
+            worker_address: "<none>".into(),
             processor_address: value.address().to_string(),
             flow_control_id: value.flow_control_id().clone(),
         }
@@ -113,8 +114,8 @@ impl From<TcpConnection> for TransportStatus {
         Self {
             tt: TransportType::Tcp,
             tm: TransportMode::Outgoing,
-            socket_addr: value.socket_address().to_string(),
-            worker_addr: value.sender_address().to_string(),
+            socket_address: value.socket_address().to_string(),
+            worker_address: value.sender_address().to_string(),
             processor_address: value.receiver_address().to_string(),
             flow_control_id: value.flow_control_id().clone(),
         }
@@ -126,8 +127,8 @@ impl From<TcpListener> for TransportStatus {
         Self {
             tt: TransportType::Tcp,
             tm: TransportMode::Listen,
-            socket_addr: value.socket_address().to_string(),
-            worker_addr: "<none>".into(),
+            socket_address: value.socket_address().to_string(),
+            worker_address: "<none>".into(),
             processor_address: value.processor_address().to_string(),
             flow_control_id: value.flow_control_id().clone(),
         }
@@ -136,12 +137,13 @@ impl From<TcpListener> for TransportStatus {
 
 impl Display for TransportStatus {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
+        writeln!(f, "{}:", color_primary(&self.worker_address))?;
+        writeln!(f, "{}{} {} Connection", fmt::INDENTATION, self.tt, self.tm,)?;
+        writeln!(
             f,
-            "{}, {} at {}",
-            self.tt,
-            self.tm,
-            color_primary(&self.socket_addr)
+            "{}bound to {}",
+            fmt::INDENTATION,
+            color_primary(&self.socket_address)
         )?;
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -111,7 +111,7 @@ impl ShowCommandTui for ShowTui {
             .clone()
             .to_stdout()
             .plain(&node_resources)
-            .json(serde_json::to_string(&node_resources).into_diagnostic()?)
+            .json_obj(&node_resources)?
             .write_line()?;
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -1,19 +1,15 @@
 use async_trait::async_trait;
 use clap::Args;
 use miette::IntoDiagnostic;
-use serde::Serialize;
 use std::fmt::Write;
-use std::net::SocketAddrV4;
 
 use colorful::Colorful;
 use ockam_api::address::extract_address_value;
 use ockam_api::colors::color_primary;
 use ockam_api::nodes::models::transport::TransportStatus;
 use ockam_api::nodes::{models, BackgroundNodeClient};
-use ockam_api::output::Output;
 use ockam_api::{fmt_log, fmt_ok};
 use ockam_core::api::Request;
-use ockam_multiaddr::MultiAddr;
 use ockam_node::Context;
 
 use crate::docs;
@@ -22,7 +18,7 @@ use crate::{Command, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
 
-/// Create a TCP connection
+/// Create a TCP Connection
 #[derive(Args, Clone, Debug)]
 #[command(arg_required_else_help = true, after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct CreateCommand {
@@ -44,58 +40,46 @@ impl Command for CreateCommand {
         let node = BackgroundNodeClient::create(ctx, opts.state.clone(), &self.from).await?;
         let payload = models::transport::CreateTcpConnection::new(self.address.clone());
         let request = Request::post("/node/tcp/connection").body(payload);
-        let transport_status: TransportStatus = node.ask(ctx, request).await?;
-
-        let output = TcpConnection::new(
-            node.node_name().to_string(),
-            transport_status.socket_addr().into_diagnostic()?,
-            transport_status.multiaddr().into_diagnostic()?,
-        );
+        let res: TransportStatus = node.ask(ctx, request).await?;
 
         opts.terminal
             .to_stdout()
-            .plain(output.item()?)
-            .machine(output.address.to_string())
-            .json(serde_json::to_string(&output).into_diagnostic()?)
+            .plain(self.plain_output(&res, node.node_name())?)
+            .machine(res.worker_address.to_string())
+            .json_obj(&res)?
             .write_line()?;
         Ok(())
     }
 }
 
-#[derive(Debug, Serialize)]
-struct TcpConnection {
-    from: String,
-    to: SocketAddrV4,
-    address: MultiAddr,
-}
-
-impl TcpConnection {
-    pub fn new(from: String, to: SocketAddrV4, address: MultiAddr) -> Self {
-        Self { from, to, address }
-    }
-}
-
-impl Output for TcpConnection {
-    fn item(&self) -> ockam_api::Result<String> {
-        let mut output = String::new();
+impl CreateCommand {
+    fn plain_output(&self, status: &TransportStatus, node_name: &str) -> crate::Result<String> {
+        let mut plain = String::new();
         writeln!(
-            output,
+            plain,
             "{}",
             fmt_ok!(
-                "A TCP connection with worker address {}",
-                color_primary(self.address.to_string()),
+                "A TCP {} Connection with worker address {}",
+                status.tm,
+                color_primary(&status.worker_address),
             ),
-        )?;
+        )
+        .into_diagnostic()?;
         writeln!(
-            output,
+            plain,
             "{}",
-            fmt_log!("was created at the Node {}", color_primary(&self.from)),
-        )?;
+            fmt_log!("was created at the Node {}", color_primary(node_name)),
+        )
+        .into_diagnostic()?;
         writeln!(
-            output,
+            plain,
             "{}",
-            fmt_log!("bound to {}", color_primary(self.to.to_string()))
-        )?;
-        Ok(output)
+            fmt_log!(
+                "bound to {}",
+                color_primary(status.socket_address.to_string())
+            )
+        )
+        .into_diagnostic()?;
+        Ok(plain)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
@@ -1,55 +1,128 @@
+use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
+use console::Term;
 use ockam_api::fmt_ok;
+use std::net::SocketAddr;
+use std::str::FromStr;
 
 use ockam_api::nodes::{models, BackgroundNodeClient};
+use ockam_api::terminal::{Terminal, TerminalStream};
 use ockam_core::api::Request;
+use ockam_core::TryClone;
 use ockam_node::Context;
 
-use crate::{docs, node::NodeOpts, CommandGlobalOpts};
+use crate::tui::{DeleteCommandTui, PluralTerm};
+use crate::{docs, node::NodeOpts, Command, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
 
-/// Delete a TCP connection
+/// Delete a TCP Connection
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true, after_long_help = docs::after_help(AFTER_LONG_HELP))]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct DeleteCommand {
     #[command(flatten)]
     node_opts: NodeOpts,
 
-    /// TCP connection internal address or socket address
-    pub address: String,
+    /// TCP Connection worker address or socket address
+    pub address: Option<String>,
 
     /// Confirm the deletion without prompting
     #[arg(display_order = 901, long, short)]
     yes: bool,
+
+    /// Delete all the TCP Connections
+    #[arg(long)]
+    all: bool,
 }
 
-impl DeleteCommand {
-    pub fn name(&self) -> String {
-        "tcp-connection delete".into()
+#[async_trait]
+impl Command for DeleteCommand {
+    const NAME: &'static str = "tcp-connection delete";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        Ok(DeleteTui::run(ctx, opts, self).await?)
+    }
+}
+
+#[derive(TryClone)]
+struct DeleteTui {
+    ctx: Context,
+    opts: CommandGlobalOpts,
+    node: BackgroundNodeClient,
+    cmd: DeleteCommand,
+}
+
+impl DeleteTui {
+    pub async fn run(
+        ctx: &Context,
+        opts: CommandGlobalOpts,
+        cmd: DeleteCommand,
+    ) -> miette::Result<()> {
+        let node =
+            BackgroundNodeClient::create(ctx, opts.state.clone(), &cmd.node_opts.at_node).await?;
+        let tui = Self {
+            ctx: ctx.try_clone()?,
+            opts,
+            node,
+            cmd,
+        };
+        tui.delete().await
+    }
+}
+
+#[async_trait]
+impl DeleteCommandTui for DeleteTui {
+    const ITEM_NAME: PluralTerm = PluralTerm::TcpConnection;
+
+    fn cmd_arg_item_name(&self) -> Option<String> {
+        self.cmd.address.clone()
     }
 
-    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        if opts.terminal.confirmed_with_flag_or_prompt(
-            self.yes,
-            "Are you sure you want to delete this TCP connection?",
-        )? {
-            let node =
-                BackgroundNodeClient::create(ctx, opts.state.clone(), &self.node_opts.at_node)
-                    .await?;
-            let address = self.address.clone();
-            let req = Request::delete("/node/tcp/connection")
-                .body(models::transport::DeleteTransport::new(address.clone()));
-            node.tell(ctx, req).await?;
-            opts.terminal
-                .to_stdout()
-                .plain(fmt_ok!(
-                    "TCP connection {address} has been successfully deleted"
-                ))
-                .json(serde_json::json!({ "address": address }))
-                .write_line()?;
-        }
+    fn cmd_arg_delete_all(&self) -> bool {
+        self.cmd.all
+    }
+
+    fn cmd_arg_confirm_deletion(&self) -> bool {
+        self.cmd.yes
+    }
+
+    fn terminal(&self) -> Terminal<TerminalStream<Term>> {
+        self.opts.terminal.clone()
+    }
+
+    async fn list_items_names(&self) -> miette::Result<Vec<String>> {
+        let transports = super::ListCommand::get_connection_list(&self.ctx, &self.node).await?;
+        let is_socket_address = self
+            .cmd
+            .address
+            .as_ref()
+            .map(|a| SocketAddr::from_str(a).is_ok())
+            .unwrap_or(false);
+        Ok(transports
+            .into_iter()
+            .map(|t| {
+                if is_socket_address {
+                    t.socket_address
+                } else {
+                    t.worker_address
+                }
+            })
+            .collect())
+    }
+
+    async fn delete_single(&self, item_name: &str) -> miette::Result<()> {
+        let req = Request::delete("/node/tcp/connection").body(
+            models::transport::DeleteTransport::new(item_name.to_string()),
+        );
+        self.node.tell(&self.ctx, req).await?;
+        self.terminal()
+            .to_stdout()
+            .plain(fmt_ok!(
+                "TCP Connection {item_name} has been successfully deleted"
+            ))
+            .machine(item_name)
+            .write_line()?;
         Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -1,21 +1,19 @@
+use async_trait::async_trait;
 use clap::Args;
-use colorful::Colorful;
-use ockam_api::colors::OckamColor;
-use tokio::sync::Mutex;
-use tokio::try_join;
+use ockam_api::colors::color_primary;
 
-use ockam_api::nodes::models::transport::TransportStatusList;
+use ockam_api::nodes::models::transport::{TransportMode, TransportStatus, TransportStatusList};
 use ockam_api::nodes::BackgroundNodeClient;
 use ockam_core::api::Request;
 use ockam_node::Context;
 
 use crate::node::NodeOpts;
-use crate::{docs, CommandGlobalOpts};
+use crate::{docs, Command, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
 
-/// List TCP connections
+/// List TCP Connections
 #[derive(Args, Clone, Debug)]
 #[command(
 before_help = docs::before_help(PREVIEW_TAG),
@@ -25,42 +23,60 @@ pub struct ListCommand {
     node_opts: NodeOpts,
 }
 
-impl ListCommand {
-    pub fn name(&self) -> String {
-        "tcp-connection list".into()
-    }
+#[async_trait]
+impl Command for ListCommand {
+    const NAME: &'static str = "tcp-connection list";
 
-    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        let node =
-            BackgroundNodeClient::create(ctx, opts.state.clone(), &self.node_opts.at_node).await?;
-        let is_finished: Mutex<bool> = Mutex::new(false);
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        let node = BackgroundNodeClient::create(ctx, opts.state, &self.node_opts.at_node).await?;
+        let node_name = node.node_name();
 
-        let get_transports = async {
-            let transports: TransportStatusList =
-                node.ask(ctx, Request::get("/node/tcp/connection")).await?;
-            *is_finished.lock().await = true;
-            Ok(transports.0)
-        };
+        let spinner = opts.terminal.spinner();
+        if let Some(spinner) = &spinner {
+            spinner.set_message(format!(
+                "Listing TCP Connections at {}...",
+                color_primary(node_name)
+            ));
+        }
 
-        let output_messages = vec![format!(
-            "Listing TCP Connections on {}...\n",
-            node.node_name().color(OckamColor::PrimaryResource.color())
-        )];
+        let transports = Self::get_connection_list(ctx, &node).await?;
 
-        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
-
-        let (transports, _) = try_join!(get_transports, progress_output)?;
+        if let Some(spinner) = &spinner {
+            spinner.finish_and_clear();
+        }
 
         let list = opts.terminal.build_list(
             &transports,
-            &format!(
-                "No TCP Connections found on {}",
-                node.node_name().color(OckamColor::PrimaryResource.color())
-            ),
+            &format!("No TCP Connections found on {}", color_primary(node_name)),
         )?;
 
-        opts.terminal.to_stdout().plain(list).write_line()?;
+        opts.terminal
+            .to_stdout()
+            .plain(list)
+            .json_obj(transports)?
+            .write_line()?;
 
         Ok(())
+    }
+}
+
+impl ListCommand {
+    pub(super) async fn get_connection_list(
+        ctx: &Context,
+        node: &BackgroundNodeClient,
+    ) -> crate::Result<Vec<TransportStatus>> {
+        let transports: TransportStatusList =
+            node.ask(ctx, Request::get("/node/tcp/connection")).await?;
+        let mut transports = transports.0;
+        // Filter out the last Incoming connection, which is the one created by the current command execution
+        let self_transport = transports
+            .iter()
+            .rev()
+            .position(|t| t.tm == TransportMode::Incoming);
+        if let Some(rev_position) = self_transport {
+            let position = transports.len() - 1 - rev_position;
+            transports.remove(position);
+        }
+        Ok(transports)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
@@ -1,20 +1,24 @@
+use crate::node::NodeOpts;
+use crate::tui::{PluralTerm, ShowCommandTui};
+use crate::{docs, Command, CommandGlobalOpts};
+use async_trait::async_trait;
 use clap::Args;
-
-use colorful::Colorful;
+use console::Term;
+use miette::miette;
 use ockam::Context;
-use ockam_api::colors::color_primary;
 use ockam_api::nodes::models::transport::TransportStatus;
 use ockam_api::nodes::BackgroundNodeClient;
-use ockam_api::{fmt_log, fmt_ok};
+use ockam_api::output::Output;
+use ockam_api::terminal::{Terminal, TerminalStream};
 use ockam_core::api::Request;
-
-use crate::node::NodeOpts;
-use crate::{docs, CommandGlobalOpts};
+use ockam_core::TryClone;
+use std::net::SocketAddr;
+use std::str::FromStr;
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
 
-/// Show a TCP connection
+/// Show a TCP Connection
 #[derive(Clone, Debug, Args)]
 #[command(
 before_help = docs::before_help(PREVIEW_TAG),
@@ -23,52 +27,104 @@ pub struct ShowCommand {
     #[command(flatten)]
     pub node_opts: NodeOpts,
 
-    /// TCP connection internal address or socket address
-    pub address: String,
+    /// TCP Connection worker address or socket address
+    pub address: Option<String>,
 }
 
-impl ShowCommand {
-    pub fn name(&self) -> String {
-        "tcp-connection show".into()
+#[async_trait]
+impl Command for ShowCommand {
+    const NAME: &'static str = "tcp-connection show";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        Ok(ShowTui::run(ctx, opts, self.clone()).await?)
+    }
+}
+
+pub struct ShowTui {
+    pub ctx: Context,
+    pub opts: CommandGlobalOpts,
+    pub cmd: ShowCommand,
+    pub node: BackgroundNodeClient,
+}
+
+impl ShowTui {
+    pub async fn run(
+        ctx: &Context,
+        opts: CommandGlobalOpts,
+        mut cmd: ShowCommand,
+    ) -> miette::Result<()> {
+        let node =
+            BackgroundNodeClient::create(ctx, opts.state.clone(), &cmd.node_opts.at_node).await?;
+        cmd.node_opts.at_node = Some(node.node_name().to_string());
+
+        let tui = Self {
+            ctx: ctx.try_clone()?,
+            opts,
+            cmd,
+            node,
+        };
+
+        tui.show().await
+    }
+}
+
+#[async_trait]
+impl ShowCommandTui for ShowTui {
+    const ITEM_NAME: PluralTerm = PluralTerm::TcpConnection;
+
+    fn cmd_arg_item_name(&self) -> Option<String> {
+        self.cmd.address.clone()
     }
 
-    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        let node =
-            BackgroundNodeClient::create(ctx, opts.state.clone(), &self.node_opts.at_node).await?;
-        let transport_status: TransportStatus = node
+    fn node_name(&self) -> Option<&str> {
+        self.cmd.node_opts.at_node.as_deref()
+    }
+
+    fn terminal(&self) -> Terminal<TerminalStream<Term>> {
+        self.opts.terminal.clone()
+    }
+
+    async fn get_arg_item_name_or_default(&self) -> miette::Result<String> {
+        self.cmd
+            .address
+            .clone()
+            .ok_or(miette!("No TCP Connection address provided"))
+    }
+
+    async fn list_items_names(&self) -> miette::Result<Vec<String>> {
+        let transports = super::ListCommand::get_connection_list(&self.ctx, &self.node).await?;
+        let is_socket_address = self
+            .cmd
+            .address
+            .as_ref()
+            .map(|a| SocketAddr::from_str(a).is_ok())
+            .unwrap_or(false);
+        Ok(transports
+            .into_iter()
+            .map(|t| {
+                if is_socket_address {
+                    t.socket_address
+                } else {
+                    t.worker_address
+                }
+            })
+            .collect())
+    }
+
+    async fn show_single(&self, item_name: &str) -> miette::Result<()> {
+        let transport_status: TransportStatus = self
+            .node
             .ask(
-                ctx,
-                Request::get(format!("/node/tcp/connection/{}", &self.address)),
+                &self.ctx,
+                Request::get(format!("/node/tcp/connection/{item_name}")),
             )
             .await?;
-
-        opts.terminal
+        self.terminal()
             .to_stdout()
-            .plain(
-                fmt_ok!("TCP Connection:\n")
-                    + &fmt_log!(
-                        "  Type: {}\n",
-                        color_primary(transport_status.tt.to_string())
-                    )
-                    + &fmt_log!(
-                        "  Mode: {}\n",
-                        color_primary(transport_status.tm.to_string())
-                    )
-                    + &fmt_log!(
-                        "  Socket address: {}\n",
-                        color_primary(&transport_status.socket_addr)
-                    )
-                    + &fmt_log!(
-                        "  Processor address: {}\n",
-                        color_primary(&transport_status.processor_address)
-                    )
-                    + &fmt_log!(
-                        "  Flow Control Id: {}\n",
-                        color_primary(transport_status.flow_control_id.to_string())
-                    ),
-            )
+            .plain(transport_status.item()?)
+            .json_obj(&transport_status)?
+            .machine(&transport_status.worker_address)
             .write_line()?;
-
         Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/static/create/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/static/create/after_long_help.txt
@@ -1,7 +1,7 @@
 ```sh
-# To create a new TCP connection at the given address using the default node
+# To create a new TCP Connection at the given address using the default node
 $ ockam tcp-connection create --to 127.0.0.1:5000
 
-# To create a new TCP connection at the given address using a specific node
+# To create a new TCP Connection at the given address using a specific node
 $ ockam tcp-connection create --from n1 --to 127.0.0.1:5000
 ```

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/static/delete/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/static/delete/after_long_help.txt
@@ -1,10 +1,10 @@
 ```sh
-# To delete a TCP connection given its internal address on the default node
+# To delete a TCP Connection given its worker address on the default node
 $ ockam tcp-connection delete d59c01ab8d9683f8c454df746e627b43
 
-# To delete a TCP connection given its socket address on the default node
+# To delete a TCP Connection given its socket address on the default node
 $ ockam tcp-connection delete 127.0.0.1:5000
 
-# To delete a TCP connection given its internal address on a specific node
+# To delete a TCP Connection given its worker address on a specific node
 $ ockam tcp-connection delete d59c01ab8d9683f8c454df746e627b43 --at n1
 ```

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/static/list/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/static/list/after_long_help.txt
@@ -1,7 +1,7 @@
 ```sh
-# To list the TCP connections on the default node
+# To list the TCP Connections on the default node
 $ ockam tcp-connection list
 
-# To list the TCP connections on a specific node
+# To list the TCP Connections on a specific node
 $ ockam tcp-connection list --at n1
 ```

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/static/show/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/static/show/after_long_help.txt
@@ -1,7 +1,7 @@
 ```sh
-# To show a TCP connection given its internal address
+# To show a TCP Connection given its worker address
 $ ockam tcp-connection show d59c01ab8d9683f8c454df746e627b43
 
-# To show a TCP connection given its socket address
+# To show a TCP Connection given its socket address
 $ ockam tcp-connection show 127.0.0.1:5000
 ```

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -54,7 +54,7 @@ pub struct CreateCommand {
     #[arg(long, display_order = 900, id = "NODE_NAME", value_parser = extract_address_value)]
     pub at: Option<String>,
 
-    /// Address on which to accept InfluxDB connections, in the format `<scheme>://<hostname>:<port>`.
+    /// Address on which to accept TCP connections, in the format `<scheme>://<hostname>:<port>`.
     /// At least the port must be provided. The default scheme is `tcp` and the default hostname is `127.0.0.1`.
     /// If the argument is not set, a random port will be used on the default address.
     ///

--- a/implementations/rust/ockam/ockam_command/src/terminal/tui.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/tui.rs
@@ -83,8 +83,8 @@ pub trait ShowCommandTui {
                         self.show_single(item_name).await?;
                     }
                     _ => {
-                        for item_name in selected_item_names {
-                            if self.show_single(&item_name).await.is_err() {
+                        for (idx, item_name) in selected_item_names.iter().enumerate() {
+                            if self.show_single(item_name).await.is_err() {
                                 self.terminal()
                                     .to_stdout()
                                     .plain(fmt_warn!(
@@ -93,6 +93,9 @@ pub trait ShowCommandTui {
                                         color_primary(item_name)
                                     ))
                                     .write_line()?;
+                            }
+                            if idx < selected_item_names.len() - 1 {
+                                self.terminal().write_line("")?;
                             }
                         }
                     }
@@ -292,6 +295,7 @@ pub enum PluralTerm {
     ProjectAdmin,
     TcpInlet,
     TcpOutlet,
+    TcpConnection,
     KafkaInlet,
     KafkaOutlet,
     Policy,
@@ -311,6 +315,7 @@ impl PluralTerm {
             PluralTerm::ProjectAdmin => "project admin",
             PluralTerm::TcpInlet => "tcp inlet",
             PluralTerm::TcpOutlet => "tcp outlet",
+            PluralTerm::TcpConnection => "tcp connection",
             PluralTerm::KafkaInlet => "kafka inlet",
             PluralTerm::KafkaOutlet => "kafka outlet",
             PluralTerm::Policy => "policy",
@@ -330,6 +335,7 @@ impl PluralTerm {
             PluralTerm::ProjectAdmin => "project admins",
             PluralTerm::TcpInlet => "tcp inlets",
             PluralTerm::TcpOutlet => "tcp outlets",
+            PluralTerm::TcpConnection => "tcp connections",
             PluralTerm::KafkaInlet => "kafka inlets",
             PluralTerm::KafkaOutlet => "kafka outlets",
             PluralTerm::Policy => "policies",

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/tcp.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/tcp.bats
@@ -16,28 +16,33 @@ teardown() {
 
 @test "tcp connection - CRUD" {
   port="$(random_port)"
-  addr="127.0.0.1:$port"
-  run_success "$OCKAM" node create n1 --tcp-listener-address "$addr"
+  run_success "$OCKAM" node create n1 --tcp-listener-address "127.0.0.1:$port"
 
   # Create tcp-connection and check output
-  run_success "$OCKAM" tcp-connection create --from n1 --to "$addr" --output json
-  assert_output --partial "n1"
-  assert_output --partial $addr
+  addr=$("$OCKAM" tcp-connection create --from n1 --to "127.0.0.1:$port")
 
   # Check that the connection is listed
-  run_success "$OCKAM" tcp-connection list --at n1
+  run_success "$OCKAM" tcp-connection list --at n1 --output json
   assert_output --partial "$addr"
+  assert_output --partial "127.0.0.1:$port"
 
   # Show the connection details
-  run_success "$OCKAM" tcp-connection show --at n1 "$addr"
+  run_success "$OCKAM" tcp-connection show --at n1 "$addr" --output json
   assert_output --partial "$addr"
+  assert_output --partial "127.0.0.1:$port"
+
+  # It also works passing the socket address
+  run_success "$OCKAM" tcp-connection show --at n1 "127.0.0.1:$port" --output json
+  assert_output --partial "$addr"
+  assert_output --partial "127.0.0.1:$port"
 
   # Delete the connection
   run_success "$OCKAM" tcp-connection delete --at n1 "$addr" --yes
 
   # Check that it's no longer listed
-  run_success "$OCKAM" tcp-connection list --at n1
+  run_success "$OCKAM" tcp-connection list --at n1 --output json
   refute_output --partial "$addr"
+  refute_output --partial "127.0.0.1:$port"
 }
 
 @test "tcp listener - CRUD" {


### PR DESCRIPTION
Follow up of https://github.com/build-trust/ockam/pull/8867

- Use the same output structure on show/delete/list. 
- Add interactive behavior to show/delete

![image](https://github.com/user-attachments/assets/47c90aa2-8f6b-447c-8fbe-4ca273c05f5f)
