### PR TITLE
feat(rust): node http api portal endpoints args refinement

### DIFF
--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -121,7 +121,7 @@ tracing-error = "0.2.0"
 tracing-opentelemetry = "0.28"
 tracing-subscriber = { version = "0.3", features = ["json"] }
 url = "2.5.2"
-utoipa = { version = "^5.3", features = ["yaml", "openapi_extensions"] }
+utoipa = { version = "^5.3", features = ["yaml", "openapi_extensions", "non_strict_integers"] }
 
 ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.70.0", features = ["cbor", "serde"] }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.103.0" }

--- a/implementations/rust/ockam/ockam_api/src/address.rs
+++ b/implementations/rust/ockam/ockam_api/src/address.rs
@@ -1,11 +1,11 @@
-use std::net::{SocketAddr, TcpListener};
-use std::str::FromStr;
-
+use crate::error::ApiError;
+use crate::CliState;
+use miette::miette;
 use ockam_core::Result;
 use ockam_multiaddr::proto::{Node, Project, Service};
 use ockam_multiaddr::{MultiAddr, Protocol};
-
-use crate::error::ApiError;
+use std::net::{SocketAddr, TcpListener};
+use std::str::FromStr;
 
 /// Get address value from a string.
 ///
@@ -49,6 +49,32 @@ pub fn extract_address_value(input: &str) -> Result<String, ApiError> {
         )));
     }
     Ok(addr)
