### PR TITLE
fix(rust): `node create` with configuration was swallowing an error produced in a subprocess

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/config.rs
@@ -266,29 +266,34 @@ impl NodeConfig {
             (node_handle, callback)
         };
 
-        // Wait for the node to be up
-        callback.wait_for_signal().await?;
+        let node_exit_future = async { node_handle.await.map_err(|err| miette!("{err:?}")) };
 
-        // Run the other sections
-        let node_name = Some(node_name);
-        let other_sections: Vec<ParsedCommands> = vec![
-            self.policies.into_parsed_commands()?.into(),
-            self.relays.into_parsed_commands(node_name)?.into(),
-            self.tcp_outlets.into_parsed_commands(node_name)?.into(),
-            self.tcp_inlets.into_parsed_commands(node_name)?.into(),
-            self.influxdb_outlets
-                .into_parsed_commands(node_name)?
-                .into(),
-            self.influxdb_inlets.into_parsed_commands(node_name)?.into(),
-            self.kafka_outlet.into_parsed_commands(node_name)?.into(),
-            self.kafka_inlet.into_parsed_commands(node_name)?.into(),
-        ];
-        opts.terminal.write_line("")?;
-        Self::run_commands_sections(ctx, opts, other_sections).await?;
-        opts.terminal.write_line("")?;
+        // Wait for either the callback signal or the node to exit
+        tokio::select! {
+            result = callback.wait_for_signal() => {
+                result?;
 
-        // Block on the node until it exits
-        let _ = node_handle.await.into_diagnostic()?;
+                // Run the other sections
+                let node_name = Some(node_name);
+                let other_sections: Vec<ParsedCommands> = vec![
+                    self.policies.into_parsed_commands()?.into(),
+                    self.relays.into_parsed_commands(node_name)?.into(),
+                    self.tcp_outlets.into_parsed_commands(node_name)?.into(),
+                    self.tcp_inlets.into_parsed_commands(node_name)?.into(),
+                    self.influxdb_outlets
+                        .into_parsed_commands(node_name)?
+                        .into(),
+                    self.influxdb_inlets.into_parsed_commands(node_name)?.into(),
+                    self.kafka_outlet.into_parsed_commands(node_name)?.into(),
+                    self.kafka_inlet.into_parsed_commands(node_name)?.into(),
+                ];
+                opts.terminal.write_line("")?;
+                Self::run_commands_sections(ctx, opts, other_sections).await?;
+                opts.terminal.write_line("")?;
+            },
+            result = node_exit_future => result??,
+        }
+
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_command/src/node/create/node_callback.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/node_callback.rs
@@ -1,5 +1,6 @@
 use miette::{miette, IntoDiagnostic};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use tracing::trace;
 
 /// A callback node should call when it's up and running, implemented via creating a localhost TCP
 /// connection
