### PR TITLE
feat(rust): unify output of show/list portals commands

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/tcp_portals_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/tcp_portals_repository_sql.rs
@@ -108,7 +108,7 @@ impl TcpPortalsRepository for TcpPortalsSqlxDatabase {
         )
         .bind(node_name)
         .bind(tcp_outlet_status.to.to_string())
-        .bind(tcp_outlet_status.worker_addr.to_string())
+        .bind(tcp_outlet_status.worker_address.to_string())
         .bind(tcp_outlet_status.payload.as_ref())
         .bind(tcp_outlet_status.privileged);
         query.execute(&*self.database.pool).await.void()?;
@@ -189,10 +189,10 @@ impl TcpOutletStatusRow {
     fn tcp_outlet_status(&self) -> Result<OutletStatus> {
         let to = HostnamePort::from_str(&self.socket_addr)
             .map_err(|e| Error::new(Origin::Application, Kind::Serialization, e.to_string()))?;
-        let worker_addr = Address::from_string(&self.worker_addr);
+        let worker_address = Address::from_string(&self.worker_addr);
         Ok(OutletStatus {
             to,
-            worker_addr,
+            worker_address,
             payload: self.payload.clone(),
             privileged: self.privileged.to_bool(),
         })

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/outlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/outlet.rs
@@ -70,7 +70,7 @@ impl From<crate::nodes::models::portal::OutletStatus> for OutletStatus {
                 hostname: status.to.hostname,
                 port: status.to.port,
             },
-            address: status.worker_addr.address().to_string(),
+            address: status.worker_address.address().to_string(),
             privileged: status.privileged,
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/multiaddr_resolver/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/multiaddr_resolver/mod.rs
@@ -1,6 +1,7 @@
 mod local_resolver;
 mod remote_resolver;
 mod reverse_local_converter;
+mod serde_utils;
 mod transport_route_resolver;
 
 pub use local_resolver::*;
@@ -9,6 +10,7 @@ use ockam_core::Error;
 use ockam_multiaddr::MultiAddr;
 pub use remote_resolver::*;
 pub use reverse_local_converter::*;
+pub use serde_utils::*;
 pub use transport_route_resolver::*;
 
 fn invalid_multiaddr_error(ma: &MultiAddr) -> Error {

--- a/implementations/rust/ockam/ockam_api/src/multiaddr_resolver/serde_utils.rs
+++ b/implementations/rust/ockam/ockam_api/src/multiaddr_resolver/serde_utils.rs
@@ -1,0 +1,86 @@
+use crate::{LocalMultiaddrResolver, ReverseLocalConverter};
+use ockam_core::Address;
+use ockam_multiaddr::MultiAddr;
+use serde::{Deserialize, Deserializer, Serializer};
+use std::str::FromStr;
+
+pub fn serialize_address_as_local_service<S>(
+    address: &Address,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let ma = ReverseLocalConverter::convert_address(address)
+        .map_err(|e| serde::ser::Error::custom(e.to_string()))?;
+    serializer.serialize_str(&ma.to_string())
+}
+
+pub fn deserialize_address_from_local_service<'de, D>(deserializer: D) -> Result<Address, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let service_str = String::deserialize(deserializer)?;
+    let multiaddr = MultiAddr::from_str(&service_str)
+        .map_err(|e| serde::de::Error::custom(format!("Invalid MultiAddr: {}", e)))?;
+
+    let route = LocalMultiaddrResolver::resolve(&multiaddr)
+        .map_err(|e| serde::de::Error::custom(e.to_string()))?;
+    let address = route
+        .next()
+        .map_err(|e| serde::de::Error::custom(e.to_string()))?;
+    Ok(address.clone())
+}
+
+#[cfg(test)]
+mod tests_serde_address_as_local_service {
+    use super::*;
+    use ockam_core::Address;
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct TestStruct {
+        #[serde(serialize_with = "serialize_address_as_local_service")]
+        #[serde(deserialize_with = "deserialize_address_from_local_service")]
+        address: Address,
+    }
+
+    #[test]
+    fn test_serialize_address() {
+        let address = Address::from_str("test_worker").unwrap();
+        let test_struct = TestStruct { address };
+
+        let serialized = serde_json::to_value(test_struct).unwrap();
+
+        let expected_multiaddr = "/service/test_worker";
+        assert_eq!(serialized["address"], json!(expected_multiaddr));
+    }
+
+    #[test]
+    fn test_deserialize_address() {
+        let json_value = json!({
+            "address": "/service/test_worker"
+        });
+
+        let deserialized: TestStruct = serde_json::from_value(json_value).unwrap();
+
+        assert_eq!(
+            deserialized.address,
+            Address::from_str("test_worker").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_deserialize_invalid_multiaddr() {
+        let json_value = json!({
+            "address": "invalid-multiaddr"
+        });
+
+        let result: Result<TestStruct, _> = serde_json::from_value(json_value);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Invalid MultiAddr"));
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -6,6 +6,9 @@ use std::time::Duration;
 
 use crate::colors::{color_primary, color_primary_alt};
 use crate::error::ApiError;
+use crate::multiaddr_resolver::{
+    deserialize_address_from_local_service, serialize_address_as_local_service,
+};
 use crate::output::Output;
 use crate::session::connection_status::ConnectionStatus;
 use crate::terminal::fmt;
@@ -303,13 +306,19 @@ impl InletStatus {
 }
 
 impl Display for InletStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         writeln!(
             f,
-            "Inlet {} at {} is {}",
+            "TCP Inlet {} at {} is {}",
             color_primary(&self.alias),
             color_primary(&self.bind_addr),
             self.status,
+        )?;
+        writeln!(
+            f,
+            "{}With outlet address {}",
+            fmt::INDENTATION,
+            color_primary(&self.outlet_addr)
         )?;
         if let Some(r) = self
             .outlet_route
@@ -319,21 +328,15 @@ impl Display for InletStatus {
         {
             writeln!(
                 f,
-                "{}With route to outlet {}",
+                "{}And service route {}",
                 fmt::INDENTATION,
                 color_primary(r.to_string())
             )?;
         }
-        writeln!(
-            f,
-            "{}Outlet Address: {}",
-            fmt::INDENTATION,
-            color_primary(&self.outlet_addr)
-        )?;
         if self.privileged {
             writeln!(
                 f,
-                "{}This Inlet is operating in {} mode",
+                "{}Operating in {} mode",
                 fmt::INDENTATION,
                 color_primary_alt("privileged".to_string())
             )?;
@@ -369,7 +372,9 @@ impl Decodable for InletStatusList {
 #[cbor(map)]
 pub struct OutletStatus {
     #[n(1)] pub to: HostnamePort,
-    #[n(2)] pub worker_addr: Address,
+    #[serde(serialize_with = "serialize_address_as_local_service")]
+    #[serde(deserialize_with = "deserialize_address_from_local_service")]
+    #[n(2)] pub worker_address: Address,
     /// An optional status payload
     #[n(3)] pub payload: Option<String>,
     #[n(4)] pub privileged: bool,
@@ -390,27 +395,27 @@ impl Decodable for OutletStatus {
 impl OutletStatus {
     pub fn new(
         to: HostnamePort,
-        worker_addr: Address,
+        worker_address: Address,
         payload: impl Into<Option<String>>,
         privileged: bool,
     ) -> Self {
         Self {
             to,
-            worker_addr,
+            worker_address,
             payload: payload.into(),
             privileged,
         }
     }
 
     pub fn worker_route(&self) -> Result<MultiAddr, ockam_core::Error> {
-        ReverseLocalConverter::convert_address(&self.worker_addr)
+        ReverseLocalConverter::convert_address(&self.worker_address)
     }
 
     pub fn worker_name(&self) -> Result<String, ockam_core::Error> {
         match self.worker_route()?.last() {
             Some(worker_name) => String::from_utf8(worker_name.data().to_vec())
                 .map_err(|_| ApiError::core("Invalid Worker Address")),
-            None => Ok(self.worker_addr.to_string()),
+            None => Ok(self.worker_address.to_string()),
         }
     }
 }
@@ -419,7 +424,7 @@ impl Display for OutletStatus {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Outlet at {} is connected to {}",
+            "TCP Outlet at {} is connected to {}",
             color_primary(
                 self.worker_route()
                     .map_err(|_| std::fmt::Error)?
@@ -431,7 +436,7 @@ impl Display for OutletStatus {
         if self.privileged {
             writeln!(
                 f,
-                "{}This Outlet is operating in {} mode",
+                "{}Operating in {} mode",
                 fmt::INDENTATION,
                 color_primary_alt("privileged".to_string())
             )?;

--- a/implementations/rust/ockam/ockam_api/tests/portals.rs
+++ b/implementations/rust/ockam/ockam_api/tests/portals.rs
@@ -42,7 +42,7 @@ async fn inlet_outlet_local_successful(context: &mut Context) -> ockam::Result<(
         .await?;
 
     assert_eq!(outlet_status.to, echo_server_handle.chosen_addr);
-    assert_eq!(outlet_status.worker_addr.address(), "outlet");
+    assert_eq!(outlet_status.worker_address.address(), "outlet");
 
     let inlet_status = node_manager_handle
         .node_manager

--- a/implementations/rust/ockam/ockam_app_lib/src/invitations/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/invitations/commands.rs
@@ -196,7 +196,7 @@ impl AppState {
 
         let to = outlets
             .into_iter()
-            .find(|o| &o.worker_addr == outlet_worker_addr)
+            .find(|o| &o.worker_address == outlet_worker_addr)
             .map(|o| o.to);
 
         if let Some(to) = to {

--- a/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/state.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/state.rs
@@ -13,7 +13,8 @@ impl ModelState {
     }
 
     pub fn delete_tcp_outlet(&mut self, worker_addr: &Address) {
-        self.tcp_outlets.retain(|x| &x.worker_addr != worker_addr);
+        self.tcp_outlets
+            .retain(|x| &x.worker_address != worker_addr);
     }
 
     pub fn get_tcp_outlets(&self) -> &[OutletStatus] {
@@ -37,14 +38,14 @@ impl AppState {
         let context = self.context();
         for tcp_outlet in self.model(|m| m.get_tcp_outlets().to_vec()).await {
             let access_control = match self
-                .create_invitations_access_control(tcp_outlet.worker_addr.clone())
+                .create_invitations_access_control(tcp_outlet.worker_address.clone())
                 .await
             {
                 Ok(a) => a,
                 Err(e) => {
                     error!(
                         ?e,
-                        worker_addr = %tcp_outlet.worker_addr,
+                        worker_addr = %tcp_outlet.worker_address,
                         "Failed to create access control"
                     );
                     continue;
@@ -57,20 +58,20 @@ impl AppState {
                 Err(e) => {
                     error!(
                         ?e,
-                        worker_addr = %tcp_outlet.worker_addr,
+                        worker_addr = %tcp_outlet.worker_address,
                         "Failed to create access control"
                     );
                     continue;
                 }
             };
 
-            debug!(worker_addr = %tcp_outlet.worker_addr, "Restoring outlet");
+            debug!(worker_addr = %tcp_outlet.worker_address, "Restoring outlet");
             let _ = node_manager
                 .create_outlet(
                     &context,
                     tcp_outlet.to,
                     false,
-                    Some(tcp_outlet.worker_addr.clone()),
+                    Some(tcp_outlet.worker_address.clone()),
                     true,
                     OutletAccessControl::AccessControl((
                         Arc::new(incoming_ac),
@@ -84,7 +85,7 @@ impl AppState {
                 .map_err(|e| {
                     error!(
                         ?e,
-                        worker_addr = %tcp_outlet.worker_addr,
+                        worker_addr = %tcp_outlet.worker_address,
                         "Failed to restore outlet"
                     );
                 });

--- a/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
@@ -518,7 +518,7 @@ impl AppState {
                 .await
                 .into_iter()
                 .map(|outlet| LocalService {
-                    name: outlet.worker_addr.address().to_string(),
+                    name: outlet.worker_address.address().to_string(),
                     address: outlet.to.hostname().to_string(),
                     port: outlet.to.port(),
                     scheme: None,

--- a/implementations/rust/ockam/ockam_app_lib/src/state/model_state_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/model_state_repository_sql.rs
@@ -58,7 +58,7 @@ impl ModelStateRepository for ModelStateSqlxDatabase {
             )
             .bind(node_name)
             .bind(tcp_outlet_status.to.to_string())
-            .bind(tcp_outlet_status.worker_addr.to_string())
+            .bind(tcp_outlet_status.worker_address.to_string())
             .bind(tcp_outlet_status.payload.as_ref())
             .bind(tcp_outlet_status.privileged);
             query.execute(&mut *transaction).await.void()?;
@@ -129,7 +129,7 @@ impl TcpOutletStatusRow {
         let worker_addr = Address::from_string(&self.worker_addr);
         Ok(OutletStatus {
             to,
-            worker_addr,
+            worker_address: worker_addr,
             payload: self.payload.to_option(),
             privileged: self.privileged.to_bool(),
         })

--- a/implementations/rust/ockam/ockam_command/src/influxdb/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/outlet/create.rs
@@ -136,15 +136,17 @@ impl Command for CreateCommand {
             .await?
         };
 
+        let worker_route = outlet_status.worker_route()?;
+
         opts.terminal
             .to_stdout()
             .plain(fmt_ok!(
                 "Created a new InfluxDB Outlet in the Node {} at {} bound to {}\n\n",
                 color_primary(node.node_name()),
-                color_primary(&outlet_status.worker_addr),
+                color_primary(worker_route.to_string()),
                 color_primary(&cmd.to)
             ))
-            .machine(&outlet_status.worker_addr)
+            .machine(&worker_route)
             .json_obj(&outlet_status)?
             .write_line()?;
         Ok(())

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
@@ -31,7 +31,7 @@ impl ListCommand {
         let inlets: InletStatusList = {
             let pb = opts.terminal.spinner();
             if let Some(pb) = pb.as_ref() {
-                pb.set_message(format!("Listing TCP Inlets on {}...", node.node_name()));
+                pb.set_message(format!("Listing TCP Inlets at {}...", node.node_name()));
             }
             node.ask(ctx, Request::get("/node/inlet")).await?
         };
@@ -39,7 +39,7 @@ impl ListCommand {
 
         let plain = opts.terminal.build_list(
             &inlets,
-            &format!("No TCP Inlets found on {}", node.node_name()),
+            &format!("No TCP Inlets found at {}", node.node_name()),
         )?;
         opts.terminal
             .to_stdout()

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -129,7 +129,7 @@ impl Command for CreateCommand {
 
         if cmd.privileged {
             msg += &fmt_info!(
-                "This Outlet is operating in {} mode\n",
+                "This TCP Outlet is operating in {} mode\n",
                 color_primary_alt("privileged".to_string())
             );
         }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -109,7 +109,7 @@ impl DeleteCommandTui for DeleteTui {
         let items_names: Vec<String> = res
             .0
             .iter()
-            .map(|outlet| outlet.worker_addr.address().to_string())
+            .map(|outlet| outlet.worker_address.address().to_string())
             .collect();
         Ok(items_names)
     }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
@@ -1,9 +1,5 @@
 use clap::Args;
-use colorful::Colorful;
 use ockam_api::colors::color_primary;
-use ockam_api::fmt_info;
-use tokio::sync::Mutex;
-use tokio::try_join;
 
 use crate::node::NodeOpts;
 use crate::{docs, CommandGlobalOpts};
@@ -36,50 +32,33 @@ impl ListCommand {
     pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
         let node = BackgroundNodeClient::create(ctx, &opts.state, &self.node_opts.at_node).await?;
 
-        let is_finished: Mutex<bool> = Mutex::new(false);
+        let spinner = opts.terminal.spinner();
+        if let Some(spinner) = &spinner {
+            spinner.set_message(format!(
+                "Listing TCP Outlets at {}...",
+                color_primary(node.node_name())
+            ));
+        }
 
-        let send_req = async {
-            let res: OutletStatusList = node.ask(ctx, Request::get("/node/outlet")).await?;
-            *is_finished.lock().await = true;
-            Ok(res)
-        };
-
-        let output_messages = vec![format!(
-            "Listing TCP Outlets on node {}...\n",
-            color_primary(node.node_name())
-        )];
-
-        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
-
-        let (outlets, _) = try_join!(send_req, progress_output)?;
+        let outlets: OutletStatusList = node.ask(ctx, Request::get("/node/outlet")).await?;
         let outlets = outlets.0;
 
-        let list: String = {
-            let empty_message = fmt_info!(
-                "No TCP Outlets found on node {}",
-                color_primary(node.node_name())
-            );
-            match outlets.is_empty() {
-                true => empty_message,
-                false => opts.terminal.build_list(&outlets, &empty_message)?,
-            }
-        };
+        if let Some(spinner) = &spinner {
+            spinner.finish_and_clear();
+        }
 
-        let json: Vec<_> = outlets
-            .iter()
-            .map(|outlet| {
-                Ok(serde_json::json!({
-                    "from": outlet.worker_route()?,
-                    "to": outlet.to,
-                }))
-            })
-            .flat_map(|res: Result<_, ockam_core::Error>| res.ok())
-            .collect();
+        let list = opts.terminal.build_list(
+            &outlets,
+            &format!(
+                "No TCP Outlets found at {}",
+                color_primary(node.node_name())
+            ),
+        )?;
 
         opts.terminal
             .to_stdout()
             .plain(list)
-            .json(serde_json::json!(json))
+            .json_obj(outlets)?
             .write_line()?;
 
         Ok(())

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -1,10 +1,8 @@
 use async_trait::async_trait;
-use core::fmt::Write;
 
 use clap::Args;
 use console::Term;
 use miette::{miette, IntoDiagnostic};
-use serde::Serialize;
 
 use ockam::Context;
 use ockam_api::nodes::models::portal::OutletStatusList;
@@ -13,7 +11,6 @@ use ockam_api::terminal::{Terminal, TerminalStream};
 use ockam_api::{address::extract_address_value, nodes::models::portal::OutletStatus};
 use ockam_core::api::Request;
 use ockam_core::TryClone;
-use ockam_multiaddr::MultiAddr;
 
 use crate::tcp::util::alias_parser;
 use crate::{docs, Command, CommandGlobalOpts};
@@ -48,24 +45,6 @@ impl Command for ShowCommand {
 
     async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
         Ok(ShowTui::run(ctx.try_clone().into_diagnostic()?, opts, self.clone()).await?)
-    }
-}
-
-#[derive(Debug, Serialize)]
-struct OutletInformation {
-    node_name: String,
-    worker_address: MultiAddr,
-    to: String,
-}
-
-impl Output for OutletInformation {
-    fn item(&self) -> ockam_api::Result<String> {
-        let mut w = String::new();
-        write!(w, "Outlet")?;
-        write!(w, "\n  On Node: {}", self.node_name)?;
-        write!(w, "\n  From address: {}", self.worker_address)?;
-        write!(w, "\n  To TCP server: {}", self.to)?;
-        Ok(w)
     }
 }
 
@@ -127,7 +106,7 @@ impl ShowCommandTui for ShowTui {
         let items_names: Vec<String> = outlets
             .0
             .into_iter()
-            .map(|outlet| outlet.worker_addr.address().to_string())
+            .map(|outlet| outlet.worker_address.address().to_string())
             .collect();
         Ok(items_names)
     }
@@ -137,15 +116,10 @@ impl ShowCommandTui for ShowTui {
             .node
             .ask(&self.ctx, Request::get(format!("/node/outlet/{item_name}")))
             .await?;
-        let info = OutletInformation {
-            node_name: self.node.node_name().to_string(),
-            worker_address: outlet_status.worker_route().into_diagnostic()?,
-            to: outlet_status.to.to_string(),
-        };
         self.terminal()
             .to_stdout()
-            .plain(info.item()?)
-            .json_obj(info)?
+            .plain(outlet_status.item()?)
+            .json_obj(outlet_status)?
             .write_line()?;
         Ok(())
     }


### PR DESCRIPTION
- Use same output struct in `tcp-outlet show/list` commands
- Add custom serde methods for the outlet status address to serialize it as a multiaddr route (to keep the existing functionality while using a struct with typed addresses, instead of the [ad-hoc struct](https://github.com/build-trust/ockam/pull/8871/files#diff-110572d0ecb5099ab054d64a4f0a69555dcf8bb5ac454f7673aed15c4664a360L61) with strings)