+}
+
+/// Replace the node's name with its address or leave it if it's another type of address.
+///
+/// Example:
+///     if n1 has address of 127.0.0.1:1234
+///     `/node/n1` -> `/ip4/127.0.0.1/tcp/1234`
+pub async fn process_nodes_multiaddr(
+    addr: &MultiAddr,
+    cli_state: &CliState,
+) -> miette::Result<MultiAddr> {
+    let mut processed_addr = MultiAddr::default();
+    for proto in addr.iter() {
+        match proto.code() {
+            Node::CODE => {
+                let alias = proto
+                    .cast::<Node>()
+                    .ok_or_else(|| miette!("Invalid node address protocol"))?;
+                let node_info = cli_state.get_node(&alias).await?;
+                let addr = node_info.tcp_listener_multi_address()?;
+                processed_addr.try_extend(&addr)?
+            }
+            _ => processed_addr.push_back_value(&proto)?,
+        }
+    }
+    Ok(processed_addr)
 }
 
 pub fn get_free_address() -> Result<SocketAddr, ApiError> {

--- a/implementations/rust/ockam/ockam_api/src/common_api/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/common_api/mod.rs
@@ -1,0 +1,4 @@
+//! This module contains logic shared between Ockam's various APIs,
+//! such as the control HTTP API and the Command.
+
+pub mod tcp_inlet_create;

--- a/implementations/rust/ockam/ockam_api/src/common_api/tcp_inlet_create.rs
+++ b/implementations/rust/ockam/ockam_api/src/common_api/tcp_inlet_create.rs
@@ -1,0 +1,192 @@
+use crate::address::process_nodes_multiaddr;
+use crate::{CliState, DefaultAddress, ParseError};
+use miette::IntoDiagnostic;
+use ockam_multiaddr::{proto, MultiAddr, Protocol};
+use std::str::FromStr;
+
+pub fn tcp_inlet_default_to_address() -> String {
+    "/project/<default_project_name>/service/forward_to_<default_relay_name>/secure/api/service/<default_service_name>".to_string()
+}
+
+pub async fn parse_to_address(
+    state: &CliState,
+    to: impl Into<String>,
+    via: Option<&String>,
+) -> miette::Result<String> {
+    let mut to = to.into();
+    let to_is_default = to == tcp_inlet_default_to_address();
+    let mut service_name = DefaultAddress::OUTLET_SERVICE.to_string();
+    let relay_name = via.cloned().unwrap_or("default".to_string());
+
+    match MultiAddr::from_str(&to) {
+        // "to" is a valid multiaddr
+        Ok(route) => {
+            // check whether it's a full route or a single service
+            let protos = route.iter().collect::<Vec<_>>();
+            if let Some(proto) = protos.first() {
+                // "to" refers to the service name
+                if proto.code() == proto::Service::CODE && protos.len() == 1 {
+                    service_name = proto
+                        .cast::<proto::Service>()
+                        .ok_or_else(|| ParseError::validation("to", via, None))?
+                        .to_string();
+
+                    // if "via" is passed, then we reset "to" to the default value
+                    if via.is_some() {
+                        to = tcp_inlet_default_to_address();
+                    }
+                }
+                // "to" is a full route
+                else {
+                    // "via" can't be passed if the user provides a value for "to"
+                    if !to_is_default && via.is_some() {
+                        return Err(ParseError::validation(
+                            "to",
+                            via,
+                            Some("'via' can't be used if 'to' is a full route"),
+                        ))?;
+                    }
+                }
+            }
+        }
+        // If it's not
+        Err(_) => {
+            // "to" refers to the service name
+            service_name = to.to_string();
+            // and we set "to" to the default route, so we can do the replacements later
+            to = tcp_inlet_default_to_address();
+        }
+    }
+
+    // Replace the placeholders
+    if to.contains("<default_project_name>") {
+        let project_name = state
+            .projects()
+            .get_default_project()
+            .await
+            .map(|p| p.name().to_string())
+            .ok()
+            .ok_or(ParseError::validation("to", via, Some("No projects found")))?;
+        to = to.replace("<default_project_name>", &project_name);
+    }
+    to = to.replace("<default_relay_name>", &relay_name);
+    to = to.replace("<default_service_name>", &service_name);
+
+    // Parse "to" as a multiaddr again with all the values in place
+    let to = MultiAddr::from_str(&to).into_diagnostic()?;
+    Ok(process_nodes_multiaddr(&to, state).await?.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::lookup::InternetAddress;
+    use crate::orchestrator::project::models::ProjectModel;
+    use crate::orchestrator::project::Project;
+    use ockam::identity::Identifier;
+    use std::str::FromStr;
+
+    #[tokio::test]
+    async fn test_parse_to_address() {
+        let state = CliState::test().await.unwrap();
+        setup_state(&state).await;
+
+        let node_name = "n1";
+        let node_port = state
+            .get_node(node_name)
+            .await
+            .unwrap()
+            .tcp_listener_port()
+            .unwrap();
+
+        // Invalid "to" values throw an error
+        let cases = ["/alice/service", "alice/relay"];
+        for to in cases {
+            parse_to_address(&state, to, None)
+                .await
+                .expect_err("Invalid multiaddr");
+        }
+
+        // "to" with default value expands the placeholders
+        let res = parse_to_address(&state, tcp_inlet_default_to_address(), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            res,
+            "/project/p1/service/forward_to_default/secure/api/service/outlet".to_string()
+        );
+
+        // "to" argument accepts a full route
+        let cases = [
+            ("/project/p2/service/forward_to_n1/secure/api/service/myoutlet", None),
+            ("/worker/603b62d245c9119d584ba3d874eb8108/service/forward_to_n3/service/hop/service/outlet", None),
+            (&format!("/node/{node_name}/service/myoutlet"), Some(format!("/ip4/127.0.0.1/tcp/{node_port}/service/myoutlet"))),
+        ];
+        for (to, expected) in cases {
+            let res = parse_to_address(&state, to, None).await.unwrap();
+            let expected = expected.unwrap_or(to.to_string());
+            assert_eq!(res, expected);
+        }
+
+        // "to" argument accepts the name of the service
+        let res = parse_to_address(&state, "myoutlet", None).await.unwrap();
+        assert_eq!(
+            res,
+            "/project/p1/service/forward_to_default/secure/api/service/myoutlet".to_string()
+        );
+
+        // "via" argument is used to replace the relay name, and "to" is a service name
+        let cases = [
+            (
+                tcp_inlet_default_to_address(),
+                "myrelay",
+                "/project/p1/service/forward_to_myrelay/secure/api/service/outlet",
+            ),
+            (
+                "myoutlet".to_string(),
+                "myrelay",
+                "/project/p1/service/forward_to_myrelay/secure/api/service/myoutlet",
+            ),
+            (
+                "/service/myoutlet".to_string(),
+                "myrelay",
+                "/project/p1/service/forward_to_myrelay/secure/api/service/myoutlet",
+            ),
+        ];
+        for (to, via, expected) in cases {
+            let res = parse_to_address(&state, &to, Some(&via.to_string()))
+                .await
+                .unwrap();
+            assert_eq!(res, expected.to_string());
+        }
+
+        // if "to" is passed as a full route and also "via" is passed, return an error
+        let to = "/project/p1/service/forward_to_n1/secure/api/service/outlet";
+        parse_to_address(&state, to, Some(&"myrelay".to_string()))
+            .await
+            .expect_err("'via' can't be passed if 'to' is a full route");
+    }
+
+    // UTILS
+
+    async fn setup_state(state: &CliState) {
+        let project = ProjectModel {
+            identity: Some(
+                Identifier::from_str(
+                    "Ie92f183eb4c324804ef4d62962dea94cf095a265a1b2c3d4e5f6a6b5c4d3e2f1",
+                )
+                .unwrap(),
+            ),
+            name: "p1".to_string(),
+            ..Default::default()
+        };
+        let project = Project::import(project).await.unwrap();
+        state.projects().store_project(project).await.unwrap();
+
+        state.create_node("n1").await.unwrap();
+        state
+            .set_tcp_listener_address("n1", &InternetAddress::new("127.0.0.1:1234").unwrap())
+            .await
+            .unwrap();
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/control_api/backend/authority_member.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/backend/authority_member.rs
@@ -153,8 +153,8 @@ async fn handle_authority_member_list(
 #[utoipa::path(
     get,
     operation_id = "get_authority_member",
-    summary = "Get Authority Member",
-    description = "Get the specified member of the Authority by identity.",
+    summary = "Get an Authority Member",
+    description = "Get an Authority Member given its identity.",
     path = "/{node}/authority-members/{member}",
     tags = ["Authority Members"],
     responses(
@@ -207,7 +207,7 @@ async fn handle_authority_member_get(
     delete,
     operation_id = "remove_authority_member",
     summary = "Remove an Authority Member",
-    description = "Remove the specified member of the Authority by identity.",
+    description = "Remove an Authority Member given its identity.",
     path = "/{node}/authority-members/{member}",
     tags = ["Authority Members"],
     responses(

--- a/implementations/rust/ockam/ockam_api/src/control_api/backend/entrypoint.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/backend/entrypoint.rs
@@ -139,7 +139,7 @@ impl Worker for HttpControlNodeApiBackend {
                         );
                         response
                     }
-                    ControlApiError::OckamError(error) => {
+                    ControlApiError::Ockam(error) => {
                         warn!(
                             "The API {} {} failed with an expected error: {error:?}",
                             request.method, request.uri

--- a/implementations/rust/ockam/ockam_api/src/control_api/backend/inlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/backend/inlet.rs
@@ -54,7 +54,7 @@ impl HttpControlNodeApiBackend {
 #[utoipa::path(
     post,
     operation_id = "create_tcp_inlet",
-    summary = "Create a new TCP Inlet",
+    summary = "Create a TCP Inlet",
     description =
 "The main parameters are the destination `to`, and the bind address `from`.
 You can also attach a TLS certificate in the `tls` object, restrict access to the TCP Inlet with
@@ -337,7 +337,7 @@ async fn handle_tcp_inlet_get(
 #[cfg(test)]
 mod test {
     use crate::control_api::http::{ControlApiHttpRequest, ControlApiHttpResponse};
-    use crate::control_api::protocol::common::{ConnectionStatus, ErrorResponse, HostPort};
+    use crate::control_api::protocol::common::{ConnectionStatus, ErrorResponse, HostPortRequest};
     use crate::control_api::protocol::inlet::{CreateInletRequest, InletStatus};
     use crate::orchestrator::project::models::ProjectModel;
     use crate::orchestrator::project::Project;
@@ -366,7 +366,7 @@ mod test {
                     name: Some("inlet-name".to_string()),
                     kind: Default::default(),
                     tls: Default::default(),
-                    from: HostPort {
+                    from: HostPortRequest {
                         host: "127.0.0.1".to_string(),
                         port: 0,
                     },
@@ -393,11 +393,10 @@ mod test {
         let inlet_status: InletStatus = serde_json::from_slice(response.body.as_slice()).unwrap();
         assert_eq!(inlet_status.name, "inlet-name");
         assert_eq!(inlet_status.status, ConnectionStatus::Down);
-        assert_eq!(inlet_status.current_route, None);
+        assert_eq!(inlet_status.internal_route, None);
         assert_eq!(inlet_status.to, "/service/outlet");
-        let bind_address = HostPort::try_from(inlet_status.bind_address.as_str())?;
-        assert_eq!(bind_address.host, "127.0.0.1");
-        assert!(bind_address.port > 0);
+        assert_eq!(inlet_status.bind_address.host, "127.0.0.1");
+        assert!(inlet_status.bind_address.port > 0);
 
         tokio::time::sleep(Duration::from_millis(100)).await;
 
@@ -418,7 +417,7 @@ mod test {
         let inlet_status: InletStatus = serde_json::from_slice(response.body.as_slice()).unwrap();
         assert_eq!(inlet_status.name, "inlet-name");
         assert_eq!(inlet_status.status, ConnectionStatus::Up);
-        assert_eq!(inlet_status.current_route, Some("0#outlet".to_string()));
+        assert_eq!(inlet_status.internal_route, Some("0#outlet".to_string()));
         assert_eq!(inlet_status.to, "/service/outlet");
 
         let request = ControlApiHttpRequest {
@@ -439,7 +438,7 @@ mod test {
         assert_eq!(inlets.len(), 1);
         assert_eq!(inlets[0].name, "inlet-name");
         assert_eq!(inlets[0].status, ConnectionStatus::Up);
-        assert_eq!(inlets[0].current_route, Some("0#outlet".to_string()));
+        assert_eq!(inlets[0].internal_route, Some("0#outlet".to_string()));
         assert_eq!(inlets[0].to, "/service/outlet");
 
         let request = ControlApiHttpRequest {
@@ -529,7 +528,7 @@ mod test {
                     name: Some("inlet-name".to_string()),
                     kind: Default::default(),
                     tls: Default::default(),
-                    from: HostPort {
+                    from: HostPortRequest {
                         host: "127.0.0.1".to_string(),
                         port: 0,
                     },
@@ -555,14 +554,13 @@ mod test {
         let inlet_status: InletStatus = serde_json::from_slice(response.body.as_slice()).unwrap();
         assert_eq!(inlet_status.name, "inlet-name");
         assert_eq!(inlet_status.status, ConnectionStatus::Down);
-        assert_eq!(inlet_status.current_route, None);
+        assert_eq!(inlet_status.internal_route, None);
         assert_eq!(
             inlet_status.to,
             "/project/p1/service/forward_to_myrelay/secure/api/service/myoutlet"
         );
-        let bind_address = HostPort::try_from(inlet_status.bind_address.as_str())?;
-        assert_eq!(bind_address.host, "127.0.0.1");
-        assert!(bind_address.port > 0);
+        assert_eq!(inlet_status.bind_address.host, "127.0.0.1");
+        assert!(inlet_status.bind_address.port > 0);
 
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_api/src/control_api/backend/inlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/backend/inlet.rs
@@ -82,7 +82,8 @@ async fn handle_tcp_inlet_create(
     body: Option<Vec<u8>>,
 ) -> Result<ControlApiHttpResponse, ControlApiError> {
     let request: CreateInletRequest = common::parse_request_body(body)?;
-    let request = CreateInletRequestValidated::try_from(request)?;
+    let request =
+        CreateInletRequestValidated::from_request(&node_manager.cli_state, request).await?;
 
     let enable_udp_puncture;
     let disable_tcp_fallback;
@@ -338,14 +339,18 @@ mod test {
     use crate::control_api::http::{ControlApiHttpRequest, ControlApiHttpResponse};
     use crate::control_api::protocol::common::{ConnectionStatus, ErrorResponse, HostPort};
     use crate::control_api::protocol::inlet::{CreateInletRequest, InletStatus};
+    use crate::orchestrator::project::models::ProjectModel;
+    use crate::orchestrator::project::Project;
     use crate::test_utils::start_manager_for_tests;
     use crate::DefaultAddress;
+    use ockam::identity::Identifier;
     use ockam_core::{Address, NeutralMessage};
     use ockam_node::Context;
+    use std::str::FromStr;
     use std::time::Duration;
 
     #[ockam::test]
-    pub async fn tcp_inlet_create_get_list_delete(context: &mut Context) -> ockam_core::Result<()> {
+    async fn tcp_inlet_create_get_list_delete(context: &mut Context) -> ockam_core::Result<()> {
         let handle = start_manager_for_tests(context, None, None).await?;
         let address: Address = DefaultAddress::CONTROL_API.into();
 
@@ -484,6 +489,80 @@ mod test {
 
         let inlets: Vec<InletStatus> = serde_json::from_slice(response.body.as_slice()).unwrap();
         assert_eq!(inlets.len(), 0);
+
+        Ok(())
+    }
+
+    #[ockam::test]
+    async fn tcp_inlet_create_using_via(context: &mut Context) -> ockam_core::Result<()> {
+        let handle = start_manager_for_tests(context, None, None).await?;
+
+        let project = ProjectModel {
+            identity: Some(
+                Identifier::from_str(
+                    "Ie92f183eb4c324804ef4d62962dea94cf095a265a1b2c3d4e5f6a6b5c4d3e2f1",
+                )
+                .unwrap(),
+            ),
+            name: "p1".to_string(),
+            ..Default::default()
+        };
+        let project = Project::import(project).await.unwrap();
+        handle
+            .cli_state
+            .projects()
+            .store_project(project)
+            .await
+            .unwrap();
+
+        let address: Address = DefaultAddress::CONTROL_API.into();
+        handle
+            .node_manager
+            .create_control_api_backend(context, None)?;
+
+        // Create an inlet using "from" as an object
+        let request = ControlApiHttpRequest {
+            method: "POST".to_string(),
+            uri: "/node-name/tcp-inlets".to_string(),
+            body: Some(
+                serde_json::to_vec(&CreateInletRequest {
+                    name: Some("inlet-name".to_string()),
+                    kind: Default::default(),
+                    tls: Default::default(),
+                    from: HostPort {
+                        host: "127.0.0.1".to_string(),
+                        port: 0,
+                    },
+                    to: "myoutlet".to_string(),
+                    via: Some("myrelay".to_string()),
+                    identity: None,
+                    authorized: None,
+                    allow: None,
+                    retry_wait: 1000,
+                })
+                .unwrap(),
+            ),
+        };
+
+        let encoded_request = NeutralMessage::from(minicbor::to_vec(&request)?);
+        let encoded_response: NeutralMessage = context
+            .send_and_receive(address.clone(), encoded_request)
+            .await?;
+
+        let response: ControlApiHttpResponse = minicbor::decode(&encoded_response.into_vec())?;
+        assert_eq!(response.status, 201);
+
+        let inlet_status: InletStatus = serde_json::from_slice(response.body.as_slice()).unwrap();
+        assert_eq!(inlet_status.name, "inlet-name");
+        assert_eq!(inlet_status.status, ConnectionStatus::Down);
+        assert_eq!(inlet_status.current_route, None);
+        assert_eq!(
+            inlet_status.to,
+            "/project/p1/service/forward_to_myrelay/secure/api/service/myoutlet"
+        );
+        let bind_address = HostPort::try_from(inlet_status.bind_address.as_str())?;
+        assert_eq!(bind_address.host, "127.0.0.1");
+        assert!(bind_address.port > 0);
 
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_api/src/control_api/backend/inlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/backend/inlet.rs
@@ -336,7 +336,7 @@ async fn handle_tcp_inlet_get(
 #[cfg(test)]
 mod test {
     use crate::control_api::http::{ControlApiHttpRequest, ControlApiHttpResponse};
-    use crate::control_api::protocol::common::{ConnectionStatus, ErrorResponse, HostnamePort};
+    use crate::control_api::protocol::common::{ConnectionStatus, ErrorResponse, HostPort};
     use crate::control_api::protocol::inlet::{CreateInletRequest, InletStatus};
     use crate::test_utils::start_manager_for_tests;
     use crate::DefaultAddress;
@@ -361,8 +361,8 @@ mod test {
                     name: Some("inlet-name".to_string()),
                     kind: Default::default(),
                     tls: Default::default(),
-                    from: HostnamePort {
-                        hostname: "127.0.0.1".to_string(),
+                    from: HostPort {
+                        host: "127.0.0.1".to_string(),
                         port: 0,
                     },
                     to: "/service/outlet".to_string(),
@@ -390,8 +390,8 @@ mod test {
         assert_eq!(inlet_status.status, ConnectionStatus::Down);
         assert_eq!(inlet_status.current_route, None);
         assert_eq!(inlet_status.to, "/service/outlet");
-        let bind_address = HostnamePort::try_from(inlet_status.bind_address.as_str())?;
-        assert_eq!(bind_address.hostname, "127.0.0.1");
+        let bind_address = HostPort::try_from(inlet_status.bind_address.as_str())?;
+        assert_eq!(bind_address.host, "127.0.0.1");
         assert!(bind_address.port > 0);
 
         tokio::time::sleep(Duration::from_millis(100)).await;

--- a/implementations/rust/ockam/ockam_api/src/control_api/backend/inlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/backend/inlet.rs
@@ -3,12 +3,14 @@ use crate::control_api::backend::common::ResourceKind;
 use crate::control_api::backend::entrypoint::HttpControlNodeApiBackend;
 use crate::control_api::http::ControlApiHttpResponse;
 use crate::control_api::protocol::common::{ErrorResponse, NodeName};
-use crate::control_api::protocol::inlet::{CreateInletRequest, InletKind, InletTls};
+use crate::control_api::protocol::inlet::{
+    CreateInletRequest, CreateInletRequestValidated, InletKind, InletTls,
+};
 use crate::control_api::protocol::inlet::{InletStatus, UpdateInletRequest};
 use crate::control_api::ControlApiError;
 use crate::nodes::NodeManager;
 use http::{Method, StatusCode};
-use ockam_abac::{Action, Expr, PolicyExpression, ResourceName};
+use ockam_abac::{Action, Expr, ResourceName};
 use ockam_core::compat::rand::random_string;
 use ockam_core::errcode::Kind;
 use ockam_core::Route;
@@ -54,9 +56,10 @@ impl HttpControlNodeApiBackend {
     operation_id = "create_tcp_inlet",
     summary = "Create a new TCP Inlet",
     description =
-"Create a TCP Inlet, the main parameters are the destination `to`, and the bind address `from`.
-You can also choose to listen with a valid TLS certificate, restrict access to the Inlet with
-`authorized` and `allow`, and select a specialized Portal with `kind`.
+"The main parameters are the destination `to`, and the bind address `from`.
+You can also attach a TLS certificate in the `tls` object, restrict access to the TCP Inlet with
+`authorized` and `allow`, or select a specialized Portal with `kind`.
+
 The creation will be asynchronous and the initial status will be `down`.",
     path = "/{node}/tcp-inlets",
     tags = ["Portals"],
@@ -79,10 +82,7 @@ async fn handle_tcp_inlet_create(
     body: Option<Vec<u8>>,
 ) -> Result<ControlApiHttpResponse, ControlApiError> {
     let request: CreateInletRequest = common::parse_request_body(body)?;
-    let allow = match request.allow {
-        None => None,
-        Some(policy) => Some(PolicyExpression::try_from(policy.as_str())?),
-    };
+    let request = CreateInletRequestValidated::try_from(request)?;
 
     let enable_udp_puncture;
     let disable_tcp_fallback;
@@ -94,12 +94,12 @@ async fn handle_tcp_inlet_create(
             disable_tcp_fallback = false;
             privileged = false;
         }
-        InletKind::UdpPucture => {
+        InletKind::UdpPuncture => {
             enable_udp_puncture = true;
             disable_tcp_fallback = false;
             privileged = false;
         }
-        InletKind::OnlyUdpPucture => {
+        InletKind::OnlyUdpPuncture => {
             enable_udp_puncture = true;
             disable_tcp_fallback = true;
             privileged = false;
@@ -122,52 +122,48 @@ async fn handle_tcp_inlet_create(
     }
 
     let tls_certificate_provider: Option<MultiAddr> = match request.tls {
-        InletTls::None => None,
-        InletTls::ProjectTls => {
-            let default_project = match node_manager
-                .cli_state
-                .projects()
-                .get_default_project()
-                .await
-            {
-                Ok(project) => project,
-                Err(error) => {
-                    warn!("Failed to get default project: {:?}", error);
-                    return ControlApiHttpResponse::internal_error("Failed to get default project");
-                }
-            };
-            let default_project_name = default_project.name();
-            Some(
-                format!("/project/{default_project_name}/service/tls_certificate_provider")
-                    .parse()?,
-            )
-        }
-        InletTls::CustomTlsProvider {
-            tls_certificate_provider,
-        } => Some(tls_certificate_provider.parse()?),
-    };
-
-    let authorized = match request.authorized {
         None => None,
-        Some(authorized) => Some(common::parse_identifier(
-            authorized.as_str(),
-            "Invalid authorized identity",
-        )?),
+        Some(tls) => match tls {
+            InletTls::ProjectTls => {
+                let default_project = match node_manager
+                    .cli_state
+                    .projects()
+                    .get_default_project()
+                    .await
+                {
+                    Ok(project) => project,
+                    Err(error) => {
+                        warn!("Failed to get default project: {:?}", error);
+                        return ControlApiHttpResponse::internal_error(
+                            "Failed to get default project",
+                        );
+                    }
+                };
+                let default_project_name = default_project.name();
+                Some(
+                    format!("/project/{default_project_name}/service/tls_certificate_provider")
+                        .parse()?,
+                )
+            }
+            InletTls::CustomTlsProvider {
+                tls_certificate_provider,
+            } => Some(tls_certificate_provider.parse()?),
+        },
     };
 
     let result = node_manager
         .create_inlet(
             context,
-            request.from.try_into()?,
+            request.from,
             Route::default(),
             Route::default(),
-            request.to.parse()?,
+            request.to,
             request.name.unwrap_or_else(random_string),
-            allow,
-            None,
-            authorized,
+            request.allow,
+            Some(request.retry_wait),
+            request.authorized,
             false,
-            None,
+            request.identity,
             enable_udp_puncture,
             disable_tcp_fallback,
             privileged,
@@ -200,10 +196,11 @@ async fn handle_tcp_inlet_create(
     operation_id = "update_tcp_inlet",
     summary = "Update a TCP Inlet",
     description =
-"Update the specified TCP Inlet by name.
-Currently the only `allow` policy expression can be updated, for more advanced updates it's necessary
-to delete the TCP Inlet and create a new one.",
-    path = "/{node}/tcp-inlets/{tcp_inlet_name}",
+"Update a TCP Inlet given its name.
+
+Only the `allow` policy expression can be updated.
+To update any other field, delete the TCP Inlet and create a new one.",
+    path = "/{node}/tcp-inlets/{name}",
     tags = ["Portals"],
     responses(
         (status = OK, description = "Successfully updated", body = InletStatus),
@@ -211,7 +208,7 @@ to delete the TCP Inlet and create a new one.",
     ),
     params(
         ("node" = NodeName,),
-        ("tcp_inlet_name" = String, description = "TCP Inlet name"),
+        ("name" = String, description = "TCP Inlet name"),
     ),
     request_body(
         content = UpdateInletRequest,
@@ -256,7 +253,7 @@ async fn handle_tcp_inlet_update(
     get,
     operation_id = "list_tcp_inlet",
     summary = "List all TCP Inlets",
-    description = "List all TCP Inlets created in the node regardless of their status.",
+    description = "List all TCP Inlets created in a node regardless of their statuses.",
     path = "/{node}/tcp-inlets",
     tags = ["Portals"],
     responses(
@@ -280,15 +277,15 @@ async fn handle_tcp_inlet_list(
     delete,
     operation_id = "delete_tcp_inlet",
     summary = "Delete a TCP Inlet",
-    description = "Delete the specified TCP Inlet by name.",
-    path = "/{node}/tcp-inlets/{tcp_inlet_name}",
+    description = "Delete a TCP Inlet given its name.",
+    path = "/{node}/tcp-inlets/{name}",
     tags = ["Portals"],
     responses(
         (status = NO_CONTENT, description = "Successfully deleted"),
     ),
     params(
         ("node" = NodeName,),
-        ("tcp_inlet_name" = String, description = "TCP Inlet name"),
+        ("name" = String, description = "TCP Inlet name"),
     )
 )]
 async fn handle_tcp_inlet_delete(
@@ -311,8 +308,8 @@ async fn handle_tcp_inlet_delete(
     get,
     operation_id = "get_tcp_inlet",
     summary = "Get a TCP Inlet",
-    description = "Get the specified TCP Inlet by name",
-    path = "/{node}/tcp-inlets/{tcp_inlet_name}",
+    description = "Get a TCP Inlet given its name.",
+    path = "/{node}/tcp-inlets/{name}",
     tags = ["Portals"],
     responses(
         (status = OK, description = "Successfully retrieved", body = InletStatus),
@@ -320,7 +317,7 @@ async fn handle_tcp_inlet_delete(
     ),
     params(
         ("node" = NodeName,),
-        ("tcp_inlet_name" = String, description = "TCP Inlet name")
+        ("name" = String, description = "TCP Inlet name")
     )
 )]
 async fn handle_tcp_inlet_get(
@@ -369,6 +366,7 @@ mod test {
                         port: 0,
                     },
                     to: "/service/outlet".to_string(),
+                    via: None,
                     identity: None,
                     authorized: None,
                     allow: None,
@@ -392,8 +390,9 @@ mod test {
         assert_eq!(inlet_status.status, ConnectionStatus::Down);
         assert_eq!(inlet_status.current_route, None);
         assert_eq!(inlet_status.to, "/service/outlet");
-        assert_eq!(inlet_status.bind_address.hostname, "127.0.0.1");
-        assert!(inlet_status.bind_address.port > 0);
+        let bind_address = HostnamePort::try_from(inlet_status.bind_address.as_str())?;
+        assert_eq!(bind_address.hostname, "127.0.0.1");
+        assert!(bind_address.port > 0);
 
         tokio::time::sleep(Duration::from_millis(100)).await;
 

--- a/implementations/rust/ockam/ockam_api/src/control_api/backend/outlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/backend/outlet.rs
@@ -84,12 +84,9 @@ async fn handle_tcp_outlet_create(
     let request: CreateOutletRequest = common::parse_request_body(body)?;
     let request = CreateOutletRequestValidated::try_from(request)?;
 
-    let allow = OutletAccessControl::WithPolicyExpression(request.allow.map(|policy| policy));
+    let allow = OutletAccessControl::WithPolicyExpression(request.allow);
 
-    let tls = match request.tls {
-        None => false,
-        Some(_) => true,
-    };
+    let tls = request.tls.is_some();
 
     let privileged = match request.kind {
         OutletKind::Regular => false,
@@ -99,7 +96,7 @@ async fn handle_tcp_outlet_create(
     let result = node_manager
         .create_outlet(
             context,
-            request.to.try_into()?,
+            request.to,
             tls,
             request.name.map(Address::from_string),
             true,
@@ -272,7 +269,7 @@ async fn handle_tcp_outlet_delete(
 #[cfg(test)]
 mod test {
     use crate::control_api::http::{ControlApiHttpRequest, ControlApiHttpResponse};
-    use crate::control_api::protocol::common::ErrorResponse;
+    use crate::control_api::protocol::common::{ErrorResponse, HostPort};
     use crate::control_api::protocol::outlet::{CreateOutletRequest, OutletKind, OutletStatus};
     use crate::test_utils::start_manager_for_tests;
     use crate::DefaultAddress;
@@ -297,7 +294,10 @@ mod test {
                 serde_json::to_vec(&CreateOutletRequest {
                     kind: OutletKind::Regular,
                     name: Some("outlet-address".to_string()),
-                    to: "127.0.0.1:1234".to_string(),
+                    to: HostPort {
+                        host: "127.0.0.1".to_string(),
+                        port: 1234,
+                    },
                     tls: Default::default(),
                     allow: None,
                 })

--- a/implementations/rust/ockam/ockam_api/src/control_api/backend/outlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/backend/outlet.rs
@@ -55,11 +55,11 @@ impl HttpControlNodeApiBackend {
     operation_id = "create_tcp_outlet",
     summary = "Create a TCP Outlet",
     description =
-"Create a new TCP Outlet.
-The main parameters are the destination `to`, and the service address `name` which is
+"The main parameters are the destination `to`, and the service address `name` which is
 used to identify the outlet within the node.
 The `kind` parameter can be used to create a special outlet, and the `tls` parameter
 can be used to connect to TLS endpoints.
+
 The creation will be synchronous, without any blocking operation.",
     path = "/{node}/tcp-outlets",
     tags = ["Portals"],
@@ -84,10 +84,7 @@ async fn handle_tcp_outlet_create(
     let request: CreateOutletRequest = common::parse_request_body(body)?;
     let request = CreateOutletRequestValidated::try_from(request)?;
 
-    let allow = OutletAccessControl::WithPolicyExpression(match request.allow {
-        None => None,
-        Some(policy) => Some(policy),
-    });
+    let allow = OutletAccessControl::WithPolicyExpression(request.allow.map(|policy| policy));
 
     let tls = match request.tls {
         None => false,
@@ -136,7 +133,8 @@ async fn handle_tcp_outlet_create(
     operation_id = "update_tcp_outlet",
     summary = "Update a TCP Outlet",
     description =
-"Update the specified TCP Outlet.
+"Update a TCP Outlet given its name.
+
 Only the `allow` policy expression can be updated.
 To update any other field, delete the TCP Outlet and create a new one.",
     path = "/{node}/tcp-outlets/{name}",
@@ -192,7 +190,7 @@ async fn handle_tcp_outlet_update(
     get,
     operation_id = "list_tcp_outlets",
     summary = "List all TCP Outlets",
-    description = "List all TCP Outlets created in the node.",
+    description = "List all TCP Outlets created in a node.",
     path = "/{node}/tcp-outlets",
     tags = ["Portals"],
     responses(
@@ -217,7 +215,7 @@ async fn handle_tcp_outlet_list(
     get,
     operation_id = "get_tcp_outlet",
     summary = "Get a TCP Outlet",
-    description = "Get the specified TCP Outlet.",
+    description = "Get a TCP Outlet given its name.",
     path = "/{node}/tcp-outlets/{name}",
     tags = ["Portals"],
     responses(
@@ -247,7 +245,7 @@ async fn handle_tcp_outlet_get(
     delete,
     operation_id = "delete_tcp_outlet",
     summary = "Delete a TCP Outlet",
-    description = "Delete the specified TCP Outlet.",
+    description = "Delete a TCP Outlet given its name.",
     path = "/{node}/tcp-outlets/{name}",
     tags = ["Portals"],
     responses(

--- a/implementations/rust/ockam/ockam_api/src/control_api/backend/outlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/backend/outlet.rs
@@ -110,7 +110,7 @@ async fn handle_tcp_outlet_create(
     match result {
         Ok(outlet_status) => Ok(ControlApiHttpResponse::with_body(
             StatusCode::CREATED,
-            OutletStatus::from(outlet_status),
+            OutletStatus::try_from(outlet_status)?,
         )?),
         Err(error) => match error.code().kind {
             Kind::AlreadyExists => Err(ControlApiHttpResponse::with_body(
@@ -200,11 +200,10 @@ async fn handle_tcp_outlet_update(
 async fn handle_tcp_outlet_list(
     node_manager: &Arc<NodeManager>,
 ) -> Result<ControlApiHttpResponse, ControlApiError> {
-    let outlets: Vec<OutletStatus> = node_manager
-        .list_outlets()
-        .into_iter()
-        .map(OutletStatus::from)
-        .collect();
+    let mut outlets: Vec<OutletStatus> = Vec::new();
+    for status in node_manager.list_outlets() {
+        outlets.push(OutletStatus::try_from(status)?);
+    }
     Ok(ControlApiHttpResponse::with_body(StatusCode::OK, outlets)?)
 }
 
@@ -233,7 +232,7 @@ async fn handle_tcp_outlet_get(
         None => ControlApiHttpResponse::not_found("Outlet not found"),
         Some(status) => Ok(ControlApiHttpResponse::with_body(
             StatusCode::OK,
-            OutletStatus::from(status),
+            OutletStatus::try_from(status)?,
         )?),
     }
 }
@@ -269,7 +268,7 @@ async fn handle_tcp_outlet_delete(
 #[cfg(test)]
 mod test {
     use crate::control_api::http::{ControlApiHttpRequest, ControlApiHttpResponse};
-    use crate::control_api::protocol::common::{ErrorResponse, HostPort};
+    use crate::control_api::protocol::common::{ErrorResponse, HostPortRequest};
     use crate::control_api::protocol::outlet::{CreateOutletRequest, OutletKind, OutletStatus};
     use crate::test_utils::start_manager_for_tests;
     use crate::DefaultAddress;
@@ -294,7 +293,7 @@ mod test {
                 serde_json::to_vec(&CreateOutletRequest {
                     kind: OutletKind::Regular,
                     name: Some("outlet-address".to_string()),
-                    to: HostPort {
+                    to: HostPortRequest {
                         host: "127.0.0.1".to_string(),
                         port: 1234,
                     },
@@ -314,8 +313,9 @@ mod test {
         assert_eq!(response.status, 201);
 
         let outlet_status: OutletStatus = serde_json::from_slice(response.body.as_slice()).unwrap();
-        assert_eq!(outlet_status.name, "outlet-address");
-        assert_eq!(outlet_status.to, "127.0.0.1:1234");
+        assert_eq!(outlet_status.address, "outlet-address");
+        assert_eq!(outlet_status.to.host, "127.0.0.1");
+        assert_eq!(outlet_status.to.port, 1234);
         assert!(!outlet_status.privileged);
 
         let request = ControlApiHttpRequest {
@@ -333,8 +333,9 @@ mod test {
         assert_eq!(response.status, 200);
 
         let outlet_status: OutletStatus = serde_json::from_slice(response.body.as_slice()).unwrap();
-        assert_eq!(outlet_status.name, "outlet-address");
-        assert_eq!(outlet_status.to, "127.0.0.1:1234");
+        assert_eq!(outlet_status.address, "outlet-address");
+        assert_eq!(outlet_status.to.host, "127.0.0.1");
+        assert_eq!(outlet_status.to.port, 1234);
         assert!(!outlet_status.privileged);
 
         let request = ControlApiHttpRequest {
@@ -353,8 +354,9 @@ mod test {
 
         let outlets: Vec<OutletStatus> = serde_json::from_slice(response.body.as_slice()).unwrap();
         assert_eq!(outlets.len(), 1);
-        assert_eq!(outlets[0].name, "outlet-address");
-        assert_eq!(outlet_status.to, "127.0.0.1:1234");
+        assert_eq!(outlets[0].address, "outlet-address");
+        assert_eq!(outlets[0].to.host, "127.0.0.1");
+        assert_eq!(outlets[0].to.port, 1234);
         assert!(!outlets[0].privileged);
 
         let request = ControlApiHttpRequest {

--- a/implementations/rust/ockam/ockam_api/src/control_api/backend/outlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/backend/outlet.rs
@@ -4,13 +4,14 @@ use crate::control_api::backend::entrypoint::HttpControlNodeApiBackend;
 use crate::control_api::http::ControlApiHttpResponse;
 use crate::control_api::protocol::common::{ErrorResponse, NodeName};
 use crate::control_api::protocol::outlet::{
-    CreateOutletRequest, OutletKind, OutletStatus, OutletTls, UpdateOutletRequest,
+    CreateOutletRequest, CreateOutletRequestValidated, OutletKind, OutletStatus,
+    UpdateOutletRequest,
 };
 use crate::control_api::ControlApiError;
 use crate::nodes::models::portal::OutletAccessControl;
 use crate::nodes::NodeManager;
 use http::{Method, StatusCode};
-use ockam_abac::{Action, Expr, PolicyExpression, ResourceName};
+use ockam_abac::{Action, Expr, ResourceName};
 use ockam_core::errcode::Kind;
 use ockam_core::Address;
 use ockam_node::Context;
@@ -54,10 +55,11 @@ impl HttpControlNodeApiBackend {
     operation_id = "create_tcp_outlet",
     summary = "Create a TCP Outlet",
     description =
-"Create a new TCP Outlet, the main parameter are the destination `to`, and the worker address
-`address` which is used to identify the outlet within the node.
-The `kind` parameter can be used to create a special outlet, and the `tls` parameter can be used to
-connect to TLS endpoints.
+"Create a new TCP Outlet.
+The main parameters are the destination `to`, and the service address `name` which is
+used to identify the outlet within the node.
+The `kind` parameter can be used to create a special outlet, and the `tls` parameter
+can be used to connect to TLS endpoints.
 The creation will be synchronous, without any blocking operation.",
     path = "/{node}/tcp-outlets",
     tags = ["Portals"],
@@ -80,18 +82,19 @@ async fn handle_tcp_outlet_create(
     body: Option<Vec<u8>>,
 ) -> Result<ControlApiHttpResponse, ControlApiError> {
     let request: CreateOutletRequest = common::parse_request_body(body)?;
+    let request = CreateOutletRequestValidated::try_from(request)?;
 
     let allow = OutletAccessControl::WithPolicyExpression(match request.allow {
         None => None,
-        Some(policy) => Some(PolicyExpression::try_from(policy.as_str())?),
+        Some(policy) => Some(policy),
     });
 
     let tls = match request.tls {
-        OutletTls::None => false,
-        OutletTls::Validate => true,
+        None => false,
+        Some(_) => true,
     };
 
-    let priviledged = match request.kind {
+    let privileged = match request.kind {
         OutletKind::Regular => false,
         OutletKind::Privileged => true,
     };
@@ -101,10 +104,10 @@ async fn handle_tcp_outlet_create(
             context,
             request.to.try_into()?,
             tls,
-            request.address.map(Address::from_string),
+            request.name.map(Address::from_string),
             true,
             allow,
-            priviledged,
+            privileged,
             false,
             false,
         )
@@ -133,10 +136,10 @@ async fn handle_tcp_outlet_create(
     operation_id = "update_tcp_outlet",
     summary = "Update a TCP Outlet",
     description =
-"Update the specified TCP Outlet by address.
-Currently only `allow` policy expression can be updated, for more advanced updates it's necessary
-to delete the TCP Outlet and create a new one.",
-    path = "/{node}/tcp-outlets/{tcp_outlet_address}",
+"Update the specified TCP Outlet.
+Only the `allow` policy expression can be updated.
+To update any other field, delete the TCP Outlet and create a new one.",
+    path = "/{node}/tcp-outlets/{name}",
     tags = ["Portals"],
     responses(
         (status = OK, description = "Successfully updated", body = OutletStatus),
@@ -144,7 +147,7 @@ to delete the TCP Outlet and create a new one.",
     ),
     params(
         ("node" = NodeName,),
-        ("tcp_outlet_address" = String, description = "TCP Outlet address"),
+        ("name" = String, description = "TCP Outlet name (service address)"),
     ),
     request_body(
         content = UpdateOutletRequest,
@@ -214,8 +217,8 @@ async fn handle_tcp_outlet_list(
     get,
     operation_id = "get_tcp_outlet",
     summary = "Get a TCP Outlet",
-    description = "Get the specified TCP Outlet by address.",
-    path = "/{node}/tcp-outlets/{tcp_outlet_address}",
+    description = "Get the specified TCP Outlet.",
+    path = "/{node}/tcp-outlets/{name}",
     tags = ["Portals"],
     responses(
         (status = OK, description = "Successfully retrieved", body = OutletStatus),
@@ -223,7 +226,7 @@ async fn handle_tcp_outlet_list(
     ),
     params(
         ("node" = NodeName,),
-        ("tcp_outlet_address" = String, description = "TCP Outlet address"),
+        ("name" = String, description = "TCP Outlet name (service address)"),
     )
 )]
 async fn handle_tcp_outlet_get(
@@ -244,8 +247,8 @@ async fn handle_tcp_outlet_get(
     delete,
     operation_id = "delete_tcp_outlet",
     summary = "Delete a TCP Outlet",
-    description = "Delete the specified TCP Outlet by address.",
-    path = "/{node}/tcp-outlets/{tcp_outlet_address}",
+    description = "Delete the specified TCP Outlet.",
+    path = "/{node}/tcp-outlets/{name}",
     tags = ["Portals"],
     responses(
         (status = NO_CONTENT, description = "Successfully deleted"),
@@ -253,7 +256,7 @@ async fn handle_tcp_outlet_get(
     ),
     params(
         ("node" = NodeName,),
-        ("tcp_outlet_address" = String, description = "TCP Outlet address"),
+        ("name" = String, description = "TCP Outlet name (service address)"),
     )
 )]
 async fn handle_tcp_outlet_delete(
@@ -271,7 +274,7 @@ async fn handle_tcp_outlet_delete(
 #[cfg(test)]
 mod test {
     use crate::control_api::http::{ControlApiHttpRequest, ControlApiHttpResponse};
-    use crate::control_api::protocol::common::{ErrorResponse, HostnamePort};
+    use crate::control_api::protocol::common::ErrorResponse;
     use crate::control_api::protocol::outlet::{CreateOutletRequest, OutletKind, OutletStatus};
     use crate::test_utils::start_manager_for_tests;
     use crate::DefaultAddress;
@@ -295,11 +298,8 @@ mod test {
             body: Some(
                 serde_json::to_vec(&CreateOutletRequest {
                     kind: OutletKind::Regular,
-                    address: Some("outlet-address".to_string()),
-                    to: HostnamePort {
-                        hostname: "127.0.0.1".to_string(),
-                        port: 1234,
-                    },
+                    name: Some("outlet-address".to_string()),
+                    to: "127.0.0.1:1234".to_string(),
                     tls: Default::default(),
                     allow: None,
                 })
@@ -316,9 +316,8 @@ mod test {
         assert_eq!(response.status, 201);
 
         let outlet_status: OutletStatus = serde_json::from_slice(response.body.as_slice()).unwrap();
-        assert_eq!(outlet_status.address, "outlet-address");
-        assert_eq!(outlet_status.to.hostname, "127.0.0.1");
-        assert_eq!(outlet_status.to.port, 1234);
+        assert_eq!(outlet_status.name, "outlet-address");
+        assert_eq!(outlet_status.to, "127.0.0.1:1234");
         assert!(!outlet_status.privileged);
 
         let request = ControlApiHttpRequest {
@@ -336,9 +335,8 @@ mod test {
         assert_eq!(response.status, 200);
 
         let outlet_status: OutletStatus = serde_json::from_slice(response.body.as_slice()).unwrap();
-        assert_eq!(outlet_status.address, "outlet-address");
-        assert_eq!(outlet_status.to.hostname, "127.0.0.1");
-        assert_eq!(outlet_status.to.port, 1234);
+        assert_eq!(outlet_status.name, "outlet-address");
+        assert_eq!(outlet_status.to, "127.0.0.1:1234");
         assert!(!outlet_status.privileged);
 
         let request = ControlApiHttpRequest {
@@ -357,9 +355,8 @@ mod test {
 
         let outlets: Vec<OutletStatus> = serde_json::from_slice(response.body.as_slice()).unwrap();
         assert_eq!(outlets.len(), 1);
-        assert_eq!(outlets[0].address, "outlet-address");
-        assert_eq!(outlets[0].to.hostname, "127.0.0.1");
-        assert_eq!(outlets[0].to.port, 1234);
+        assert_eq!(outlets[0].name, "outlet-address");
+        assert_eq!(outlet_status.to, "127.0.0.1:1234");
         assert!(!outlets[0].privileged);
 
         let request = ControlApiHttpRequest {

--- a/implementations/rust/ockam/ockam_api/src/control_api/backend/relay.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/backend/relay.rs
@@ -46,12 +46,14 @@ impl HttpControlNodeApiBackend {
 #[utoipa::path(
     post,
     operation_id = "create_relay",
-    summary = "Create a new Relay",
+    summary = "Create a Relay",
     description =
-"Create a new Relay, the main parameters are the destination node `to` and the `name`.
-The address inherits the name value, but it's possible to specify it to allow the creation
-of multiple relays with the same address to different nodes.
+"The main parameters are the destination node `to` and the `name`.
+By default, the address inherits the name value, but it's possible to specify it to allow the creation
+of multiple relays with the same address on different nodes.
+
 The creation will be asynchronous and the initial status will be `down`.
+
 Note that, to allow the relay creation in the destination node, the caller identity credential must
 have an `ockam-relay` attribute set with the relay name.",
     path = "/{node}/relays",
@@ -152,15 +154,15 @@ async fn handle_relay_list(
     delete,
     operation_id = "delete_relay",
     summary = "Delete a Relay",
-    description = "Delete the specified Relay by name.",
-    path = "/{node}/relays/{relay_name}",
+    description = "Delete a Relay given its name.",
+    path = "/{node}/relays/{name}",
     tags = ["Relays"],
     responses(
         (status = NO_CONTENT, description = "Successfully deleted"),
     ),
     params(
         ("node" = NodeName,),
-        ("relay_name" = String, description = "Relay name"),
+        ("name" = String, description = "Relay name"),
     )
 )]
 async fn handle_relay_delete(
@@ -183,8 +185,8 @@ async fn handle_relay_delete(
     get,
     operation_id = "get_relay",
     summary = "Get a Relay",
-    description = "Get the specified Relay by name.",
-    path = "/{node}/relays/{relay_name}",
+    description = "Get a Relay given its name.",
+    path = "/{node}/relays/{name}",
     tags = ["Relays"],
     responses(
         (status = OK, description = "Successfully retrieved", body = RelayStatus),
@@ -192,7 +194,7 @@ async fn handle_relay_delete(
     ),
     params(
         ("node" = NodeName,),
-        ("relay_name" = String, description = "Relay name"),
+        ("name" = String, description = "Relay name"),
     )
 )]
 async fn handle_relay_get(

--- a/implementations/rust/ockam/ockam_api/src/control_api/backend/ticket.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/backend/ticket.rs
@@ -57,15 +57,15 @@ impl HttpControlNodeApiBackend {
 #[utoipa::path(
     post,
     operation_id = "create_ticket",
-    summary = "Create a new Ticket",
+    summary = "Create a Ticket",
     description =
-"Create a new Ticket, the main parameters are `attributes`, the list of attributes associated
-with the ticket, and `project`, the target project for the ticket. In the vast majority of cases,
-specifying the project name will be enough, but it's also possible to specify a custom Ockam
+"The main parameters are the `attributes` associated with the ticket, and target `project` for the ticket.
+Normally, specifying the project name will be enough, but it's also possible to specify a custom Ockam
 Authority and a custom node acting as a Project.
-You can also limit the validity of the ticket by specifying the `usage_count` and `expires_in`
-fields.
-The ticket is returned as an opaque string that can be used to enroll to a project, either via API
+You can also configure how long the ticket is valid, and how many times it can be redeemed
+by specifying the `usage-count` and `expires-in` fields.
+
+The ticket is returned as a string that can be used to enroll to a project, either via API
 or via CLI with the `ockam project enroll` command.",
     path = "/{node}/tickets",
     tags = ["Tickets"],
@@ -253,8 +253,15 @@ async fn create_encoded_ticket(
 #[utoipa::path(
     post,
     operation_id = "project_enroll",
-    summary = "Enroll to a Project using a Ticket",
-    description = "This API enrolls a node to a Project using the provided Ticket.",
+    summary = "Enroll to a Project",
+    description =
+"Enrolls an identity to a Project using the provided Ticket.
+
+When an identity is enrolled, they become a member of the Project, and they get a credential at the end of this process.
+The Project's Membership Authority will cryptographically attest to the specific attributes that the ticket
+was created with. As a member, they can request a credential whenever they need one.
+Credentials do not live forever, and expire.
+",
     path = "/{node}/tickets/enroll",
     tags = ["Tickets"],
     responses(

--- a/implementations/rust/ockam/ockam_api/src/control_api/backend/ticket.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/backend/ticket.rs
@@ -7,7 +7,7 @@ use crate::control_api::backend::common::{
 };
 use crate::control_api::backend::entrypoint::HttpControlNodeApiBackend;
 use crate::control_api::http::ControlApiHttpResponse;
-use crate::control_api::protocol::common::{ErrorResponse, HostPort, NodeName, Project};
+use crate::control_api::protocol::common::{ErrorResponse, HostPortRequest, NodeName, Project};
 use crate::control_api::protocol::ticket::{
     AuthorityInformation, CreateTicketRequest, EnrollProjectRequest, Ticket,
 };
@@ -157,9 +157,9 @@ async fn create_encoded_ticket(
             )
         }
         Project::Existing {
-            name: None,
             project_route,
             authority_route,
+            ..
         } => {
             overridden_project_route = project_route;
             overridden_authority_route = authority_route;
@@ -306,7 +306,7 @@ async fn handle_ticket_enroll(
             .await?;
 
     let address = if let Some(address) = project.authority_socket_addr() {
-        HostPort::try_from(address.as_str())?
+        HostPortRequest::try_from(address.as_str())?
     } else {
         return Err(ockam_core::Error::new(
             Origin::Api,
@@ -328,7 +328,7 @@ async fn handle_ticket_enroll(
     let authority_info = AuthorityInformation {
         route: authority_route,
         identity: authority_identifier.to_string(),
-        address,
+        address: address.into(),
     };
 
     let result = authority_client

--- a/implementations/rust/ockam/ockam_api/src/control_api/backend/ticket.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/backend/ticket.rs
@@ -7,7 +7,7 @@ use crate::control_api::backend::common::{
 };
 use crate::control_api::backend::entrypoint::HttpControlNodeApiBackend;
 use crate::control_api::http::ControlApiHttpResponse;
-use crate::control_api::protocol::common::{ErrorResponse, HostnamePort, NodeName, Project};
+use crate::control_api::protocol::common::{ErrorResponse, HostPort, NodeName, Project};
 use crate::control_api::protocol::ticket::{
     AuthorityInformation, CreateTicketRequest, EnrollProjectRequest, Ticket,
 };
@@ -306,7 +306,7 @@ async fn handle_ticket_enroll(
             .await?;
 
     let address = if let Some(address) = project.authority_socket_addr() {
-        HostnamePort::try_from(address.as_str())?
+        HostPort::try_from(address.as_str())?
     } else {
         return Err(ockam_core::Error::new(
             Origin::Api,

--- a/implementations/rust/ockam/ockam_api/src/control_api/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/mod.rs
@@ -11,39 +11,38 @@ mod protocol;
 
 use crate::cli_state::CliStateError;
 use crate::control_api::http::ControlApiHttpResponse;
+use miette::Diagnostic;
 pub use openapi::generate_schema;
+use strum::Display;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Display, Error, Diagnostic)]
 pub enum ControlApiError {
     Response(ControlApiHttpResponse),
-    OckamError(ockam_core::Error),
+    Ockam(#[from] ockam_core::Error),
 }
+
 impl From<ControlApiHttpResponse> for ControlApiError {
     fn from(response: ControlApiHttpResponse) -> Self {
         Self::Response(response)
     }
 }
 
-impl From<ockam_core::Error> for ControlApiError {
-    fn from(error: ockam_core::Error) -> Self {
-        Self::OckamError(error)
-    }
+macro_rules! impl_from_for_control_api_error {
+    ($($err_type:ty),*) => {
+        $(
+            impl From<$err_type> for ControlApiError {
+                fn from(error: $err_type) -> Self {
+                    Self::Ockam(ockam_core::Error::from(error))
+                }
+            }
+        )*
+    };
 }
 
-impl From<CliStateError> for ControlApiError {
-    fn from(error: CliStateError) -> Self {
-        Self::OckamError(ockam_core::Error::from(error))
-    }
-}
-
-impl From<ockam_multiaddr::Error> for ControlApiError {
-    fn from(error: ockam_multiaddr::Error) -> Self {
-        Self::OckamError(ockam_core::Error::from(error))
-    }
-}
-
-impl From<ockam_abac::ParseError> for ControlApiError {
-    fn from(error: ockam_abac::ParseError) -> Self {
-        Self::OckamError(ockam_core::Error::from(error))
-    }
-}
+impl_from_for_control_api_error!(
+    CliStateError,
+    ockam_multiaddr::Error,
+    ockam_abac::ParseError,
+    crate::error::ParseError
+);

--- a/implementations/rust/ockam/ockam_api/src/control_api/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/mod.rs
@@ -12,6 +12,7 @@ mod protocol;
 use crate::cli_state::CliStateError;
 use crate::control_api::http::ControlApiHttpResponse;
 use miette::Diagnostic;
+use ockam_core::errcode::Origin;
 pub use openapi::generate_schema;
 use strum::Display;
 use thiserror::Error;
@@ -25,6 +26,15 @@ pub enum ControlApiError {
 impl From<ControlApiHttpResponse> for ControlApiError {
     fn from(response: ControlApiHttpResponse) -> Self {
         Self::Response(response)
+    }
+}
+
+impl From<miette::Error> for ControlApiError {
+    fn from(error: miette::Error) -> Self {
+        Self::Ockam(ockam_core::Error::new_unknown(
+            Origin::Application,
+            error.to_string(),
+        ))
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/common.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/common.rs
@@ -7,9 +7,9 @@ use utoipa::openapi::{ObjectBuilder, OneOfBuilder, RefOr, Schema};
 use utoipa::{PartialSchema, ToSchema};
 
 // This is an alias for documentation purposes only
-/// The destination node name.
+/// The name of the node that will process the request.
 /// Depending on the type of node resolution used, it can be a relay name
-/// or a dns address.
+/// or a DNS address.
 /// The special value `self` can be used to refer to the current node.
 #[derive(Serialize, Deserialize, ToSchema)]
 pub struct NodeName(String);

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/common.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/common.rs
@@ -1,8 +1,10 @@
 use ockam::identity::{Identity, Vault};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::BTreeMap;
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
-use utoipa::ToSchema;
+use utoipa::openapi::{ObjectBuilder, OneOfBuilder, RefOr, Schema};
+use utoipa::{PartialSchema, ToSchema};
 
 // This is an alias for documentation purposes only
 /// The destination node name.
@@ -30,11 +32,56 @@ Ockam uses `ockam-` as a prefix for its own attributes.
 )]
 pub struct Attributes(pub BTreeMap<String, String>);
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug)]
 pub struct HostnamePort {
     pub hostname: String,
     pub port: u16,
 }
+
+impl PartialSchema for HostnamePort {
+    fn schema() -> RefOr<Schema> {
+        RefOr::T(Schema::OneOf(
+            OneOfBuilder::new()
+                .item(RefOr::T(Schema::Object(
+                    ObjectBuilder::new()
+                        .schema_type(utoipa::openapi::schema::Type::String)
+                        .format(Some(utoipa::openapi::SchemaFormat::Custom(
+                            "hostname:port".to_string(),
+                        )))
+                        .build(),
+                )))
+                .item(
+                    // Object to support {hostname: "example.com", port: 8080}
+                    RefOr::T(Schema::Object(
+                        ObjectBuilder::new()
+                            .schema_type(utoipa::openapi::schema::Type::Object)
+                            .property(
+                                "hostname",
+                                ObjectBuilder::new()
+                                    .schema_type(utoipa::openapi::schema::Type::String)
+                                    .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(
+                                        utoipa::openapi::KnownFormat::Hostname,
+                                    )))
+                                    .build(),
+                            )
+                            .property(
+                                "port",
+                                ObjectBuilder::new()
+                                    .schema_type(utoipa::openapi::schema::Type::Integer)
+                                    .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(
+                                        utoipa::openapi::KnownFormat::Int32,
+                                    )))
+                                    .build(),
+                            )
+                            .build(),
+                    )),
+                )
+                .build(),
+        ))
+    }
+}
+
+impl ToSchema for HostnamePort {}
 
 impl TryInto<ockam_transport_core::HostnamePort> for HostnamePort {
     type Error = ockam_core::Error;
@@ -52,6 +99,85 @@ impl TryFrom<&str> for HostnamePort {
             hostname: hostname.hostname,
             port: hostname.port,
         })
+    }
+}
+
+impl Serialize for HostnamePort {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for HostnamePort {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct HostnamePortVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for HostnamePortVisitor {
+            type Value = HostnamePort;
+
+            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+                formatter.write_str("a string in format 'hostname:port' or an object with 'hostname' and 'port' fields")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                HostnamePort::try_from(value).map_err(serde::de::Error::custom)
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut hostname = None;
+                let mut port = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "hostname" => {
+                            if hostname.is_some() {
+                                return Err(serde::de::Error::duplicate_field("hostname"));
+                            }
+                            hostname = Some(map.next_value::<String>()?);
+                        }
+                        "port" => {
+                            if port.is_some() {
+                                return Err(serde::de::Error::duplicate_field("port"));
+                            }
+                            port = Some(map.next_value::<u16>()?);
+                        }
+                        _ => {
+                            let _ = map.next_value::<serde::de::IgnoredAny>()?;
+                        }
+                    }
+                }
+
+                let hostname =
+                    hostname.ok_or_else(|| serde::de::Error::missing_field("hostname"))?;
+                let port = port.ok_or_else(|| serde::de::Error::missing_field("port"))?;
+
+                Ok(HostnamePort { hostname, port })
+            }
+        }
+
+        deserializer.deserialize_any(HostnamePortVisitor)
+    }
+}
+
+impl Display for HostnamePort {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        ockam_transport_core::HostnamePort {
+            hostname: self.hostname.clone(),
+            port: self.port,
+        }
+        .fmt(f)
     }
 }
 
@@ -176,5 +302,96 @@ impl Project {
                 })
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_hostname_port_deserialize_string() {
+        // Deserialize from string format
+        let json = json!("localhost:8080");
+        let result: HostnamePort = serde_json::from_value(json).unwrap();
+        assert_eq!(result.hostname, "localhost");
+        assert_eq!(result.port, 8080);
+
+        // IPv4 address
+        let json = json!("127.0.0.1:9000");
+        let result: HostnamePort = serde_json::from_value(json).unwrap();
+        assert_eq!(result.hostname, "127.0.0.1");
+        assert_eq!(result.port, 9000);
+
+        // IPv6 address
+        let json = json!("[::1]:8080");
+        let result: HostnamePort = serde_json::from_value(json).unwrap();
+        assert_eq!(result.hostname, "[::1]");
+        assert_eq!(result.port, 8080);
+
+        // Just port
+        let json = json!("8080");
+        let result: HostnamePort = serde_json::from_value(json).unwrap();
+        assert_eq!(result.hostname, "127.0.0.1"); // localhost
+        assert_eq!(result.port, 8080);
+    }
+
+    #[test]
+    fn test_hostname_port_deserialize_object() {
+        // Deserialize from object format
+        let json = json!({
+            "hostname": "example.com",
+            "port": 8080
+        });
+        let result: HostnamePort = serde_json::from_value(json).unwrap();
+        assert_eq!(result.hostname, "example.com");
+        assert_eq!(result.port, 8080);
+
+        // Duplicate fields -- It keeps the last one
+        let json = json!({
+            "hostname": "example.com",
+            "hostname": "duplicate.com",
+            "port": 8080
+        });
+        let result = serde_json::from_value::<HostnamePort>(json).unwrap();
+        assert_eq!(result.hostname, "duplicate.com");
+        assert_eq!(result.port, 8080);
+    }
+
+    #[test]
+    fn test_hostname_port_deserialize_error_cases() {
+        // Invalid string format
+        let json = json!("invalid_format");
+        let result = serde_json::from_value::<HostnamePort>(json);
+        assert!(result.is_err());
+
+        // Missing hostname in object
+        let json = json!({
+            "port": 8080
+        });
+        let result = serde_json::from_value::<HostnamePort>(json);
+        assert!(result.is_err());
+
+        // Missing port in object
+        let json = json!({
+            "hostname": "example.com"
+        });
+        let result = serde_json::from_value::<HostnamePort>(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_hostname_port_serde() {
+        let original = HostnamePort {
+            hostname: "example.com".to_string(),
+            port: 8080,
+        };
+
+        let serialized = serde_json::to_string(&original).unwrap();
+        let deserialized: HostnamePort = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(original.hostname, deserialized.hostname);
+        assert_eq!(original.port, deserialized.port);
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/common.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/common.rs
@@ -33,12 +33,12 @@ Ockam uses `ockam-` as a prefix for its own attributes.
 pub struct Attributes(pub BTreeMap<String, String>);
 
 #[derive(Debug)]
-pub struct HostnamePort {
-    pub hostname: String,
+pub struct HostPort {
+    pub host: String,
     pub port: u16,
 }
 
-impl PartialSchema for HostnamePort {
+impl PartialSchema for HostPort {
     fn schema() -> RefOr<Schema> {
         RefOr::T(Schema::OneOf(
             OneOfBuilder::new()
@@ -46,7 +46,7 @@ impl PartialSchema for HostnamePort {
                     ObjectBuilder::new()
                         .schema_type(utoipa::openapi::schema::Type::String)
                         .format(Some(utoipa::openapi::SchemaFormat::Custom(
-                            "hostname:port".to_string(),
+                            "host:port".to_string(),
                         )))
                         .build(),
                 )))
@@ -56,20 +56,17 @@ impl PartialSchema for HostnamePort {
                         ObjectBuilder::new()
                             .schema_type(utoipa::openapi::schema::Type::Object)
                             .property(
-                                "hostname",
+                                "host",
                                 ObjectBuilder::new()
                                     .schema_type(utoipa::openapi::schema::Type::String)
-                                    .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(
-                                        utoipa::openapi::KnownFormat::Hostname,
-                                    )))
                                     .build(),
                             )
                             .property(
                                 "port",
                                 ObjectBuilder::new()
-                                    .schema_type(utoipa::openapi::schema::Type::Integer)
+                                    .schema_type(utoipa::openapi::schema::Type::Number)
                                     .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(
-                                        utoipa::openapi::KnownFormat::Int32,
+                                        utoipa::openapi::KnownFormat::UInt32,
                                     )))
                                     .build(),
                             )
@@ -81,28 +78,28 @@ impl PartialSchema for HostnamePort {
     }
 }
 
-impl ToSchema for HostnamePort {}
+impl ToSchema for HostPort {}
 
-impl TryInto<ockam_transport_core::HostnamePort> for HostnamePort {
+impl TryInto<ockam_transport_core::HostnamePort> for HostPort {
     type Error = ockam_core::Error;
     fn try_into(self) -> Result<ockam_transport_core::HostnamePort, Self::Error> {
-        ockam_transport_core::HostnamePort::new(self.hostname, self.port)
+        ockam_transport_core::HostnamePort::new(self.host, self.port)
     }
 }
 
-impl TryFrom<&str> for HostnamePort {
+impl TryFrom<&str> for HostPort {
     type Error = ockam_core::Error;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         let hostname = ockam_transport_core::HostnamePort::from_str(value)?;
-        Ok(HostnamePort {
-            hostname: hostname.hostname,
+        Ok(HostPort {
+            host: hostname.hostname,
             port: hostname.port,
         })
     }
 }
 
-impl Serialize for HostnamePort {
+impl Serialize for HostPort {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -111,7 +108,7 @@ impl Serialize for HostnamePort {
     }
 }
 
-impl<'de> Deserialize<'de> for HostnamePort {
+impl<'de> Deserialize<'de> for HostPort {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -119,7 +116,7 @@ impl<'de> Deserialize<'de> for HostnamePort {
         struct HostnamePortVisitor;
 
         impl<'de> serde::de::Visitor<'de> for HostnamePortVisitor {
-            type Value = HostnamePort;
+            type Value = HostPort;
 
             fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
                 formatter.write_str("a string in format 'hostname:port' or an object with 'hostname' and 'port' fields")
@@ -129,7 +126,7 @@ impl<'de> Deserialize<'de> for HostnamePort {
             where
                 E: serde::de::Error,
             {
-                HostnamePort::try_from(value).map_err(serde::de::Error::custom)
+                HostPort::try_from(value).map_err(serde::de::Error::custom)
             }
 
             fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
@@ -163,7 +160,10 @@ impl<'de> Deserialize<'de> for HostnamePort {
                     hostname.ok_or_else(|| serde::de::Error::missing_field("hostname"))?;
                 let port = port.ok_or_else(|| serde::de::Error::missing_field("port"))?;
 
-                Ok(HostnamePort { hostname, port })
+                Ok(HostPort {
+                    host: hostname,
+                    port,
+                })
             }
         }
 
@@ -171,10 +171,10 @@ impl<'de> Deserialize<'de> for HostnamePort {
     }
 }
 
-impl Display for HostnamePort {
+impl Display for HostPort {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         ockam_transport_core::HostnamePort {
-            hostname: self.hostname.clone(),
+            hostname: self.host.clone(),
             port: self.port,
         }
         .fmt(f)
@@ -314,26 +314,26 @@ mod tests {
     fn test_hostname_port_deserialize_string() {
         // Deserialize from string format
         let json = json!("localhost:8080");
-        let result: HostnamePort = serde_json::from_value(json).unwrap();
-        assert_eq!(result.hostname, "localhost");
+        let result: HostPort = serde_json::from_value(json).unwrap();
+        assert_eq!(result.host, "localhost");
         assert_eq!(result.port, 8080);
 
         // IPv4 address
         let json = json!("127.0.0.1:9000");
-        let result: HostnamePort = serde_json::from_value(json).unwrap();
-        assert_eq!(result.hostname, "127.0.0.1");
+        let result: HostPort = serde_json::from_value(json).unwrap();
+        assert_eq!(result.host, "127.0.0.1");
         assert_eq!(result.port, 9000);
 
         // IPv6 address
         let json = json!("[::1]:8080");
-        let result: HostnamePort = serde_json::from_value(json).unwrap();
-        assert_eq!(result.hostname, "[::1]");
+        let result: HostPort = serde_json::from_value(json).unwrap();
+        assert_eq!(result.host, "[::1]");
         assert_eq!(result.port, 8080);
 
         // Just port
         let json = json!("8080");
-        let result: HostnamePort = serde_json::from_value(json).unwrap();
-        assert_eq!(result.hostname, "127.0.0.1");
+        let result: HostPort = serde_json::from_value(json).unwrap();
+        assert_eq!(result.host, "127.0.0.1");
         assert_eq!(result.port, 8080);
     }
 
@@ -344,8 +344,8 @@ mod tests {
             "hostname": "example.com",
             "port": 8080
         });
-        let result: HostnamePort = serde_json::from_value(json).unwrap();
-        assert_eq!(result.hostname, "example.com");
+        let result: HostPort = serde_json::from_value(json).unwrap();
+        assert_eq!(result.host, "example.com");
         assert_eq!(result.port, 8080);
 
         // Duplicate fields; It keeps the last one
@@ -354,8 +354,8 @@ mod tests {
             "hostname": "duplicate.com",
             "port": 8080
         });
-        let result = serde_json::from_value::<HostnamePort>(json).unwrap();
-        assert_eq!(result.hostname, "duplicate.com");
+        let result = serde_json::from_value::<HostPort>(json).unwrap();
+        assert_eq!(result.host, "duplicate.com");
         assert_eq!(result.port, 8080);
     }
 
@@ -363,35 +363,35 @@ mod tests {
     fn test_hostname_port_deserialize_error_cases() {
         // Invalid string format
         let json = json!("invalid_format");
-        let result = serde_json::from_value::<HostnamePort>(json);
+        let result = serde_json::from_value::<HostPort>(json);
         assert!(result.is_err());
 
         // Missing hostname in object
         let json = json!({
             "port": 8080
         });
-        let result = serde_json::from_value::<HostnamePort>(json);
+        let result = serde_json::from_value::<HostPort>(json);
         assert!(result.is_err());
 
         // Missing port in object
         let json = json!({
             "hostname": "example.com"
         });
-        let result = serde_json::from_value::<HostnamePort>(json);
+        let result = serde_json::from_value::<HostPort>(json);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_hostname_port_serde() {
-        let original = HostnamePort {
-            hostname: "example.com".to_string(),
+        let original = HostPort {
+            host: "example.com".to_string(),
             port: 8080,
         };
 
         let serialized = serde_json::to_string(&original).unwrap();
-        let deserialized: HostnamePort = serde_json::from_str(&serialized).unwrap();
+        let deserialized: HostPort = serde_json::from_str(&serialized).unwrap();
 
-        assert_eq!(original.hostname, deserialized.hostname);
+        assert_eq!(original.host, deserialized.host);
         assert_eq!(original.port, deserialized.port);
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/common.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/common.rs
@@ -333,7 +333,7 @@ mod tests {
         // Just port
         let json = json!("8080");
         let result: HostnamePort = serde_json::from_value(json).unwrap();
-        assert_eq!(result.hostname, "127.0.0.1"); // localhost
+        assert_eq!(result.hostname, "127.0.0.1");
         assert_eq!(result.port, 8080);
     }
 
@@ -348,7 +348,7 @@ mod tests {
         assert_eq!(result.hostname, "example.com");
         assert_eq!(result.port, 8080);
 
-        // Duplicate fields -- It keeps the last one
+        // Duplicate fields; It keeps the last one
         let json = json!({
             "hostname": "example.com",
             "hostname": "duplicate.com",

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/common.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/common.rs
@@ -32,13 +32,28 @@ Ockam uses `ockam-` as a prefix for its own attributes.
 )]
 pub struct Attributes(pub BTreeMap<String, String>);
 
-#[derive(Debug)]
-pub struct HostPort {
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct HostPortResponse {
     pub host: String,
     pub port: u16,
 }
 
-impl PartialSchema for HostPort {
+impl From<HostPortRequest> for HostPortResponse {
+    fn from(request: HostPortRequest) -> Self {
+        HostPortResponse {
+            host: request.host,
+            port: request.port,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct HostPortRequest {
+    pub host: String,
+    pub port: u16,
+}
+
+impl PartialSchema for HostPortRequest {
     fn schema() -> RefOr<Schema> {
         RefOr::T(Schema::OneOf(
             OneOfBuilder::new()
@@ -78,28 +93,28 @@ impl PartialSchema for HostPort {
     }
 }
 
-impl ToSchema for HostPort {}
+impl ToSchema for HostPortRequest {}
 
-impl TryInto<ockam_transport_core::HostnamePort> for HostPort {
+impl TryInto<ockam_transport_core::HostnamePort> for HostPortRequest {
     type Error = ockam_core::Error;
     fn try_into(self) -> Result<ockam_transport_core::HostnamePort, Self::Error> {
         ockam_transport_core::HostnamePort::new(self.host, self.port)
     }
 }
 
-impl TryFrom<&str> for HostPort {
+impl TryFrom<&str> for HostPortRequest {
     type Error = ockam_core::Error;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         let hostname = ockam_transport_core::HostnamePort::from_str(value)?;
-        Ok(HostPort {
+        Ok(HostPortRequest {
             host: hostname.hostname,
             port: hostname.port,
         })
     }
 }
 
-impl Serialize for HostPort {
+impl Serialize for HostPortRequest {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -108,7 +123,7 @@ impl Serialize for HostPort {
     }
 }
 
-impl<'de> Deserialize<'de> for HostPort {
+impl<'de> Deserialize<'de> for HostPortRequest {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -116,7 +131,7 @@ impl<'de> Deserialize<'de> for HostPort {
         struct HostnamePortVisitor;
 
         impl<'de> serde::de::Visitor<'de> for HostnamePortVisitor {
-            type Value = HostPort;
+            type Value = HostPortRequest;
 
             fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
                 formatter.write_str("a string in format 'hostname:port' or an object with 'hostname' and 'port' fields")
@@ -126,7 +141,7 @@ impl<'de> Deserialize<'de> for HostPort {
             where
                 E: serde::de::Error,
             {
-                HostPort::try_from(value).map_err(serde::de::Error::custom)
+                HostPortRequest::try_from(value).map_err(serde::de::Error::custom)
             }
 
             fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
@@ -138,7 +153,7 @@ impl<'de> Deserialize<'de> for HostPort {
 
                 while let Some(key) = map.next_key::<String>()? {
                     match key.as_str() {
-                        "hostname" => {
+                        "host" | "hostname" => {
                             if hostname.is_some() {
                                 return Err(serde::de::Error::duplicate_field("hostname"));
                             }
@@ -160,7 +175,7 @@ impl<'de> Deserialize<'de> for HostPort {
                     hostname.ok_or_else(|| serde::de::Error::missing_field("hostname"))?;
                 let port = port.ok_or_else(|| serde::de::Error::missing_field("port"))?;
 
-                Ok(HostPort {
+                Ok(HostPortRequest {
                     host: hostname,
                     port,
                 })
@@ -171,7 +186,7 @@ impl<'de> Deserialize<'de> for HostPort {
     }
 }
 
-impl Display for HostPort {
+impl Display for HostPortRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         ockam_transport_core::HostnamePort {
             hostname: self.host.clone(),
@@ -314,25 +329,25 @@ mod tests {
     fn test_hostname_port_deserialize_string() {
         // Deserialize from string format
         let json = json!("localhost:8080");
-        let result: HostPort = serde_json::from_value(json).unwrap();
+        let result: HostPortRequest = serde_json::from_value(json).unwrap();
         assert_eq!(result.host, "localhost");
         assert_eq!(result.port, 8080);
 
         // IPv4 address
         let json = json!("127.0.0.1:9000");
-        let result: HostPort = serde_json::from_value(json).unwrap();
+        let result: HostPortRequest = serde_json::from_value(json).unwrap();
         assert_eq!(result.host, "127.0.0.1");
         assert_eq!(result.port, 9000);
 
         // IPv6 address
         let json = json!("[::1]:8080");
-        let result: HostPort = serde_json::from_value(json).unwrap();
+        let result: HostPortRequest = serde_json::from_value(json).unwrap();
         assert_eq!(result.host, "[::1]");
         assert_eq!(result.port, 8080);
 
         // Just port
         let json = json!("8080");
-        let result: HostPort = serde_json::from_value(json).unwrap();
+        let result: HostPortRequest = serde_json::from_value(json).unwrap();
         assert_eq!(result.host, "127.0.0.1");
         assert_eq!(result.port, 8080);
     }
@@ -344,7 +359,15 @@ mod tests {
             "hostname": "example.com",
             "port": 8080
         });
-        let result: HostPort = serde_json::from_value(json).unwrap();
+        let result: HostPortRequest = serde_json::from_value(json).unwrap();
+        assert_eq!(result.host, "example.com");
+        assert_eq!(result.port, 8080);
+
+        let json = json!({
+            "host": "example.com",
+            "port": 8080
+        });
+        let result: HostPortRequest = serde_json::from_value(json).unwrap();
         assert_eq!(result.host, "example.com");
         assert_eq!(result.port, 8080);
 
@@ -354,7 +377,7 @@ mod tests {
             "hostname": "duplicate.com",
             "port": 8080
         });
-        let result = serde_json::from_value::<HostPort>(json).unwrap();
+        let result = serde_json::from_value::<HostPortRequest>(json).unwrap();
         assert_eq!(result.host, "duplicate.com");
         assert_eq!(result.port, 8080);
     }
@@ -363,33 +386,33 @@ mod tests {
     fn test_hostname_port_deserialize_error_cases() {
         // Invalid string format
         let json = json!("invalid_format");
-        let result = serde_json::from_value::<HostPort>(json);
+        let result = serde_json::from_value::<HostPortRequest>(json);
         assert!(result.is_err());
 
         // Missing hostname in object
         let json = json!({
             "port": 8080
         });
-        let result = serde_json::from_value::<HostPort>(json);
+        let result = serde_json::from_value::<HostPortRequest>(json);
         assert!(result.is_err());
 
         // Missing port in object
         let json = json!({
             "hostname": "example.com"
         });
-        let result = serde_json::from_value::<HostPort>(json);
+        let result = serde_json::from_value::<HostPortRequest>(json);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_hostname_port_serde() {
-        let original = HostPort {
+        let original = HostPortRequest {
             host: "example.com".to_string(),
             port: 8080,
         };
 
         let serialized = serde_json::to_string(&original).unwrap();
-        let deserialized: HostPort = serde_json::from_str(&serialized).unwrap();
+        let deserialized: HostPortRequest = serde_json::from_str(&serialized).unwrap();
 
         assert_eq!(original.host, deserialized.host);
         assert_eq!(original.port, deserialized.port);

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/inlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/inlet.rs
@@ -1,5 +1,11 @@
 use crate::control_api::protocol::common::{ConnectionStatus, HostnamePort};
+use crate::control_api::ControlApiError;
+use ockam::identity::Identifier;
+use ockam_abac::PolicyExpression;
+use ockam_multiaddr::MultiAddr;
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use std::time::Duration;
 use utoipa::ToSchema;
 
 fn tcp_inlet_default_bind_address() -> HostnamePort {
@@ -16,14 +22,14 @@ fn retry_wait_default() -> u64 {
 #[derive(Debug, Serialize, Deserialize, Default, ToSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum InletKind {
-    /// Uses the provided Multiaddress to connect to the Outlet
+    /// Uses the provided route to connect to the Outlet
     #[default]
     Regular,
-    /// Uses the provided Multiaddress to connect to the Outlet but
+    /// Uses the provided route to connect to the Outlet but
     /// tries to establish a direct UDP communication via UDP puncture
-    UdpPucture,
+    UdpPuncture,
     /// Only uses a direct UDP communication via UDP puncture
-    OnlyUdpPucture,
+    OnlyUdpPuncture,
     /// Use eBPF and RawSocket to access TCP packets instead of TCP data stream.
     Privileged,
     /// Use eBPF and RawSocket to access TCP packets instead of TCP data stream but
@@ -34,14 +40,12 @@ pub enum InletKind {
     PrivilegedOnlyUdpPuncture,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum InletTls {
-    #[default]
-    None,
     ProjectTls,
     CustomTlsProvider {
-        /// Multiaddress to a certificate provider;
+        /// Route to a certificate provider;
         /// Typical: /project/default/service/tls_certificate_provider
         #[serde(rename = "tls-certificate-provider")]
         tls_certificate_provider: String,
@@ -51,46 +55,141 @@ pub enum InletTls {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct CreateInletRequest {
-    /// Name of the TCP Inlet;
-    /// Whe omitted, a random name will be generated
+    /// Name of the TCP Inlet.
+    /// When omitted, a random name will be generated.
+    #[schema(example = "my-inlet")]
     pub name: Option<String>,
-    /// Kind of the Portal
-    #[serde(default)]
-    pub kind: InletKind,
-    /// TLS Inlet implementation
-    #[serde(default)]
-    #[schema(default = "none")]
-    pub tls: InletTls,
-    /// Bind address for the TCP Inlet
+
+    /// Network address on which to accept TCP connections, in the format `<host>:<port>`.
+    /// At least the port must be provided.
+    ///
+    /// The default host is `127.0.0.1`.
+    /// If not set, a random port will be used on the default host.
     #[serde(default = "tcp_inlet_default_bind_address")]
     #[schema(default = tcp_inlet_default_bind_address)]
     pub from: HostnamePort,
-    /// Multiaddress to a TCP Outlet
-    #[schema(example = "/project/default/service/forward_to_node1/secure/api/service/outlet")]
+
+    /// Route to a TCP Outlet or the name of the TCP Outlet service you want to connect to.
+    ///
+    /// If you are connecting to a local node, you can provide the route as `/node/n/service/outlet`.
+    ///
+    /// If you are connecting to a remote node through a relay in the Orchestrator you can either
+    /// provide the full route to the TCP Outlet as `/project/myproject/service/forward_to_myrelay/secure/api/service/outlet`,
+    /// or just the service name as `outlet` or `/service/outlet`.
+    ///
+    /// If you are passing just the service name, consider using `via` to specify the
+    /// relay name.
+    #[schema(example = "/project/default/service/forward_to_myrelay/secure/api/service/outlet")]
     pub to: String,
-    /// Identity to be used to create the secure channel;
-    /// When omitted, the node's identity will be used
+
+    /// Name of the relay that this TCP Inlet will use to connect to the TCP Outlet.
+    ///
+    /// Use this flag when you are using `to` to specify the service name of a TCP Outlet
+    /// that is reachable through a relay in the Orchestrator.
+    ///
+    /// If you don't provide it, the default relay name will be used, if necessary.
+    #[schema(example = default_via)]
+    pub via: Option<String>,
+
+    /// Identity to be used to create the secure channel. If not set, the node's identity will be used.
+    #[schema(example = "Id3b788c6a89de8b1f2fd13743eb3123178cf6ec7c9253be8ddcf7e154abe016a")]
     pub identity: Option<String>,
-    /// Restrict access to the TCP Inlet to the provided identity;
-    /// When omitted, all identities are allowed;
+
+    /// Restrict access to the TCP Inlet to the provided identity.
+    /// When omitted, all identities are allowed.
     #[schema(example = "Id3b788c6a89de8b1f2fd13743eb3123178cf6ec7c9253be8ddcf7e154abe016a")]
     pub authorized: Option<String>,
-    /// Policy expression that will be used for access control to the TCP Inlet;
-    /// When omitted, the policy set for the "tcp-inlet" resource type will be used.
-    /// [Learn more about Policies expressions on the Ockam documentation](https://docs.ockam.io/reference/protocols/access-controls).
+
+    /// Policy expression that will be used for access control to the TCP Inlet.
+    ///
+    /// If you don't provide it, the policy set for the "tcp-inlet" resource type will be used.
+    ///
+    /// [Learn more about Policy expressions on the Ockam documentation](https://docs.ockam.io/reference/protocols/access-controls).
+    #[schema(example = "user1")]
     pub allow: Option<String>,
-    /// When connection is lost, how long to wait before retrying to connect to the TCP Outlet;
-    /// In milliseconds;
+
+    /// Time to wait in milliseconds before retrying to connect to the TCP Outlet.
     #[serde(default = "retry_wait_default")]
     #[schema(default = retry_wait_default)]
     pub retry_wait: u64,
+
+    /// Kind of the Portal.
+    #[serde(default)]
+    #[schema(default = InletKind::default)]
+    pub kind: InletKind,
+
+    /// TLS Inlet implementation.
+    #[serde(default)]
+    #[schema(default = default_inlet_tls)]
+    pub tls: Option<InletTls>,
 }
+
+fn default_inlet_tls() -> Option<InletTls> {
+    None
+}
+
+fn default_via() -> Option<String> {
+    None
+}
+
+pub struct CreateInletRequestValidated {
+    pub name: Option<String>,
+    pub from: ockam_transport_core::HostnamePort,
+    pub to: MultiAddr,
+    pub identity: Option<Identifier>,
+    pub authorized: Option<Identifier>,
+    pub allow: Option<PolicyExpression>,
+    pub retry_wait: Duration,
+    pub kind: InletKind,
+    pub tls: Option<InletTls>,
+}
+
+impl TryFrom<CreateInletRequest> for CreateInletRequestValidated {
+    type Error = ControlApiError;
+
+    fn try_from(request: CreateInletRequest) -> Result<Self, Self::Error> {
+        let name = request.name;
+        let from = request.from.try_into()?;
+        let to = MultiAddr::try_from(request.to.as_str()).map_err(ControlApiError::from)?;
+        let identity = request
+            .identity
+            .map(|id| Identifier::from_str(&id).map_err(ControlApiError::from))
+            .transpose()?;
+        let authorized = request
+            .authorized
+            .map(|id| Identifier::from_str(&id).map_err(ControlApiError::from))
+            .transpose()?;
+        let allow = request
+            .allow
+            .map(|allow| PolicyExpression::from_str(&allow).map_err(ControlApiError::from))
+            .transpose()?;
+        let retry_wait = Duration::from_millis(request.retry_wait);
+        let kind = request.kind;
+        let tls = request.tls;
+
+        Ok(CreateInletRequestValidated {
+            name,
+            from,
+            to,
+            identity,
+            authorized,
+            allow,
+            retry_wait,
+            kind,
+            tls,
+        })
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct UpdateInletRequest {
-    /// Policy expression that will be used for access control to the TCP Inlet;
-    /// When omitted, the policy set for the "tcp-inlet" resource type will be used.
-    /// [Learn more about Policies expression on the Ockam documentation](https://docs.ockam.io/reference/protocols/access-controls).
+    /// Policy expression that will be used for access control to the TCP Inlet.
+    ///
+    /// If you don't provide it, the policy set for the "tcp-inlet" resource type will be used.
+    ///
+    /// [Learn more about Policy expressions on the Ockam documentation](https://docs.ockam.io/reference/protocols/access-controls).
+    #[schema(example = "user1")]
     pub allow: Option<String>,
 }
 
@@ -98,14 +197,19 @@ pub struct UpdateInletRequest {
 #[serde(rename_all = "kebab-case")]
 pub struct InletStatus {
     /// Name of the TCP Inlet
+    #[schema(example = "my-inlet")]
     pub name: String,
     /// Status of the TCP Inlet
+    #[schema(example = ConnectionStatus::Up)]
     pub status: ConnectionStatus,
     /// Bind address of the TCP Inlet
-    pub bind_address: HostnamePort,
+    #[schema(example = "127.0.0.1:1234")]
+    pub bind_address: String,
     /// The current route of the TCP Inlet, populated only when the status is `up`
+    // TODO: what shape does this have?
     pub current_route: Option<String>,
-    /// Multiaddress to the TCP Outlet
+    /// Route to the TCP Outlet
+    #[schema(example = "/project/default/service/forward_to_myrelay/secure/api/service/outlet")]
     pub to: String,
 }
 
@@ -117,7 +221,7 @@ impl TryFrom<crate::nodes::models::portal::InletStatus> for InletStatus {
 
         Ok(InletStatus {
             status: status.status.into(),
-            bind_address,
+            bind_address: bind_address.to_string(),
             name: status.alias,
             current_route: status.outlet_route.map(|r| r.to_string()),
             to: status.outlet_addr,

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/inlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/inlet.rs
@@ -1,5 +1,7 @@
+use crate::common_api::tcp_inlet_create::{parse_to_address, tcp_inlet_default_to_address};
 use crate::control_api::protocol::common::{ConnectionStatus, HostPort};
 use crate::control_api::ControlApiError;
+use crate::CliState;
 use ockam::identity::Identifier;
 use ockam_abac::PolicyExpression;
 use ockam_multiaddr::MultiAddr;
@@ -7,17 +9,6 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::time::Duration;
 use utoipa::ToSchema;
-
-fn tcp_inlet_default_bind_address() -> HostPort {
-    HostPort {
-        host: "127.0.0.1".to_string(),
-        port: 0,
-    }
-}
-
-fn retry_wait_default() -> u64 {
-    20000
-}
 
 #[derive(Debug, Serialize, Deserialize, Default, ToSchema)]
 #[serde(rename_all = "kebab-case")]
@@ -80,6 +71,7 @@ pub struct CreateInletRequest {
     /// If you are passing just the service name, consider using `via` to specify the
     /// relay name.
     #[schema(example = "/project/default/service/forward_to_myrelay/secure/api/service/outlet")]
+    #[serde(default = "tcp_inlet_default_to_address")]
     pub to: String,
 
     /// Name of the relay that this TCP Inlet will use to connect to the TCP Outlet.
@@ -124,6 +116,17 @@ pub struct CreateInletRequest {
     pub tls: Option<InletTls>,
 }
 
+fn tcp_inlet_default_bind_address() -> HostPort {
+    HostPort {
+        host: "127.0.0.1".to_string(),
+        port: 0,
+    }
+}
+
+fn retry_wait_default() -> u64 {
+    20000
+}
+
 fn default_inlet_tls() -> Option<InletTls> {
     None
 }
@@ -144,13 +147,19 @@ pub struct CreateInletRequestValidated {
     pub tls: Option<InletTls>,
 }
 
-impl TryFrom<CreateInletRequest> for CreateInletRequestValidated {
-    type Error = ControlApiError;
-
-    fn try_from(request: CreateInletRequest) -> Result<Self, Self::Error> {
+impl CreateInletRequestValidated {
+    pub async fn from_request(
+        state: &CliState,
+        request: CreateInletRequest,
+    ) -> Result<Self, ControlApiError> {
         let name = request.name;
         let from = request.from.try_into()?;
-        let to = MultiAddr::try_from(request.to.as_str()).map_err(ControlApiError::from)?;
+        let to = {
+            let to = parse_to_address(state, request.to, request.via.as_ref())
+                .await
+                .map_err(ControlApiError::from)?;
+            MultiAddr::try_from(to.as_str()).map_err(ControlApiError::from)?
+        };
         let identity = request
             .identity
             .map(|id| Identifier::from_str(&id).map_err(ControlApiError::from))
@@ -218,7 +227,6 @@ impl TryFrom<crate::nodes::models::portal::InletStatus> for InletStatus {
 
     fn try_from(status: crate::nodes::models::portal::InletStatus) -> Result<Self, Self::Error> {
         let bind_address = HostPort::try_from(status.bind_addr.as_str())?;
-
         Ok(InletStatus {
             status: status.status.into(),
             bind_address: bind_address.to_string(),

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/inlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/inlet.rs
@@ -1,4 +1,4 @@
-use crate::control_api::protocol::common::{ConnectionStatus, HostnamePort};
+use crate::control_api::protocol::common::{ConnectionStatus, HostPort};
 use crate::control_api::ControlApiError;
 use ockam::identity::Identifier;
 use ockam_abac::PolicyExpression;
@@ -8,9 +8,9 @@ use std::str::FromStr;
 use std::time::Duration;
 use utoipa::ToSchema;
 
-fn tcp_inlet_default_bind_address() -> HostnamePort {
-    HostnamePort {
-        hostname: "127.0.0.1".to_string(),
+fn tcp_inlet_default_bind_address() -> HostPort {
+    HostPort {
+        host: "127.0.0.1".to_string(),
         port: 0,
     }
 }
@@ -64,10 +64,10 @@ pub struct CreateInletRequest {
     /// At least the port must be provided.
     ///
     /// The default host is `127.0.0.1`.
-    /// If not set, a random port will be used on the default host.
+    /// If not set, a random port will be used.
     #[serde(default = "tcp_inlet_default_bind_address")]
     #[schema(default = tcp_inlet_default_bind_address)]
-    pub from: HostnamePort,
+    pub from: HostPort,
 
     /// Route to a TCP Outlet or the name of the TCP Outlet service you want to connect to.
     ///
@@ -217,7 +217,7 @@ impl TryFrom<crate::nodes::models::portal::InletStatus> for InletStatus {
     type Error = ockam_core::Error;
 
     fn try_from(status: crate::nodes::models::portal::InletStatus) -> Result<Self, Self::Error> {
-        let bind_address = HostnamePort::try_from(status.bind_addr.as_str())?;
+        let bind_address = HostPort::try_from(status.bind_addr.as_str())?;
 
         Ok(InletStatus {
             status: status.status.into(),

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/inlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/inlet.rs
@@ -1,10 +1,11 @@
 use crate::common_api::tcp_inlet_create::{parse_to_address, tcp_inlet_default_to_address};
-use crate::control_api::protocol::common::{ConnectionStatus, HostPort};
+use crate::control_api::protocol::common::{ConnectionStatus, HostPortRequest, HostPortResponse};
 use crate::control_api::ControlApiError;
 use crate::CliState;
 use ockam::identity::Identifier;
 use ockam_abac::PolicyExpression;
 use ockam_multiaddr::MultiAddr;
+use ockam_transport_core::HostnamePort;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::time::Duration;
@@ -58,7 +59,8 @@ pub struct CreateInletRequest {
     /// If not set, a random port will be used.
     #[serde(default = "tcp_inlet_default_bind_address")]
     #[schema(default = tcp_inlet_default_bind_address)]
-    pub from: HostPort,
+    #[schema(example = "127.0.0.1:1234")]
+    pub from: HostPortRequest,
 
     /// Route to a TCP Outlet or the name of the TCP Outlet service you want to connect to.
     ///
@@ -116,8 +118,8 @@ pub struct CreateInletRequest {
     pub tls: Option<InletTls>,
 }
 
-fn tcp_inlet_default_bind_address() -> HostPort {
-    HostPort {
+fn tcp_inlet_default_bind_address() -> HostPortRequest {
+    HostPortRequest {
         host: "127.0.0.1".to_string(),
         port: 0,
     }
@@ -212,11 +214,10 @@ pub struct InletStatus {
     #[schema(example = ConnectionStatus::Up)]
     pub status: ConnectionStatus,
     /// Bind address of the TCP Inlet
-    #[schema(example = "127.0.0.1:1234")]
-    pub bind_address: String,
-    /// The current route of the TCP Inlet, populated only when the status is `up`
-    // TODO: what shape does this have?
-    pub current_route: Option<String>,
+    pub bind_address: HostPortResponse,
+    /// The internal route of the TCP Inlet to the Tcp Outlet.
+    /// Populated only after the connection is done (i.e., the status is `up`).
+    pub internal_route: Option<String>,
     /// Route to the TCP Outlet
     #[schema(example = "/project/default/service/forward_to_myrelay/secure/api/service/outlet")]
     pub to: String,
@@ -226,12 +227,16 @@ impl TryFrom<crate::nodes::models::portal::InletStatus> for InletStatus {
     type Error = ockam_core::Error;
 
     fn try_from(status: crate::nodes::models::portal::InletStatus) -> Result<Self, Self::Error> {
-        let bind_address = HostPort::try_from(status.bind_addr.as_str())?;
+        let bind_address = HostnamePort::try_from(status.bind_addr.as_str())?;
+        let bind_address = HostPortResponse {
+            host: bind_address.hostname,
+            port: bind_address.port,
+        };
         Ok(InletStatus {
             status: status.status.into(),
-            bind_address: bind_address.to_string(),
+            bind_address,
             name: status.alias,
-            current_route: status.outlet_route.map(|r| r.to_string()),
+            internal_route: status.outlet_route.map(|r| r.to_string()),
             to: status.outlet_addr,
         })
     }

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/outlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/outlet.rs
@@ -22,7 +22,7 @@ pub enum OutletKind {
 #[derive(Debug, Serialize, Deserialize, EnumString, ToSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum OutletTls {
-    /// If the destination uses TLS, the connection will be fully validated.
+    /// The destination is expected to be a TLS endpoint and will be fully validated.
     Validate,
 }
 

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/outlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/outlet.rs
@@ -1,4 +1,4 @@
-use crate::control_api::protocol::common::HostPort;
+use crate::control_api::protocol::common::{HostPortRequest, HostPortResponse};
 use crate::control_api::ControlApiError;
 use ockam_abac::PolicyExpression;
 use ockam_core::Address;
@@ -43,7 +43,7 @@ pub struct CreateOutletRequest {
     /// Network address where your application is listening to, in the format `<host>:<port>`.
     /// Your TCP Outlet will forward raw TCP traffic to this destination.
     #[schema(example = "dev.environment:1234")]
-    pub to: HostPort,
+    pub to: HostPortRequest,
 
     /// The TLS configuration for the TCP Outlet.
     #[serde(default)]
@@ -115,8 +115,11 @@ pub struct UpdateOutletRequest {
 #[serde(rename_all = "kebab-case")]
 pub struct OutletStatus {
     /// Network address of the TCP Outlet, in the format `<host>:<port>`.
-    #[schema(example = "dev.environment:1234")]
-    pub to: String,
+    pub to: HostPortResponse,
+    /// Name, or service address, of the TCP Outlet.
+    /// It acts as the identifier of the TCP Outlet within the node.
+    #[schema(example = "my-outlet", deprecated)]
+    pub address: String,
     /// Name, or service address, of the TCP Outlet.
     /// It acts as the identifier of the TCP Outlet within the node.
     #[schema(example = "my-outlet")]
@@ -125,12 +128,19 @@ pub struct OutletStatus {
     pub privileged: bool,
 }
 
-impl From<crate::nodes::models::portal::OutletStatus> for OutletStatus {
-    fn from(status: crate::nodes::models::portal::OutletStatus) -> Self {
-        OutletStatus {
-            to: status.to.to_string(),
+impl TryFrom<crate::nodes::models::portal::OutletStatus> for OutletStatus {
+    type Error = ockam_core::Error;
+
+    fn try_from(status: crate::nodes::models::portal::OutletStatus) -> Result<Self, Self::Error> {
+        let to = HostPortResponse {
+            host: status.to.hostname,
+            port: status.to.port,
+        };
+        Ok(OutletStatus {
+            to,
+            address: status.worker_address.address().to_string(),
             name: status.worker_address.address().to_string(),
             privileged: status.privileged,
-        }
+        })
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/outlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/outlet.rs
@@ -30,15 +30,17 @@ pub enum OutletTls {
 #[serde(rename_all = "kebab-case")]
 pub struct CreateOutletRequest {
     /// Service address of your TCP Outlet.
+    ///
     /// This unique address identifies the TCP Outlet worker on the Node on your local machine.
     /// Examples are `/service/my-outlet` or `my-outlet`.
+    ///
     /// If not provided, `outlet` will be used, or a random address will be generated if `outlet` is taken.
     /// You will need this address when creating a TCP Inlet.
     #[serde(alias = "address")]
     #[schema(example = "my-outlet")]
     pub name: Option<String>,
 
-    /// Network address where your application is listening to.
+    /// Network address where your application is listening to, in the format `<host>:<port>`.
     /// Your TCP Outlet will forward raw TCP traffic to this destination.
     #[schema(example = "dev.environment:1234")]
     pub to: String,
@@ -49,7 +51,9 @@ pub struct CreateOutletRequest {
     pub tls: Option<OutletTls>,
 
     /// Policy expression that will be used for access control to the TCP Outlet.
+    ///
     /// If you don't provide it, the policy set for the "tcp-outlet" resource type will be used.
+    ///
     /// [Learn more about Policy expressions on the Ockam documentation](https://docs.ockam.io/reference/protocols/access-controls).
     #[schema(example = "user1")]
     pub allow: Option<String>,
@@ -99,7 +103,9 @@ impl TryFrom<CreateOutletRequest> for CreateOutletRequestValidated {
 #[serde(rename_all = "kebab-case")]
 pub struct UpdateOutletRequest {
     /// Policy expression that will be used for access control to the TCP Outlet.
+    ///
     /// If you don't provide it, the policy set for the "tcp-outlet" resource type will be used.
+    ///
     /// [Learn more about Policy expressions on the Ockam documentation](https://docs.ockam.io/reference/protocols/access-controls).
     #[schema(example = "user1")]
     pub allow: Option<String>,
@@ -108,10 +114,10 @@ pub struct UpdateOutletRequest {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct OutletStatus {
-    /// The network address of the TCP Outlet.
+    /// Network address of the TCP Outlet, in the format `<host>:<port>`.
     #[schema(example = "dev.environment:1234")]
     pub to: String,
-    /// The name, or service address, of the TCP Outlet.
+    /// Name, or service address, of the TCP Outlet.
     /// It acts as the identifier of the TCP Outlet within the node.
     #[schema(example = "my-outlet")]
     pub name: String,

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/outlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/outlet.rs
@@ -28,6 +28,7 @@ pub enum OutletTls {
 #[serde(rename_all = "kebab-case")]
 pub struct CreateOutletRequest {
     /// The kind of the outlet
+    #[serde(default)]
     pub kind: OutletKind,
     /// The address of the outlet, also acts as an identifier for the resource
     pub address: Option<String>,

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/outlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/outlet.rs
@@ -1,4 +1,4 @@
-use crate::control_api::protocol::common::HostnamePort;
+use crate::control_api::protocol::common::HostPort;
 use crate::control_api::ControlApiError;
 use ockam_abac::PolicyExpression;
 use ockam_core::Address;
@@ -43,7 +43,7 @@ pub struct CreateOutletRequest {
     /// Network address where your application is listening to, in the format `<host>:<port>`.
     /// Your TCP Outlet will forward raw TCP traffic to this destination.
     #[schema(example = "dev.environment:1234")]
-    pub to: String,
+    pub to: HostPort,
 
     /// The TLS configuration for the TCP Outlet.
     #[serde(default)]
@@ -70,7 +70,7 @@ fn default_outlet_tls() -> Option<OutletTls> {
 
 pub struct CreateOutletRequestValidated {
     pub name: Option<Address>,
-    pub to: HostnamePort,
+    pub to: ockam_transport_core::HostnamePort,
     pub tls: Option<OutletTls>,
     pub allow: Option<PolicyExpression>,
     pub kind: OutletKind,
@@ -84,7 +84,7 @@ impl TryFrom<CreateOutletRequest> for CreateOutletRequestValidated {
             Some(name) => Some(Address::from_str(&name).map_err(crate::error::ParseError::from)?),
             None => None,
         };
-        let to = HostnamePort::try_from(request.to.as_str()).map_err(ControlApiError::from)?;
+        let to = request.to.try_into()?;
         let allow = match &request.allow {
             Some(allow) => Some(PolicyExpression::from_str(allow).map_err(ControlApiError::from)?),
             None => None,

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/outlet.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/outlet.rs
@@ -1,8 +1,13 @@
 use crate::control_api::protocol::common::HostnamePort;
+use crate::control_api::ControlApiError;
+use ockam_abac::PolicyExpression;
+use ockam_core::Address;
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use strum::EnumString;
 use utoipa::ToSchema;
 
-#[derive(Debug, Serialize, Deserialize, Default, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, EnumString, Default, ToSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum OutletKind {
     /// Works as a regular TCP Outlet. It's compatible with UDP Puncture,
@@ -14,64 +19,111 @@ pub enum OutletKind {
     Privileged,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, EnumString, ToSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum OutletTls {
-    #[default]
-    /// No TLS
-    None,
-    /// The destination uses TLS, the connection will be fully validated.
+    /// If the destination uses TLS, the connection will be fully validated.
     Validate,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct CreateOutletRequest {
-    /// The kind of the outlet
+    /// Service address of your TCP Outlet.
+    /// This unique address identifies the TCP Outlet worker on the Node on your local machine.
+    /// Examples are `/service/my-outlet` or `my-outlet`.
+    /// If not provided, `outlet` will be used, or a random address will be generated if `outlet` is taken.
+    /// You will need this address when creating a TCP Inlet.
+    #[serde(alias = "address")]
+    #[schema(example = "my-outlet")]
+    pub name: Option<String>,
+
+    /// Network address where your application is listening to.
+    /// Your TCP Outlet will forward raw TCP traffic to this destination.
+    #[schema(example = "dev.environment:1234")]
+    pub to: String,
+
+    /// The TLS configuration for the TCP Outlet.
     #[serde(default)]
-    pub kind: OutletKind,
-    /// The address of the outlet, also acts as an identifier for the resource
-    pub address: Option<String>,
-    /// The destination address of the TCP connection
-    pub to: HostnamePort,
-    /// The TLS configuration for the outlet
-    #[serde(default)]
-    #[schema(default = "None")]
-    pub tls: OutletTls,
-    /// Policy expression that will be used for access control to the TCP Outlet;
-    /// by default, the policy set for the "tcp-outlet" resource type will be used.
-    /// [Learn more about Policies expression on the Ockam documentation](https://docs.ockam.io/reference/protocols/access-controls).
+    #[schema(default = default_outlet_tls)]
+    pub tls: Option<OutletTls>,
+
+    /// Policy expression that will be used for access control to the TCP Outlet.
+    /// If you don't provide it, the policy set for the "tcp-outlet" resource type will be used.
+    /// [Learn more about Policy expressions on the Ockam documentation](https://docs.ockam.io/reference/protocols/access-controls).
+    #[schema(example = "user1")]
     pub allow: Option<String>,
+
+    /// The kind of the TCP Outlet.
+    #[serde(default)]
+    #[schema(default = OutletKind::default)]
+    pub kind: OutletKind,
+}
+
+fn default_outlet_tls() -> Option<OutletTls> {
+    None
+}
+
+pub struct CreateOutletRequestValidated {
+    pub name: Option<Address>,
+    pub to: HostnamePort,
+    pub tls: Option<OutletTls>,
+    pub allow: Option<PolicyExpression>,
+    pub kind: OutletKind,
+}
+
+impl TryFrom<CreateOutletRequest> for CreateOutletRequestValidated {
+    type Error = ControlApiError;
+
+    fn try_from(request: CreateOutletRequest) -> Result<Self, Self::Error> {
+        let name = match request.name {
+            Some(name) => Some(Address::from_str(&name).map_err(crate::error::ParseError::from)?),
+            None => None,
+        };
+        let to = HostnamePort::try_from(request.to.as_str()).map_err(ControlApiError::from)?;
+        let allow = match &request.allow {
+            Some(allow) => Some(PolicyExpression::from_str(allow).map_err(ControlApiError::from)?),
+            None => None,
+        };
+        Ok(CreateOutletRequestValidated {
+            name,
+            to,
+            tls: request.tls,
+            allow,
+            kind: request.kind,
+        })
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct UpdateOutletRequest {
-    /// Policy expression that will be used for access control to the TCP Outlet;
-    /// by default, the policy set for the "tcp-outlet" resource type will be used.
-    /// [Learn more about Policies expression on the Ockam documentation](https://docs.ockam.io/reference/protocols/access-controls).
+    /// Policy expression that will be used for access control to the TCP Outlet.
+    /// If you don't provide it, the policy set for the "tcp-outlet" resource type will be used.
+    /// [Learn more about Policy expressions on the Ockam documentation](https://docs.ockam.io/reference/protocols/access-controls).
+    #[schema(example = "user1")]
     pub allow: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct OutletStatus {
-    /// The address of the outlet
-    pub to: HostnamePort,
-    /// The address of the worker, this also acts as an identifier of the TCP Outlet within the node
-    pub address: String,
-    /// Whether the outlet is of privileged kind
+    /// The network address of the TCP Outlet.
+    #[schema(example = "dev.environment:1234")]
+    pub to: String,
+    /// The name, or service address, of the TCP Outlet.
+    /// It acts as the identifier of the TCP Outlet within the node.
+    #[schema(example = "my-outlet")]
+    pub name: String,
+    /// Whether the TCP Outlet is of privileged kind.
     pub privileged: bool,
 }
 
 impl From<crate::nodes::models::portal::OutletStatus> for OutletStatus {
     fn from(status: crate::nodes::models::portal::OutletStatus) -> Self {
         OutletStatus {
-            to: HostnamePort {
-                hostname: status.to.hostname,
-                port: status.to.port,
-            },
-            address: status.worker_address.address().to_string(),
+            to: status.to.to_string(),
+            name: status.worker_address.address().to_string(),
             privileged: status.privileged,
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/relay.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/relay.rs
@@ -8,7 +8,7 @@ pub struct CreateRelayRequest {
     /// Name of Relay;
     /// Whe omitted, a random name will be generated
     pub name: Option<String>,
-    /// Multiaddress to the node that will be used as a relay;
+    /// Route to the node that will be used as a relay;
     #[schema(example = "/project/default")]
     pub to: String,
     /// The address of the relay;

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/relay.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/relay.rs
@@ -5,18 +5,22 @@ use utoipa::ToSchema;
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct CreateRelayRequest {
-    /// Name of Relay;
-    /// Whe omitted, a random name will be generated
+    /// Name of Relay.
+    /// When omitted, a random name will be generated.
     pub name: Option<String>,
-    /// Route to the node that will be used as a relay;
+
+    /// Route to the node that will be used as a Relay.
     #[schema(example = "/project/default")]
     pub to: String,
-    /// The address of the relay;
-    /// The resulting address in the relay will be `forward_to_{address}`;
-    /// When omitted, the name will be used;
+
+    /// The address of the Relay.
+    /// When omitted, the name will be used.
+    ///
+    /// The resulting address in the Relay will be `forward_to_{address}`.
     pub address: Option<String>,
-    /// Only allows relay node with the provided identity;
-    /// When omitted, all identities are allowed;
+
+    /// Restrict access to the Relay to the provided identity.
+    /// When omitted, all identities are allowed.
     #[schema(example = "Id3b788c6a89de8b1f2fd13743eb3123178cf6ec7c9253be8ddcf7e154abe016a")]
     pub authorized: Option<String>,
 }
@@ -24,14 +28,16 @@ pub struct CreateRelayRequest {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct RelayStatus {
-    /// Name of the relay
+    /// Name of the Relay
     pub name: String,
-    /// Multiaddress to the node that is used as a relay
+
+    /// Route to the node that is used as a Relay
     pub to: String,
-    /// The address of the relay within the relay;
-    /// Usually it follows the form `forward_to_{address}`
+
+    /// The address of the Relay within the node.
     pub remote_address: Option<String>,
-    /// The status of the relay
+
+    /// The status of the Relay
     pub status: ConnectionStatus,
 }
 

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/ticket.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/ticket.rs
@@ -14,18 +14,22 @@ fn default_expires_in() -> u64 {
 #[serde(rename_all = "kebab-case")]
 pub struct CreateTicketRequest {
     pub attributes: Attributes,
+
     /// Identity to use when contacting the Authority node.
     /// When omitted, the default identity will be used.
     #[schema(examples("Id3b788c6a89de8b1f2fd13743eb3123178cf6ec7c9253be8ddcf7e154abe016a"))]
     pub identity: Option<String>,
+
     /// Project information to use when creating the ticket.
     #[serde(default = "default_project_information")]
     #[schema(default = default_project_information)]
     pub project: Project,
+
     /// Number of times the ticket can be used to enroll.
     #[serde(default = "default_usage_count")]
     #[schema(default = default_usage_count)]
     pub usage_count: u64,
+
     /// Duration for which the enrollment ticket is valid.
     /// The value is expressed in seconds.
     #[serde(default = "default_expires_in")]
@@ -37,15 +41,14 @@ pub struct CreateTicketRequest {
 #[serde(rename_all = "kebab-case")]
 pub struct Ticket {
     /// Encoded ticket.
-    /// The ticket is encoded in a format understood by the Ockam Command and it may
-    /// vary over time.
+    /// The ticket is encoded in a format understood by the Ockam Command and it may vary over time.
     pub encoded: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct EnrollProjectRequest {
     /// Identity to enroll.
-    /// When omitted, the default identity will be used.
+    /// When omitted, the node's identity will be used.
     #[schema(examples("Id3b788c6a89de8b1f2fd13743eb3123178cf6ec7c9253be8ddcf7e154abe016a"))]
     pub identity: Option<String>,
 
@@ -55,10 +58,12 @@ pub struct EnrollProjectRequest {
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct AuthorityInformation {
-    /// Route to the authority node
+    /// Route to the authority node.
     pub route: String,
-    /// Identity of the authority node
+
+    /// Identity of the authority node.
     pub identity: String,
-    /// Hostname and port of the authority node
+
+    /// Hostname and port of the authority node.
     pub address: HostPortResponse,
 }

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/ticket.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/ticket.rs
@@ -1,5 +1,5 @@
 use super::common::{default_project_information, Attributes, Project};
-use crate::control_api::protocol::common::HostnamePort;
+use crate::control_api::protocol::common::HostPort;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -62,5 +62,5 @@ pub struct AuthorityInformation {
     /// Identity of the authority node
     pub identity: String,
     /// Hostname and port of the authority node
-    pub address: HostnamePort,
+    pub address: HostPort,
 }

--- a/implementations/rust/ockam/ockam_api/src/control_api/protocol/ticket.rs
+++ b/implementations/rust/ockam/ockam_api/src/control_api/protocol/ticket.rs
@@ -1,5 +1,4 @@
-use super::common::{default_project_information, Attributes, Project};
-use crate::control_api::protocol::common::HostPort;
+use super::common::{default_project_information, Attributes, HostPortResponse, Project};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -15,19 +14,19 @@ fn default_expires_in() -> u64 {
 #[serde(rename_all = "kebab-case")]
 pub struct CreateTicketRequest {
     pub attributes: Attributes,
-    /// Identity to use when contacting the Authority node;
-    /// When omitted, the default identity will be used
+    /// Identity to use when contacting the Authority node.
+    /// When omitted, the default identity will be used.
     #[schema(examples("Id3b788c6a89de8b1f2fd13743eb3123178cf6ec7c9253be8ddcf7e154abe016a"))]
     pub identity: Option<String>,
-    /// Project information to use when creating the ticket;
+    /// Project information to use when creating the ticket.
     #[serde(default = "default_project_information")]
     #[schema(default = default_project_information)]
     pub project: Project,
-    /// Number of times the ticket can be used to enroll;
+    /// Number of times the ticket can be used to enroll.
     #[serde(default = "default_usage_count")]
     #[schema(default = default_usage_count)]
     pub usage_count: u64,
-    /// Duration for which the enrollment ticket is valid;
+    /// Duration for which the enrollment ticket is valid.
     /// The value is expressed in seconds.
     #[serde(default = "default_expires_in")]
     #[schema(default = default_expires_in)]
@@ -37,21 +36,20 @@ pub struct CreateTicketRequest {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct Ticket {
-    /// Encoded ticket;
-    /// The ticket is encoded in a format that is understood by the Ockam Command and it may
+    /// Encoded ticket.
+    /// The ticket is encoded in a format understood by the Ockam Command and it may
     /// vary over time.
     pub encoded: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct EnrollProjectRequest {
-    /// Identity to enroll;
-    /// When omitted, the default identity will be used
+    /// Identity to enroll.
+    /// When omitted, the default identity will be used.
     #[schema(examples("Id3b788c6a89de8b1f2fd13743eb3123178cf6ec7c9253be8ddcf7e154abe016a"))]
     pub identity: Option<String>,
 
-    /// Ticket to use for enrollment;
-    /// The encoded ticket
+    /// Ticket to use for enrollment.
     pub ticket: String,
 }
 
@@ -62,5 +60,5 @@ pub struct AuthorityInformation {
     /// Identity of the authority node
     pub identity: String,
     /// Hostname and port of the authority node
-    pub address: HostPort,
+    pub address: HostPortResponse,
 }

--- a/implementations/rust/ockam/ockam_api/src/error.rs
+++ b/implementations/rust/ockam/ockam_api/src/error.rs
@@ -64,6 +64,9 @@ pub enum ParseError {
     Addr(#[from] std::net::AddrParseError),
 
     #[error(transparent)]
+    OckamAddress(#[from] ockam_core::AddressParseError),
+
+    #[error(transparent)]
     Url(#[from] url::ParseError),
 
     #[error(transparent)]

--- a/implementations/rust/ockam/ockam_api/src/error.rs
+++ b/implementations/rust/ockam/ockam_api/src/error.rs
@@ -60,6 +60,13 @@ impl From<miette::Error> for ApiError {
 
 #[derive(Debug, thiserror::Error, Diagnostic)]
 pub enum ParseError {
+    #[error("invalid value '({value:?})' for '{var_name}'{err}")]
+    Validation {
+        var_name: String,
+        value: String,
+        err: String,
+    },
+
     #[error(transparent)]
     Addr(#[from] std::net::AddrParseError),
 
@@ -83,6 +90,17 @@ pub enum ParseError {
 
     #[error(transparent)]
     MultiAddr(#[from] ockam_multiaddr::Error),
+}
+
+impl ParseError {
+    #[track_caller]
+    pub fn validation<T: fmt::Debug>(var_name: &str, value: T, err: Option<&str>) -> Self {
+        ParseError::Validation {
+            var_name: var_name.to_string(),
+            value: format!("{:?}", value),
+            err: err.map(|e| format!(": {e}")).unwrap_or_default(),
+        }
+    }
 }
 
 impl From<ParseError> for ockam_core::Error {

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -43,6 +43,7 @@ pub mod influxdb;
 pub mod logs;
 mod schema;
 
+pub mod common_api;
 pub mod control_api;
 mod date;
 mod http;

--- a/implementations/rust/ockam/ockam_command/src/influxdb/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/inlet/create.rs
@@ -41,7 +41,7 @@ pub struct CreateCommand {
     #[arg(long, display_order = 900, id = "NODE_NAME", value_parser = extract_address_value)]
     pub at: Option<String>,
 
-    /// Address on which to accept InfluxDB connections, in the format `<scheme>://<hostname>:<port>`.
+    /// Address on which to accept InfluxDB connections, in the format `<scheme>://<host>:<port>`.
     /// At least the port must be provided. The default scheme is `tcp` and the default hostname is `127.0.0.1`.
     /// If the argument is not set, a random port will be used on the default address.
     ///

--- a/implementations/rust/ockam/ockam_command/src/influxdb/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/inlet/create.rs
@@ -1,6 +1,6 @@
 use crate::node::util::initialize_default_node;
 use crate::shared_args::OptionalTimeoutArg;
-use crate::tcp::inlet::create::{tcp_inlet_default_from_addr, tcp_inlet_default_to_addr};
+use crate::tcp::inlet::create::tcp_inlet_default_from_addr;
 use crate::tcp::util::alias_parser;
 use crate::util::parsers::duration_parser;
 use crate::util::parsers::hostname_parser;
@@ -18,6 +18,7 @@ use ockam_abac::PolicyExpression;
 use ockam_api::address::extract_address_value;
 use ockam_api::cli_state::random_name;
 use ockam_api::colors::color_primary;
+use ockam_api::common_api::tcp_inlet_create::{parse_to_address, tcp_inlet_default_to_address};
 use ockam_api::influxdb::{InfluxDBPortals, LeaseUsage};
 use ockam_api::nodes::models::portal::InletStatus;
 use ockam_api::nodes::BackgroundNodeClient;
@@ -60,7 +61,7 @@ pub struct CreateCommand {
     /// or just the name of the service as `outlet` or `/service/outlet`.
     /// If you are passing just the service name, consider using `--via` to specify the
     /// relay name (e.g. `ockam tcp-inlet create --to outlet --via myrelay`).
-    #[arg(long, display_order = 900, id = "ROUTE", default_value_t = tcp_inlet_default_to_addr())]
+    #[arg(long, display_order = 900, id = "ROUTE", default_value_t = tcp_inlet_default_to_address())]
     pub to: String,
 
     /// Name of the relay that this InfluxDB Inlet will use to connect to the InfluxDB Outlet.
@@ -288,12 +289,7 @@ impl CreateCommand {
             .into_diagnostic()?;
         port_is_free_guard(&from)?;
 
-        self.to = crate::tcp::inlet::create::CreateCommand::parse_arg_to(
-            opts.state.clone(),
-            self.to,
-            self.via.as_ref(),
-        )
-        .await?;
+        self.to = parse_to_address(&opts.state, self.to, self.via.as_ref()).await?;
         if self.to().matches(0, &[proto::Project::CODE.into()]) && self.authorized.is_some() {
             return Err(miette!(
                 "--authorized can not be used with project addresses"

--- a/implementations/rust/ockam/ockam_command/src/influxdb/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/outlet/create.rs
@@ -29,7 +29,7 @@ pub struct CreateCommand {
     #[arg(value_parser = extract_address_value)]
     pub name: Option<String>,
 
-    /// Address where your InfluxDB server is running, in the format `<scheme>://<hostname>:<port>`.
+    /// Address where your InfluxDB server is running, in the format `<scheme>://<host>:<port>`.
     /// At least the port must be provided. The default scheme is `tcp` and the default hostname is `127.0.0.1`.
     #[arg(long, display_order = 900, id = "SOCKET_ADDRESS", value_parser = hostname_parser)]
     pub to: SchemeHostnamePort,

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
@@ -25,7 +25,7 @@ pub struct CreateCommand {
     #[arg(long, default_value_t = kafka_inlet_default_addr())]
     addr: String,
 
-    /// The address where the client will connect, in the format `<scheme>://<hostname>:<port>`.
+    /// The address where the client will connect, in the format `<scheme>://<host>:<port>`.
     #[arg(long, id = "SOCKET_ADDRESS", default_value_t = kafka_default_consumer_server(), value_parser = hostname_parser)]
     bootstrap_server: SchemeHostnamePort,
 

--- a/implementations/rust/ockam/ockam_command/src/kafka/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/inlet/create.rs
@@ -45,7 +45,7 @@ pub struct CreateCommand {
     #[arg(long, default_value_t = kafka_inlet_default_addr())]
     pub addr: String,
 
-    /// The address where the client will connect, in the format `<scheme>://<hostname>:<port>`.
+    /// The address where the client will connect, in the format `<scheme>://<host>:<port>`.
     #[arg(long, id = "SOCKET_ADDRESS", default_value_t = kafka_default_inlet_bind_address(), value_parser = hostname_parser)]
     pub from: SchemeHostnamePort,
 

--- a/implementations/rust/ockam/ockam_command/src/kafka/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/inlet/create.rs
@@ -3,7 +3,7 @@ use crate::kafka::make_brokers_port_range;
 use crate::node::util::initialize_default_node;
 use crate::tcp::util::alias_parser;
 use crate::util::parsers::hostname_parser;
-use crate::util::{print_warning_for_deprecated_flag_replaced, process_nodes_multiaddr};
+use crate::util::print_warning_for_deprecated_flag_replaced;
 use crate::{
     docs,
     kafka::{kafka_default_inlet_bind_address, kafka_inlet_default_addr},
@@ -16,6 +16,7 @@ use colorful::Colorful;
 use miette::miette;
 use ockam::transport::SchemeHostnamePort;
 use ockam_abac::PolicyExpression;
+use ockam_api::address::process_nodes_multiaddr;
 use ockam_api::colors::{color_primary, color_warn};
 use ockam_api::kafka::portal::KafkaPortals;
 use ockam_api::kafka::{ConsumerPublishing, ConsumerResolution};
@@ -243,7 +244,7 @@ impl CreateCommand {
             ));
         }
 
-        self.to = process_nodes_multiaddr(&self.to, opts.state.clone()).await?;
+        self.to = process_nodes_multiaddr(&self.to, &opts.state).await?;
         Ok(self)
     }
 

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
@@ -25,7 +25,7 @@ pub struct CreateCommand {
     #[arg(long, default_value_t = kafka_inlet_default_addr())]
     addr: String,
 
-    /// The address where the client will connect, in the format `<scheme>://<hostname>:<port>`.
+    /// The address where the client will connect, in the format `<scheme>://<host>:<port>`.
     #[arg(long, id = "SOCKET_ADDRESS", default_value_t = kafka_default_producer_server(), value_parser = hostname_parser)]
     bootstrap_server: SchemeHostnamePort,
 

--- a/implementations/rust/ockam/ockam_command/src/lease/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/mod.rs
@@ -1,13 +1,13 @@
 use clap::{Args, Subcommand};
 
 use self::revoke::RevokeCommand;
-use crate::util::process_nodes_multiaddr;
 use crate::{Command, CommandGlobalOpts, Error};
 pub use create::CreateCommand;
 pub use list::ListCommand;
 pub use show::ShowCommand;
 
 use miette::IntoDiagnostic;
+use ockam_api::address::process_nodes_multiaddr;
 use ockam_api::CliState;
 use ockam_multiaddr::MultiAddr;
 use ockam_node::Context;
@@ -75,5 +75,5 @@ async fn resolve_at_arg(at: &MultiAddr, state: Arc<CliState>) -> miette::Result<
 
     // Parse "to" as a multiaddr again with all the values in place
     let to = MultiAddr::from_str(&at).into_diagnostic()?;
-    process_nodes_multiaddr(&to, state).await
+    process_nodes_multiaddr(&to, &state).await
 }

--- a/implementations/rust/ockam/ockam_command/src/project/static/ticket/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/project/static/ticket/long_about.txt
@@ -1,6 +1,6 @@
 The `project ticket` command allows you to create a one-time enrollment ticket, and provide custom attributes, after you have run `ockam enroll`. This is typically only done by Project administrators. How long the ticket is valid, and how many times it can be redeemed is also configurable via this command. Once redeemed, the attributes in this ticket are assigned to its redeemer. You can also use the `--relay` argument to allow the other Identity to create a Relay at the given address. The `--enroller` argument allows the Identity using the ticket to enroll other Identities into the Project, typically something that only administrators can do.
 
-Once you create a ticket, with attributes, for a Project, another Ockam node can use it later to enroll into this Project (using `ockam project enroll`).
+Once you create a ticket with the desired attributes for a Project, another Ockam node can use it later to enroll into this Project (using `ockam project enroll`).
 
 When another Ockam node runs `ockam project enroll` with this ticket (the Identity of that node is enrolled), they become a member of the Project, and they get a credential at the end of this process. The Project's Membership Authority will cryptographically attest to the specific attributes that the ticket was created with. As a member, they can request a credential whenever they need one. Credentials do not live forever, and expire.
 

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -8,7 +8,7 @@ use tracing::debug;
 
 use ockam::identity::Identifier;
 use ockam::Context;
-use ockam_api::address::extract_address_value;
+use ockam_api::address::{extract_address_value, process_nodes_multiaddr};
 use ockam_api::colors::color_primary;
 
 use ockam_api::nodes::models::relay::ReturnTiming;
@@ -20,7 +20,7 @@ use ockam_multiaddr::{MultiAddr, Protocol};
 
 use crate::node::util::initialize_default_node;
 use crate::shared_args::RetryOpts;
-use crate::util::{print_warning_for_deprecated_flag_no_effect, process_nodes_multiaddr};
+use crate::util::print_warning_for_deprecated_flag_no_effect;
 use crate::{docs, Command, CommandGlobalOpts, Error, Result};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
@@ -224,7 +224,7 @@ impl CreateCommand {
             at = at.replace("$DEFAULT_PROJECT_NAME", project_name);
         }
         let ma = MultiAddr::from_str(&at).map_err(|_| Error::arg_validation("at", at, None))?;
-        process_nodes_multiaddr(&ma, state).await
+        process_nodes_multiaddr(&ma, &state).await
     }
 
     fn return_timing(&self) -> ReturnTiming {

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -54,9 +54,9 @@ pub struct CreateCommand {
     #[arg(long, display_order = 900, id = "NODE_NAME", value_parser = extract_address_value)]
     pub at: Option<String>,
 
-    /// Address on which to accept TCP connections, in the format `<scheme>://<hostname>:<port>`.
-    /// At least the port must be provided. The default scheme is `tcp` and the default hostname is `127.0.0.1`.
-    /// If the argument is not set, a random port will be used on the default address.
+    /// Address on which to accept TCP connections, in the format `<scheme>://<host>:<port>`.
+    /// At least the port must be provided. The default scheme is `tcp` and the default host is `127.0.0.1`.
+    /// If the argument is not set, a random port will be used on the default address `tcp://127.0.0.1`.
     ///
     /// To enable TLS, the `ockam-tls-certificate` credential attribute is required.
     /// It will use the default project TLS certificate provider `/project/default/service/tls_certificate_provider`.
@@ -70,7 +70,7 @@ pub struct CreateCommand {
     ///
     /// If you are connecting to a remote node through a relay in the Orchestrator you can either
     /// provide the full route to the TCP Outlet as `/project/myproject/service/forward_to_myrelay/secure/api/service/outlet`,
-    /// or just the name of the service as `outlet` or `/service/outlet`.
+    /// or just the service name as `outlet` or `/service/outlet`.
     /// If you are passing just the service name, consider using `--via` to specify the
     /// relay name (e.g. `ockam tcp-inlet create --to outlet --via myrelay`).
     #[arg(long, display_order = 900, id = "ROUTE", default_value_t = tcp_inlet_default_to_addr())]
@@ -88,7 +88,8 @@ pub struct CreateCommand {
     #[arg(long, value_name = "IDENTITY_NAME", display_order = 900)]
     pub identity: Option<String>,
 
-    /// Authorized identifier for secure channel connection
+    /// Restrict access to the TCP Inlet to the provided identity.
+    /// When omitted, all identities are allowed.
     #[arg(long, name = "AUTHORIZED", display_order = 900)]
     pub authorized: Option<Identifier>,
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -4,10 +4,8 @@ use crate::tcp::util::alias_parser;
 use crate::util::parsers::duration_parser;
 use crate::util::parsers::hostname_parser;
 use crate::util::parsers::http_header_parser;
-use crate::util::{
-    port_is_free_guard, print_warning_for_deprecated_flag_replaced, process_nodes_multiaddr,
-};
-use crate::{docs, Command, CommandGlobalOpts, Error};
+use crate::util::{port_is_free_guard, print_warning_for_deprecated_flag_replaced};
+use crate::{docs, Command, CommandGlobalOpts};
 use async_trait::async_trait;
 use clap::builder::FalseyValueParser;
 use clap::Args;
@@ -34,6 +32,7 @@ use ockam_multiaddr::proto;
 use ockam_multiaddr::{MultiAddr, Protocol as _};
 use ockam_node::compat::asynchronous::resolve_peer;
 
+use ockam_api::common_api::tcp_inlet_create::{parse_to_address, tcp_inlet_default_to_address};
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -73,7 +72,7 @@ pub struct CreateCommand {
     /// or just the service name as `outlet` or `/service/outlet`.
     /// If you are passing just the service name, consider using `--via` to specify the
     /// relay name (e.g. `ockam tcp-inlet create --to outlet --via myrelay`).
-    #[arg(long, display_order = 900, id = "ROUTE", default_value_t = tcp_inlet_default_to_addr())]
+    #[arg(long, display_order = 900, id = "ROUTE", default_value_t = tcp_inlet_default_to_address())]
     pub to: String,
 
     /// Name of the relay that this TCP Inlet will use to connect to the TCP Outlet.
@@ -178,10 +177,6 @@ pub struct CreateCommand {
 
 pub(crate) fn tcp_inlet_default_from_addr() -> SchemeHostnamePort {
     SchemeHostnamePort::from_str("127.0.0.1:0").unwrap()
-}
-
-pub(crate) fn tcp_inlet_default_to_addr() -> String {
-    "/project/<default_project_name>/service/forward_to_<default_relay_name>/secure/api/service/<default_service_name>".to_string()
 }
 
 #[async_trait]
@@ -400,7 +395,7 @@ impl CreateCommand {
             .into_diagnostic()?;
         port_is_free_guard(&from)?;
 
-        self.to = Self::parse_arg_to(opts.state.clone(), self.to, self.via.as_ref()).await?;
+        self.to = parse_to_address(&opts.state, self.to, self.via.as_ref()).await?;
         if self.to().matches(0, &[proto::Project::CODE.into()]) && self.authorized.is_some() {
             return Err(miette!(
                 "--authorized can not be used with project addresses"
@@ -420,77 +415,10 @@ impl CreateCommand {
 
         Ok(self)
     }
-
-    pub(crate) async fn parse_arg_to(
-        state: Arc<CliState>,
-        to: impl Into<String>,
-        via: Option<&String>,
-    ) -> miette::Result<String> {
-        let mut to = to.into();
-        let to_is_default = to == tcp_inlet_default_to_addr();
-        let mut service_name = "outlet".to_string();
-        let relay_name = via.cloned().unwrap_or("default".to_string());
-
-        match MultiAddr::from_str(&to) {
-            // "to" is a valid multiaddr
-            Ok(to) => {
-                // check whether it's a full route or a single service
-                if let Some(proto) = to.first() {
-                    // "to" refers to the service name
-                    if proto.code() == proto::Service::CODE && to.len() == 1 {
-                        service_name = proto
-                            .cast::<proto::Service>()
-                            .ok_or_else(|| Error::arg_validation("to", via, None))?
-                            .to_string();
-                    }
-                    // "to" is a full route
-                    else {
-                        // "via" can't be passed if the user provides a value for "to"
-                        if !to_is_default && via.is_some() {
-                            return Err(Error::arg_validation(
-                                "to",
-                                via,
-                                Some("'via' can't be passed if 'to' is a route"),
-                            ))?;
-                        }
-                    }
-                }
-            }
-            // If it's not
-            Err(_) => {
-                // "to" refers to the service name
-                service_name = to.to_string();
-                // and we set "to" to the default route, so we can do the replacements later
-                to = tcp_inlet_default_to_addr();
-            }
-        }
-
-        // Replace the placeholders
-        if to.contains("<default_project_name>") {
-            let project_name = state
-                .projects()
-                .get_default_project()
-                .await
-                .map(|p| p.name().to_string())
-                .ok()
-                .ok_or(Error::arg_validation("to", via, Some("No projects found")))?;
-            to = to.replace("<default_project_name>", &project_name);
-        }
-        to = to.replace("<default_relay_name>", &relay_name);
-        to = to.replace("<default_service_name>", &service_name);
-
-        // Parse "to" as a multiaddr again with all the values in place
-        let to = MultiAddr::from_str(&to).into_diagnostic()?;
-        Ok(process_nodes_multiaddr(&to, state).await?.to_string())
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use ockam_api::nodes::InMemoryNode;
-    use ockam_api::orchestrator::project::models::ProjectModel;
-    use ockam_api::orchestrator::project::Project;
-
     use crate::run::parser::resource::utils::parse_cmd_from_args;
 
     use super::*;
@@ -499,100 +427,5 @@ mod tests {
     fn command_can_be_parsed_from_name() {
         let cmd = parse_cmd_from_args(CreateCommand::NAME, &[]);
         assert!(cmd.is_ok());
-    }
-
-    #[ockam_macros::test]
-    async fn parse_arg_to(ctx: &mut Context) -> ockam_core::Result<()> {
-        // Setup
-        let state = Arc::new(CliState::test().await.unwrap());
-        let node = InMemoryNode::start(ctx, state.clone()).await.unwrap();
-        let node_name = node.node_name();
-        let node_port = state
-            .get_node(&node_name)
-            .await
-            .unwrap()
-            .tcp_listener_port()
-            .unwrap();
-        let project = Project::import(ProjectModel {
-            identity: Some(
-                Identifier::from_str(
-                    "Ie92f183eb4c324804ef4d62962dea94cf095a265a1b2c3d4e5f6a6b5c4d3e2f1",
-                )
-                .unwrap(),
-            ),
-            name: "p1".to_string(),
-            ..Default::default()
-        })
-        .await
-        .unwrap();
-        state.projects().store_project(project).await.unwrap();
-
-        // Invalid "to" values throw an error
-        let cases = ["/alice/service", "alice/relay"];
-        for to in cases {
-            CreateCommand::parse_arg_to(state.clone(), to, None)
-                .await
-                .expect_err("Invalid multiaddr");
-        }
-
-        // "to" default value
-        let res = CreateCommand::parse_arg_to(state.clone(), tcp_inlet_default_to_addr(), None)
-            .await
-            .unwrap();
-        assert_eq!(
-            res,
-            "/project/p1/service/forward_to_default/secure/api/service/outlet".to_string()
-        );
-
-        // "to" argument accepts a full route
-        let cases = [
-            ("/project/p2/service/forward_to_n1/secure/api/service/myoutlet", None),
-            ("/worker/603b62d245c9119d584ba3d874eb8108/service/forward_to_n3/service/hop/service/outlet", None),
-            (&format!("/node/{node_name}/service/myoutlet"), Some(format!("/ip4/127.0.0.1/tcp/{node_port}/service/myoutlet"))),
-        ];
-        for (to, expected) in cases {
-            let res = CreateCommand::parse_arg_to(state.clone(), to, None)
-                .await
-                .unwrap();
-            let expected = expected.unwrap_or(to.to_string());
-            assert_eq!(res, expected);
-        }
-
-        // "to" argument accepts the name of the service
-        let res = CreateCommand::parse_arg_to(state.clone(), "myoutlet", None)
-            .await
-            .unwrap();
-        assert_eq!(
-            res,
-            "/project/p1/service/forward_to_default/secure/api/service/myoutlet".to_string()
-        );
-
-        // "via" argument is used to replace the relay name
-        let cases = [
-            (
-                tcp_inlet_default_to_addr(),
-                "myrelay",
-                "/project/p1/service/forward_to_myrelay/secure/api/service/outlet",
-            ),
-            (
-                "myoutlet".to_string(),
-                "myrelay",
-                "/project/p1/service/forward_to_myrelay/secure/api/service/myoutlet",
-            ),
-        ];
-        for (to, via, expected) in cases {
-            let res = CreateCommand::parse_arg_to(state.clone(), &to, Some(&via.to_string()))
-                .await
-                .unwrap();
-            assert_eq!(res, expected.to_string());
-        }
-
-        // if "to" is passed as a full route and also "via" is passed, return an error
-        let to = "/project/p1/service/forward_to_n1/secure/api/service/outlet";
-        CreateCommand::parse_arg_to(state.clone(), to, Some(&"myrelay".to_string()))
-            .await
-            .expect_err("'via' can't be passed if 'to' is a full route");
-
-        Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -31,7 +31,7 @@ long_about = docs::about(LONG_ABOUT),
 after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct CreateCommand {
-    /// Address of your TCP Outlet, which is part of a route used in other commands.
+    /// Service address of your TCP Outlet, which is part of a route used in other commands.
     /// This unique address identifies the TCP Outlet worker on the Node on your local machine.
     /// Examples are `/service/my-outlet` or `my-outlet`.
     /// If not provided, `outlet` will be used, or a random address will be generated if `outlet` is taken.
@@ -39,7 +39,8 @@ pub struct CreateCommand {
     #[arg(value_parser = extract_address_value)]
     pub name: Option<String>,
 
-    /// TCP address where your TCP server is running: domain:port. Your Outlet will send raw TCP traffic to it
+    /// Network address where your application is listening to.
+    /// Your TCP Outlet will forward raw TCP traffic to this destination.
     #[arg(long, id = "SOCKET_ADDRESS", display_order = 900, value_parser = hostname_parser)]
     pub to: SchemeHostnamePort,
 

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -28,32 +28,6 @@ pub fn print_path(p: &Path) -> String {
     p.to_str().unwrap_or("<unprintable>").to_string()
 }
 
-/// Replace the node's name with its address or leave it if it's another type of address.
-///
-/// Example:
-///     if n1 has address of 127.0.0.1:1234
-///     `/node/n1` -> `/ip4/127.0.0.1/tcp/1234`
-pub async fn process_nodes_multiaddr(
-    addr: &MultiAddr,
-    cli_state: Arc<CliState>,
-) -> Result<MultiAddr> {
-    let mut processed_addr = MultiAddr::default();
-    for proto in addr.iter() {
-        match proto.code() {
-            Node::CODE => {
-                let alias = proto
-                    .cast::<Node>()
-                    .ok_or_else(|| miette!("Invalid node address protocol"))?;
-                let node_info = cli_state.get_node(&alias).await?;
-                let addr = node_info.tcp_listener_multi_address()?;
-                processed_addr.try_extend(&addr)?
-            }
-            _ => processed_addr.push_back_value(&proto)?,
-        }
-    }
-    Ok(processed_addr)
-}
-
 /// Go through a multiaddr and remove all instances of
 /// `/node/<whatever>` out of it and replaces it with a fully
 /// qualified address to the target
@@ -137,6 +111,7 @@ pub fn print_warning_for_deprecated_flag_no_effect(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ockam_api::address::process_nodes_multiaddr;
     use ockam_node::Context;
     use std::str::FromStr;
 
@@ -168,15 +143,13 @@ mod tests {
         ];
         for (ma, expected) in test_cases {
             if let Ok(addr) = expected {
-                let result = process_nodes_multiaddr(&ma, cli_state.clone())
+                let result = process_nodes_multiaddr(&ma, &cli_state)
                     .await
                     .unwrap()
                     .to_string();
                 assert_eq!(result, addr);
             } else {
-                assert!(process_nodes_multiaddr(&ma, cli_state.clone())
-                    .await
-                    .is_err());
+                assert!(process_nodes_multiaddr(&ma, &cli_state).await.is_err());
             }
         }
         Ok(())

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/node_control_api.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/node_control_api.bats
@@ -154,14 +154,33 @@ teardown() {
   "
   wait_for_port $api_port
 
+  # create outlet with deprecated fields and delete it
+  run_success curl -vf \
+    -X POST \
+    -H 'Authorization: Bearer token' \
+    -d "{\"kind\":\"regular\",\"address\":\"outlet1\",\"to\":{\"hostname\":\"localhost\", \"port\":$PYTHON_SERVER_PORT}}" \
+    -o outlet-creation.json \
+    "http://localhost:${api_port}/self/tcp-outlets"
+  run_success sh -c "cat outlet-creation.json | jq -rc .name"
+  assert_output "outlet1"
+  run_success sh -c "cat outlet-creation.json | jq -rc .address" # Deprecated field is still returned
+  assert_output "outlet1"
+
+  run_success curl -vf \
+    -X DELETE \
+    -H 'Authorization: Bearer token' \
+    "http://localhost:${api_port}/self/tcp-outlets/outlet1"
+
   # create outlet
   run_success curl -vf \
     -X POST \
     -H 'Authorization: Bearer token' \
-    -d "{\"kind\":\"regular\",\"address\":\"my-outlet\",\"to\":{\"hostname\":\"localhost\", \"port\":$PYTHON_SERVER_PORT}}" \
+    -d "{\"kind\":\"regular\",\"name\":\"my-outlet\",\"to\":\"localhost:$PYTHON_SERVER_PORT\"}" \
     -o outlet-creation.json \
     "http://localhost:${api_port}/self/tcp-outlets"
-  run_success sh -c "cat outlet-creation.json | jq -rc .address"
+  run_success sh -c "cat outlet-creation.json | jq -rc .name"
+  assert_output "my-outlet"
+  run_success sh -c "cat outlet-creation.json | jq -rc .address" # Deprecated field is still returned
   assert_output "my-outlet"
 
   # verify that the outlet can be retrieved
@@ -169,7 +188,7 @@ teardown() {
     -H 'Authorization: Bearer token' \
     -o outlet.json \
     "http://localhost:${api_port}/self/tcp-outlets/my-outlet"
-  run_success sh -c "cat outlet.json | jq -rc .address"
+  run_success sh -c "cat outlet.json | jq -rc .name"
   assert_output "my-outlet"
 
   # verify that the outlet is listed
@@ -177,8 +196,20 @@ teardown() {
     -H 'Authorization: Bearer token' \
     -o outlet-list.json \
     "http://localhost:${api_port}/self/tcp-outlets"
-  run_success sh -c "cat outlet-list.json | jq -rc .[0].address"
+  run_success sh -c "cat outlet-list.json | jq -rc .[0].name"
   assert_output "my-outlet"
+
+  # create inlet with deprecated fields and delete it
+  run_success curl -vf \
+    -X POST \
+    -H 'Authorization: Bearer token' \
+    -d "{\"from\":\"127.0.0.1:0\",\"kind\":\"regular\",\"name\":\"inlet1\",\"to\":\"/secure/api/service/my-outlet\"}" \
+    -o inlet-creation.json \
+    "http://localhost:${api_port}/self/tcp-inlets"
+  run_success curl -vf \
+    -X DELETE \
+    -H 'Authorization: Bearer token' \
+    "http://localhost:${api_port}/self/tcp-inlets/inlet1"
 
   # create inlet
   run_success curl -vf \


### PR DESCRIPTION
## General changes

- Update the fields descriptions of the portals endpoints to match the Command's arguments descriptions
- Add example values for requests/responses so the docs snippets are easier to understand
- Network addresses of format `host:port` are now supported as a string (`localhost:0`) or as an object (`{"hostname": "...", "port": 0"}`) in the requests, and returned as an object in the responses for backwards compatibility
## Outlet
- Add a `Validated` struct for outlet/inlet requests, to bridge the limitations of expressing types in OpenAPI schemas with the fully typed fields we use internally within the NodeManager

- The response now returns both `address` and `name`, and `address` is marked as deprecated. We'll remove it in the future, after existing examples/demos have been updated to use the new `name` field
- The `POST` endpoint:
  - `kind`: is now optional, as in post@inlet
  - `address`: has been renamed to `name`, but it's been added as a valid alias for backwards compatibility

## Inlet

To mimic the shorthand features of the `tcp-inlet create` command, the `POST` endpoint now has the following changes:
- `to`: also supports passing the name of the outlet service, typically used when also passing `via`
- `via`: to define the name of the relay

### Breaking changes

- Inlet's `POST` endpoint, `kind` field: some variants had [a typo](https://github.com/build-trust/ockam/pull/8876/files#diff-75553af96e05a4e8cd6d8729fc6bc74e20975aee074ef98c5299dd1fcde49567R22) that is now fixed
- Inlet response: `current_route` has been [renamed](https://github.com/build-trust/ockam/pull/8876/files#diff-75553af96e05a4e8cd6d8729fc6bc74e20975aee074ef98c5299dd1fcde49567R220) to `internal_route`. This field returns the ockam route, and it's used for debugging purposes only (example: `"0#b9c31602e2cb4d03669bb81662b61ca0 => 0#my-outlet"`)