@@ -20,6 +21,8 @@ impl NodeCallback {
             .local_addr()
             .map_err(|_| miette!("Failed to get callback listener port"))?
             .port();
+
+        trace!(%callback_port, "callback listener created");
 
         Ok(Self {
             tcp_listener,

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -244,6 +244,10 @@ pub async fn wait_for_node_callback(
     mut handle: Child,
     node_callback: NodeCallback,
 ) -> miette::Result<()> {
+    debug!(
+        callback_port = node_callback.callback_port(),
+        "waiting for node to be ready"
+    );
     tokio::select! {
         res = handle.wait() => {
             trace!(?res, "node output drained");

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
@@ -286,3 +286,13 @@ tcp-listener-address 127.0.0.1:3333
 EOF
   run_failure "$OCKAM" node create "$OCKAM_HOME/node.yaml"
 }
+
+@test "node - fail when binding to a port already in use" {
+  port=$(random_port)
+  run_success $OCKAM node create --tcp-listener-address 127.0.0.1:$port
+
+  run_failure $OCKAM node create --tcp-listener-address 127.0.0.1:$port
+  run_failure $OCKAM node create "{\"tcp-listener-address\": \"127.0.0.1:$port\"}"
+  run_failure $OCKAM node create --foreground --tcp-listener-address 127.0.0.1:$port
+  run_failure $OCKAM node create --foreground "{\"tcp-listener-address\": \"127.0.0.1:$port\"}"
+}

--- a/implementations/rust/ockam/ockam_transport_core/src/error.rs
+++ b/implementations/rust/ockam/ockam_transport_core/src/error.rs
@@ -1,6 +1,6 @@
 use ockam_core::{
     compat::io,
-    compat::string::String,
+    compat::string::{String, ToString},
     errcode::{Kind, Origin},
     Error,
 };
@@ -13,7 +13,7 @@ pub enum TransportError {
     /// Failed to receive a malformed message
     RecvBadMessage,
     /// Failed to bind to the desired socket
-    BindFailed,
+    BindFailed(String),
     /// Connection was dropped unexpectedly
     ConnectionDrop,
     /// Connection was already established
@@ -90,7 +90,7 @@ impl core::fmt::Display for TransportError {
         match self {
             Self::SendBadMessage => write!(f, "failed to send a malformed message"),
             Self::RecvBadMessage => write!(f, "failed to receive a malformed message"),
-            Self::BindFailed => write!(f, "failed to bind to the desired socket"),
+            Self::BindFailed(e) => write!(f, "failed to bind to the desired socket: {e}"),
             Self::ConnectionDrop => write!(f, "connection was dropped unexpectedly"),
             Self::AlreadyConnected => write!(f, "already connected"),
             Self::PeerNotFound => write!(f, "connection peer was not found"),
@@ -144,7 +144,7 @@ impl From<TransportError> for Error {
         let kind = match err {
             SendBadMessage => Kind::Serialization,
             RecvBadMessage => Kind::Serialization,
-            BindFailed => Kind::Io,
+            BindFailed(_) => Kind::Io,
             ConnectionDrop => Kind::Io,
             AlreadyConnected => Kind::Io,
             PeerNotFound => Kind::Misuse,
@@ -186,6 +186,9 @@ impl From<io::Error> for TransportError {
     fn from(e: io::Error) -> Self {
         match e.kind() {
             io::ErrorKind::ConnectionRefused => Self::PeerNotFound,
+            io::ErrorKind::AddrNotAvailable | io::ErrorKind::AddrInUse => {
+                Self::BindFailed(e.to_string())
+            }
             _ => Self::GenericIo,
         }
     }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/privileged_portal/privileged_portals.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/privileged_portal/privileged_portals.rs
@@ -71,10 +71,8 @@ impl TcpTransport {
         let bind_addr = bind_addr.into();
         let tcp_listener = TcpListener::bind(bind_addr.clone())
             .await
-            .map_err(|_| TransportError::BindFailed)?;
-        let local_address = tcp_listener
-            .local_addr()
-            .map_err(|_| TransportError::BindFailed)?;
+            .map_err(TransportError::from)?;
+        let local_address = tcp_listener.local_addr().map_err(TransportError::from)?;
 
         if !local_address.ip().is_ipv4() {
             return Err(TransportError::ExpectedIPv4Address)?;

--- a/implementations/rust/ockam/ockam_transport_tcp/src/privileged_portal/workers/remote_worker.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/privileged_portal/workers/remote_worker.rs
@@ -74,10 +74,8 @@ impl RemoteWorker {
         //         However, we don't know it here.
         let tcp_listener = TcpListener::bind("127.0.0.1:0")
             .await
-            .map_err(|_| TransportError::BindFailed)?;
-        let local_addr = tcp_listener
-            .local_addr()
-            .map_err(|_| TransportError::BindFailed)?;
+            .map_err(TransportError::from)?;
+        let local_addr = tcp_listener.local_addr().map_err(TransportError::from)?;
         let assigned_port = local_addr.port();
 
         debug!("New TCP connection. Assigned socket {}", local_addr);

--- a/implementations/rust/ockam/ockam_transport_udp/src/transport/bind.rs
+++ b/implementations/rust/ockam/ockam_transport_udp/src/transport/bind.rs
@@ -85,7 +85,7 @@ impl UdpTransport {
         // Bind new socket
         let socket = UdpSocket::bind(arguments.bind_address)
             .await
-            .map_err(|_| TransportError::BindFailed)?;
+            .map_err(TransportError::from)?;
 
         if let Some(_peer) = &arguments.peer_address {
             // TODO: Would be better to tie this socket to a specific peer when


### PR DESCRIPTION
When running `node create` with a configuration, the tokio task handle was returning an error before it was ever awaited, blocking the `callback.wait_for_signal()` call.

The task handle and the callback are now awaited in a tokio::select block, as we do in [wait_for_node_callback](https://github.com/build-trust/ockam/blob/985af6947b679fb36a3cd1f33e4310307bcece1e/implementations/rust/ockam/ockam_command/src/node/util.rs#L243).