### PR TITLE
feat(rust): add `ContextRouter`

### DIFF
--- a/implementations/rust/ockam/ockam_identity/src/credentials/retriever/remote_retriever/remote_retriever.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/retriever/remote_retriever/remote_retriever.rs
@@ -30,9 +30,6 @@ pub const DEFAULT_MIN_REFRESH_CREDENTIAL_INTERVAL: Duration = Duration::from_sec
 /// Default timeout for requesting credential from the authority
 pub const DEFAULT_CREDENTIAL_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
-/// Start refresh in the background before it expires
-pub const DEFAULT_CREDENTIAL_PROACTIVE_REFRESH_GAP: TimestampInSeconds = TimestampInSeconds(60);
-
 /// Timing options for retrieving remote credentials
 #[derive(Clone, Copy)]
 pub struct RemoteCredentialRetrieverTimingOptions {

--- a/implementations/rust/ockam/ockam_node/src/context/context_lifecycle.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/context_lifecycle.rs
@@ -1,5 +1,6 @@
 #[cfg(not(feature = "std"))]
 use crate::tokio;
+use core::sync::atomic::AtomicUsize;
 use core::time::Duration;
 use ockam_core::compat::collections::HashMap;
 use ockam_core::compat::sync::Weak;
@@ -17,8 +18,8 @@ use ockam_transport_core::Transport;
 use crate::channel_types::{message_channel, oneshot_channel, OneshotReceiver};
 use crate::context::ContextState;
 use crate::router::Router;
-use crate::{debugger, Context, ContextMode};
 use crate::{relay::CtrlSignal, router::SenderPair};
+use crate::{Context, ContextMode};
 use tokio::runtime::Handle;
 
 impl Drop for Context {
@@ -65,7 +66,7 @@ impl Context {
     /// `async_drop_sender` must be provided when creating a detached
     /// Context type (i.e. not backed by a worker relay).
     #[allow(clippy::too_many_arguments)]
-    fn new(
+    pub(super) fn new(
         runtime_handle: Handle,
         router: Weak<Router>,
         mailboxes: Mailboxes,
@@ -127,23 +128,6 @@ impl Context {
         )
     }
 
-    pub(crate) fn new_with_mailboxes(
-        &self,
-        mailboxes: Mailboxes,
-        mode: ContextMode,
-    ) -> (Context, SenderPair, OneshotReceiver<CtrlSignal>) {
-        Self::new(
-            self.runtime().clone(),
-            self.router_weak(),
-            mailboxes,
-            mode,
-            self.transports.clone(),
-            &self.state.flow_controls,
-            #[cfg(feature = "std")]
-            OpenTelemetryContext::current(),
-        )
-    }
-
     /// Utility function to sleep tasks from other crates
     #[doc(hidden)]
     pub async fn sleep(&self, duration: Duration) {
@@ -180,11 +164,44 @@ impl Context {
         }
     }
 
-    /// TODO basically we can just rename `Self::new_detached_impl()`
+    /// Create a new [`Context`] instance with dedicated Mailbox(es)
     pub fn new_detached_with_mailboxes(&self, mailboxes: Mailboxes) -> Result<Context> {
-        let ctx = self.new_detached_impl(mailboxes)?;
+        Self::new_detached_with_mailboxes_impl(
+            self.runtime().clone(),
+            self.router()?,
+            self.transports.clone(),
+            self.flow_controls(),
+            mailboxes,
+            self.mailbox_count(),
+        )
+    }
 
-        debugger::log_inherit_context("DETACHED_WITH_MB", self, &ctx);
+    pub(crate) fn new_detached_with_mailboxes_impl(
+        runtime: Handle,
+        router: Arc<Router>,
+        transports: Arc<RwLock<HashMap<TransportType, Arc<dyn Transport>>>>,
+        flow_controls: &FlowControls,
+        mailboxes: Mailboxes,
+        mailbox_count: Arc<AtomicUsize>,
+    ) -> Result<Context> {
+        let (ctx, sender, _) = Context::new(
+            runtime,
+            Arc::downgrade(&router),
+            mailboxes,
+            ContextMode::Detached,
+            transports,
+            flow_controls,
+            #[cfg(feature = "std")]
+            OpenTelemetryContext::current(),
+        );
+
+        router.add_worker(
+            ctx.mailboxes(),
+            sender,
+            true,
+            Default::default(),
+            mailbox_count,
+        )?;
 
         Ok(ctx)
     }
@@ -226,24 +243,7 @@ impl Context {
         outgoing: impl OutgoingAccessControl,
     ) -> Result<Context> {
         let mailboxes = Mailboxes::primary(address.into(), Arc::new(incoming), Arc::new(outgoing));
-        let ctx = self.new_detached_impl(mailboxes)?;
-
-        debugger::log_inherit_context("DETACHED", self, &ctx);
-
-        Ok(ctx)
-    }
-
-    fn new_detached_impl(&self, mailboxes: Mailboxes) -> Result<Context> {
-        // Create a new context and get access to the mailbox senders
-        let (ctx, sender, _) = self.new_with_mailboxes(mailboxes, ContextMode::Detached);
-
-        self.router()?.add_worker(
-            ctx.mailboxes(),
-            sender,
-            true,
-            Default::default(),
-            self.state.mailbox_count.clone(),
-        )?;
+        let ctx = self.new_detached_with_mailboxes(mailboxes)?;
 
         Ok(ctx)
     }
@@ -263,12 +263,13 @@ mod tests {
         ctx.register_transport(transport_type, transport.clone());
 
         // after a copy with new mailboxes the list of transports should be intact
-        let mailboxes = Mailboxes::new(Mailbox::deny_all("address"), vec![]);
-        let (copy, _, _) = ctx.new_with_mailboxes(mailboxes.clone(), ContextMode::Attached);
+        let mailboxes1 = Mailboxes::new(Mailbox::deny_all("address1"), vec![]);
+        let copy = ctx.new_detached_with_mailboxes(mailboxes1)?;
         assert!(copy.is_transport_registered(transport_type));
 
         // after a detached copy with new mailboxes the list of transports should be intact
-        let (copy, _, _) = ctx.new_with_mailboxes(mailboxes, ContextMode::Attached);
+        let mailboxes2 = Mailboxes::new(Mailbox::deny_all("address2"), vec![]);
+        let copy = ctx.new_detached_with_mailboxes(mailboxes2)?;
         assert!(copy.is_transport_registered(transport_type));
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_node/src/context/context_router.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/context_router.rs
@@ -1,0 +1,316 @@
+use crate::channel_types::OneshotReceiver;
+use crate::relay::CtrlSignal;
+use crate::router::{Router, SenderPair};
+use crate::tokio::runtime::Handle;
+use crate::{Context, ContextMode, MessageSendReceiveOptions, ProcessorBuilder, WorkerBuilder};
+use core::sync::atomic::AtomicUsize;
+use ockam_core::compat::collections::HashMap;
+use ockam_core::compat::sync::Weak;
+use ockam_core::compat::sync::{Arc, RwLock};
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::flow_control::FlowControls;
+#[cfg(feature = "std")]
+use ockam_core::OpenTelemetryContext;
+use ockam_core::{
+    Address, Error, IncomingAccessControl, Mailboxes, Message, OutgoingAccessControl, Processor,
+    Result, Route, Routed, TransportType, Worker,
+};
+use ockam_transport_core::Transport;
+
+/// [`Context`] counterpart that allows starting/stopping workers and doesn't have its own mailbox
+#[derive(Clone)]
+pub struct ContextRouter {
+    pub(super) router: Weak<Router>,
+    pub(super) mailbox_count: Arc<AtomicUsize>,
+    pub(super) flow_controls: FlowControls,
+    /// List of transports used to resolve external addresses to local workers in routes
+    pub(super) transports: Arc<RwLock<HashMap<TransportType, Arc<dyn Transport>>>>,
+    pub(super) runtime_handle: Handle,
+    #[cfg(feature = "std")]
+    pub(super) tracing_context: OpenTelemetryContext,
+}
+
+impl ContextRouter {
+    /// Start a new worker instance at the given address. Default AccessControl is AllowAll
+    ///
+    /// A worker is an asynchronous piece of code that can send and
+    /// receive messages of a specific type.  This type is encoded via
+    /// the [`Worker`](ockam_core::Worker) trait.  If your code relies
+    /// on a manual run-loop you may want to use
+    /// [`start_processor()`](Self::start_processor) instead!
+    ///
+    /// Each address in the set must be unique and unused on the
+    /// current node.  Workers must implement the Worker trait and be
+    /// thread-safe.  Workers run asynchronously and will be scheduled
+    /// independently of each other.  To wait for the initialisation
+    /// of your worker to complete you can use
+    /// [`wait_for()`](Self::wait_for).
+    ///
+    /// ```rust
+    /// use ockam_core::{Result, Worker, worker};
+    /// use ockam_node::Context;
+    ///
+    /// struct MyWorker;
+    ///
+    /// #[worker]
+    /// impl Worker for MyWorker {
+    ///     type Context = Context;
+    ///     type Message = String;
+    /// }
+    ///
+    /// fn start_my_worker(ctx: &mut Context) -> Result<()> {
+    ///     ctx.start_worker("my-worker-address", MyWorker)
+    /// }
+    /// ```
+    ///
+    /// Approximate flow of starting a worker:
+    ///
+    /// 1. StartWorker message -> Router
+    /// 2. First address is considered a primary_addr (main_addr)
+    /// 3. Check if router.map.address_records_map already has primary_addr
+    /// 4. AddressRecord is created and inserted in router.map
+    /// 5. Iterate over metadata:
+    ///     Check if it belongs to that record
+    ///     Set is_terminal true in router.map.address_metadata_map (if address is terminal)
+    ///     Insert attributes one by one
+    /// 6. For each address we insert pair (Address, primary_addr) into router.map.alias_map, including (primary_addr, primary_addr itself)
+    /// 7. WorkerRelay is spawned as a tokio task:
+    ///     WorkerRelay calls initialize
+    ///     WorkerRelay calls Worker::handle_message for each message until either
+    ///         stop signal is received (CtrlSignal::InterruptStop to AddressRecord::ctrl_tx)
+    ///         there are no messages coming to that receiver (the sender side is dropped)
+    pub fn start_worker<W>(&self, address: impl Into<Address>, worker: W) -> Result<()>
+    where
+        W: Worker<Context = Context>,
+    {
+        WorkerBuilder::new(worker)
+            .with_address(address)
+            .start_using_router_context(self)?;
+
+        Ok(())
+    }
+
+    /// Start a new worker instance at the given address
+    ///
+    /// A worker is an asynchronous piece of code that can send and
+    /// receive messages of a specific type.  This type is encoded via
+    /// the [`Worker`](ockam_core::Worker) trait.  If your code relies
+    /// on a manual run-loop you may want to use
+    /// [`start_processor()`](Self::start_processor) instead!
+    ///
+    /// Each address in the set must be unique and unused on the
+    /// current node.  Workers must implement the Worker trait and be
+    /// thread-safe.  Workers run asynchronously and will be scheduled
+    /// independently of each other.
+    ///
+    /// ```rust
+    /// use ockam_core::{AllowAll, Result, Worker, worker};
+    /// use ockam_node::Context;
+    ///
+    /// struct MyWorker;
+    ///
+    /// #[worker]
+    /// impl Worker for MyWorker {
+    ///     type Context = Context;
+    ///     type Message = String;
+    /// }
+    ///
+    ///  fn start_my_worker(ctx: &mut Context) -> Result<()> {
+    ///     ctx.start_worker_with_access_control("my-worker-address", MyWorker, AllowAll, AllowAll)
+    /// }
+    /// ```
+    pub fn start_worker_with_access_control<W>(
+        &self,
+        address: impl Into<Address>,
+        worker: W,
+        incoming: impl IncomingAccessControl,
+        outgoing: impl OutgoingAccessControl,
+    ) -> Result<()>
+    where
+        W: Worker<Context = Context>,
+    {
+        WorkerBuilder::new(worker)
+            .with_address(address)
+            .with_incoming_access_control(incoming)
+            .with_outgoing_access_control(outgoing)
+            .start_using_router_context(self)?;
+
+        Ok(())
+    }
+
+    /// Start a new processor instance at the given address. Default AccessControl is DenyAll
+    ///
+    /// A processor is an asynchronous piece of code that runs a
+    /// custom run loop, with access to a worker context to send and
+    /// receive messages.  If your code is built around responding to
+    /// message events, consider using
+    /// [`start_worker()`](Self::start_worker) instead!
+    ///
+    /// Approximate flow of starting a processor:
+    ///
+    /// 1. StartProcessor message -> Router
+    /// 2. First address is considered a primary_addr (main_addr)
+    /// 3. Check if router.map.address_records_map already has primary_addr
+    /// 4. AddressRecord is created and inserted in router.map
+    /// 5. Iterate over metadata:
+    ///     Check if it belongs to that record
+    ///     Set is_terminal true in router.map.address_metadata_map (if address is terminal)
+    ///     Insert attributes one by one
+    /// 6. For each address we insert pair (Address, primary_addr) into router.map.alias_map, including (primary_addr, primary_addr itself)
+    /// 7. ProcessorRelay is spawned as a tokio task:
+    ///     ProcessorRelay calls Processor::initialize
+    ///     ProcessorRelay calls Processor::process until either false is returned or stop signal is received (CtrlSignal::InterruptStop to AddressRecord::ctrl_tx)
+    pub fn start_processor<P>(&self, address: impl Into<Address>, processor: P) -> Result<()>
+    where
+        P: Processor<Context = Context>,
+    {
+        ProcessorBuilder::new(processor)
+            .with_address(address.into())
+            .start_using_router_context(self)?;
+
+        Ok(())
+    }
+
+    /// Start a new processor instance at the given address
+    ///
+    /// A processor is an asynchronous piece of code that runs a
+    /// custom run loop, with access to a worker context to send and
+    /// receive messages.  If your code is built around responding to
+    /// message events, consider using
+    /// [`start_worker()`](Self::start_worker) instead!
+    ///
+    pub fn start_processor_with_access_control<P>(
+        &self,
+        address: impl Into<Address>,
+        processor: P,
+        incoming: impl IncomingAccessControl,
+        outgoing: impl OutgoingAccessControl,
+    ) -> Result<()>
+    where
+        P: Processor<Context = Context>,
+    {
+        ProcessorBuilder::new(processor)
+            .with_address(address)
+            .with_incoming_access_control(incoming)
+            .with_outgoing_access_control(outgoing)
+            .start_using_router_context(self)?;
+
+        Ok(())
+    }
+
+    /// Stop a Worker or a Processor running on given Address
+    pub fn stop_address(&self, address: &Address) -> Result<()> {
+        self.router()?.stop_address(address, false)
+    }
+
+    /// Reference to the Router
+    pub(crate) fn router(&self) -> Result<Arc<Router>> {
+        self.router
+            .upgrade()
+            .ok_or_else(|| Error::new(Origin::Node, Kind::Shutdown, "Failed to upgrade router"))
+    }
+
+    /// Return runtime clone
+    pub fn runtime(&self) -> &Handle {
+        &self.runtime_handle
+    }
+
+    /// Return mailbox_count clone
+    pub(crate) fn mailbox_count(&self) -> Arc<AtomicUsize> {
+        self.mailbox_count.clone()
+    }
+
+    pub(crate) fn new_with_mailboxes(
+        &self,
+        mailboxes: Mailboxes,
+        mode: ContextMode,
+    ) -> (Context, SenderPair, OneshotReceiver<CtrlSignal>) {
+        Context::new(
+            self.runtime().clone(),
+            self.router.clone(),
+            mailboxes,
+            mode,
+            self.transports.clone(),
+            &self.flow_controls,
+            #[cfg(feature = "std")]
+            OpenTelemetryContext::current(),
+        )
+    }
+
+    /// Using a temporary new context, send a message and then receive a message
+    /// with default timeout and no flow control
+    ///
+    /// This helper function uses [`new_detached`], [`send`], and
+    /// [`receive`] internally. See their documentation for more
+    /// details.
+    ///
+    /// [`new_detached`]: Self::new_detached
+    /// [`send`]: Self::send
+    /// [`receive`]: Self::receive
+    pub async fn send_and_receive<T, R>(&self, route: impl Into<Route>, msg: T) -> Result<R>
+    where
+        T: Message,
+        R: Message,
+    {
+        self.send_and_receive_extended::<T, R>(route, msg, MessageSendReceiveOptions::new())
+            .await?
+            .into_body()
+    }
+
+    /// Using a temporary new context, send a message and then receive a message
+    ///
+    /// This helper function uses [`new_detached`], [`send`], and
+    /// [`receive`] internally. See their documentation for more
+    /// details.
+    ///
+    /// [`new_detached`]: Self::new_detached
+    /// [`send`]: Self::send
+    /// [`receive`]: Self::receive
+    pub async fn send_and_receive_extended<T, R>(
+        &self,
+        route: impl Into<Route>,
+        msg: T,
+        options: MessageSendReceiveOptions,
+    ) -> Result<Routed<R>>
+    where
+        T: Message,
+        R: Message,
+    {
+        Context::send_and_receive_extended_impl(
+            self.runtime().clone(),
+            self.router()?,
+            self.transports.clone(),
+            &self.flow_controls,
+            self.mailbox_count(),
+            route.into(),
+            msg,
+            options,
+            #[cfg(feature = "std")]
+            self.tracing_context.clone(),
+        )
+        .await
+    }
+}
+
+impl Context {
+    /// Get cloneable [`Context`] variant that allows shared access to sending capabilities from
+    /// a specified address. Doesn't own any mailbox, therefore original [`Context`] must be alive
+    /// to be able to send the message.
+    pub fn get_router_context(&self) -> ContextRouter {
+        ContextRouter {
+            router: self.router_weak(),
+            mailbox_count: self.mailbox_count(),
+            flow_controls: self.flow_controls().clone(),
+            transports: self.transports.clone(),
+            runtime_handle: self.runtime_handle.clone(),
+            #[cfg(feature = "std")]
+            tracing_context: OpenTelemetryContext::current(),
+        }
+    }
+}
+
+impl From<Context> for ContextRouter {
+    fn from(value: Context) -> Self {
+        value.get_router_context()
+    }
+}

--- a/implementations/rust/ockam/ockam_node/src/context/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/mod.rs
@@ -2,6 +2,7 @@
 mod context;
 mod context_lifecycle;
 mod context_mode;
+mod context_router;
 mod context_send;
 mod context_state;
 mod has_context;
@@ -15,6 +16,7 @@ mod worker_lifecycle;
 
 pub use context::*;
 pub use context_mode::*;
+pub use context_router::*;
 pub use context_send::*;
 pub(crate) use context_state::*;
 pub use has_context::*;

--- a/implementations/rust/ockam/ockam_node/src/context/send_message.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/send_message.rs
@@ -1,20 +1,34 @@
 use crate::context::MessageWait;
 use crate::error::*;
+use crate::router::Router;
+#[cfg(not(feature = "std"))]
+use crate::tokio;
 use crate::{debugger, Context, MessageReceiveOptions, DEFAULT_TIMEOUT};
+
+use core::sync::atomic::AtomicUsize;
 use core::time::Duration;
-use ockam_core::compat::{sync::Arc, vec::Vec};
+use ockam_core::compat::collections::HashMap;
+use ockam_core::compat::sync::{Arc, RwLock};
+use ockam_core::compat::vec::Vec;
+use ockam_core::flow_control::FlowControls;
 use ockam_core::{
     errcode::{Kind, Origin},
     Address, AllOutgoingAccessControl, AllowAll, AllowOnwardAddress, Error, IncomingAccessControl,
     LocalMessage, Mailboxes, Message, OutgoingAccessControl, RelayMessage, Result, Route, Routed,
+    TransportType,
 };
 use ockam_core::{LocalInfo, Mailbox};
+use ockam_transport_core::Transport;
+use tokio::runtime::Handle;
+
+#[cfg(feature = "std")]
+use ockam_core::OpenTelemetryContext;
 
 /// Full set of options to `send_and_receive_extended` function
 pub struct MessageSendReceiveOptions {
-    message_wait: MessageWait,
-    incoming_access_control: Option<Arc<dyn IncomingAccessControl>>,
-    outgoing_access_control: Option<Arc<dyn OutgoingAccessControl>>,
+    pub(super) message_wait: MessageWait,
+    pub(super) incoming_access_control: Option<Arc<dyn IncomingAccessControl>>,
+    pub(super) outgoing_access_control: Option<Arc<dyn OutgoingAccessControl>>,
 }
 
 impl Default for MessageSendReceiveOptions {
@@ -104,8 +118,37 @@ impl Context {
         T: Message,
         R: Message,
     {
-        let route: Route = route.into();
+        Self::send_and_receive_extended_impl(
+            self.runtime().clone(),
+            self.router()?,
+            self.transports.clone(),
+            self.flow_controls(),
+            self.mailbox_count(),
+            route.into(),
+            msg,
+            options,
+            #[cfg(feature = "std")]
+            self.tracing_context(),
+        )
+        .await
+    }
 
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn send_and_receive_extended_impl<T, R>(
+        runtime: Handle,
+        router: Arc<Router>,
+        transports: Arc<RwLock<HashMap<TransportType, Arc<dyn Transport>>>>,
+        flow_controls: &FlowControls,
+        mailbox_count: Arc<AtomicUsize>,
+        route: Route,
+        msg: T,
+        options: MessageSendReceiveOptions,
+        #[cfg(feature = "std")] tracing_context: OpenTelemetryContext,
+    ) -> Result<Routed<R>>
+    where
+        T: Message,
+        R: Message,
+    {
         let next = route.next()?.clone();
         let address = Address::random_tagged("Context.send_and_receive.detached");
 
@@ -136,21 +179,25 @@ impl Context {
             vec![],
         );
 
-        if let Some(flow_control_id) = self
-            .state
-            .flow_controls
+        if let Some(flow_control_id) = flow_controls
             .find_flow_control_with_producer_address(&next)
             .map(|x| x.flow_control_id().clone())
         {
             // To be able to receive the response
-            self.flow_controls()
-                .add_consumer(&address, &flow_control_id);
+            flow_controls.add_consumer(&address, &flow_control_id);
         }
 
-        let mut child_ctx = self.new_detached_with_mailboxes(mailboxes)?;
+        let mut child_ctx = Self::new_detached_with_mailboxes_impl(
+            runtime,
+            router,
+            transports,
+            flow_controls,
+            mailboxes,
+            mailbox_count,
+        )?;
 
         #[cfg(feature = "std")]
-        child_ctx.set_tracing_context(self.tracing_context());
+        child_ctx.set_tracing_context(tracing_context);
 
         child_ctx.send(route, msg).await?;
         child_ctx

--- a/implementations/rust/ockam/ockam_node/src/debugger.rs
+++ b/implementations/rust/ockam/ockam_node/src/debugger.rs
@@ -22,8 +22,6 @@ use core::{
 #[cfg(feature = "debugger")]
 #[derive(Default)]
 struct Debugger {
-    /// Map context inheritance from parent main `Mailbox` to child [`Mailboxes`]
-    inherited_mb: Arc<RwLock<HashMap<Mailbox, Vec<Mailboxes>>>>,
     /// Map message destination to source
     incoming: Arc<RwLock<HashMap<Address, Vec<Address>>>>,
     /// Map message destination `Mailbox` to source [`Mailbox`]
@@ -144,44 +142,6 @@ pub fn log_outgoing_message(primary_address: &Address, relay_msg: &RelayMessage)
 /// No-op
 #[cfg(not(feature = "debugger"))]
 pub fn log_outgoing_message(_primary_address: &Address, _relay_msg: &RelayMessage) {}
-
-/// Log Context creation
-///
-/// This debug function builds an inheritance tree of the contexts
-/// within a node.
-///
-/// Useful for:
-///
-/// 1. Figuring out the access control inheritance structure for a
-///    node.
-/// 2. Getting a rough idea of the "worker context" for a group of
-///    contexts created by a top-level worker or processor interface
-/// 3. Tracking down "orphan" contexts that could be vulnerable to
-///    hostile messages
-#[cfg(feature = "debugger")]
-pub fn log_inherit_context(tag: &str, parent: &Context, child: &Context) {
-    static COUNTER: AtomicU32 = AtomicU32::new(0);
-
-    tracing::trace!(
-        "log_inherit_context #{:03}\n{:?}\nBegat {}\n{:?}\n",
-        COUNTER.fetch_add(1, Ordering::Relaxed),
-        parent.mailboxes(),
-        tag,
-        child.mailboxes(),
-    );
-
-    instance()
-        .inherited_mb
-        .write()
-        .unwrap()
-        .entry(parent.mailboxes().primary_mailbox().clone())
-        .or_default()
-        .push(child.mailboxes().clone());
-}
-
-/// No-op
-#[cfg(not(feature = "debugger"))]
-pub fn log_inherit_context(_tag: &str, _parent: &Context, _child: &Context) {}
 
 /// TODO
 pub fn _log_start_worker() {

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -1,5 +1,5 @@
 use crate::tokio::runtime::Runtime;
-use crate::{debugger, Context, Executor};
+use crate::{Context, Executor};
 use ockam_core::compat::sync::Arc;
 use ockam_core::flow_control::FlowControls;
 #[cfg(feature = "std")]
@@ -141,8 +141,6 @@ impl NodeBuilder {
             #[cfg(feature = "std")]
             OpenTelemetryContext::current(),
         );
-
-        debugger::log_inherit_context("NODE", &ctx, &ctx);
 
         // Register this mailbox handle with the executor
         router

--- a/implementations/rust/ockam/ockam_node/src/processor_builder.rs
+++ b/implementations/rust/ockam/ockam_node/src/processor_builder.rs
@@ -1,5 +1,5 @@
-use crate::{debugger, ContextMode, WorkerShutdownPriority};
 use crate::{relay::ProcessorRelay, Context};
+use crate::{ContextMode, ContextRouter, WorkerShutdownPriority};
 use ockam_core::compat::string::String;
 use ockam_core::compat::sync::Arc;
 use ockam_core::{
@@ -102,7 +102,7 @@ where
     /// Consume this builder and start a new Ockam [`Processor`] from the given context
     pub fn start(self, context: &Context) -> Result<()> {
         start(
-            context,
+            &context.get_router_context(),
             self.mailboxes,
             self.shutdown_priority,
             self.processor,
@@ -161,6 +161,11 @@ where
 
     /// Consume this builder and start a new Ockam [`Processor`] from the given context
     pub fn start(self, context: &Context) -> Result<()> {
+        self.start_using_router_context(&context.get_router_context())
+    }
+
+    /// Consume this builder and start a new Ockam [`Processor`] from the given context
+    pub fn start_using_router_context(self, context: &ContextRouter) -> Result<()> {
         start(
             context,
             Mailboxes::new(
@@ -226,7 +231,7 @@ where
 
 /// Consume this builder and start a new Ockam [`Processor`] from the given context
 pub fn start<P>(
-    context: &Context,
+    context: &ContextRouter,
     mailboxes: Mailboxes,
     shutdown_priority: WorkerShutdownPriority,
     processor: P,
@@ -243,8 +248,6 @@ where
 
     // Pass it to the context
     let (ctx, sender, ctrl_rx) = context.new_with_mailboxes(mailboxes, ContextMode::Attached);
-
-    debugger::log_inherit_context("PROCESSOR", context, &ctx);
 
     let router = context.router()?;
     router.add_processor(ctx.mailboxes(), sender, shutdown_priority)?;

--- a/implementations/rust/ockam/ockam_node/src/worker_builder.rs
+++ b/implementations/rust/ockam/ockam_node/src/worker_builder.rs
@@ -1,5 +1,5 @@
-use crate::{debugger, ContextMode, WorkerShutdownPriority};
 use crate::{relay::WorkerRelay, Context};
+use crate::{ContextMode, ContextRouter, WorkerShutdownPriority};
 use ockam_core::compat::string::String;
 use ockam_core::compat::sync::Arc;
 use ockam_core::{
@@ -98,7 +98,12 @@ where
 {
     /// Consume this builder and start a new Ockam [`Worker`] from the given context
     pub fn start(self, context: &Context) -> Result<()> {
-        start(context, self.mailboxes, self.shutdown_priority, self.worker)
+        start(
+            &context.get_router_context(),
+            self.mailboxes,
+            self.shutdown_priority,
+            self.worker,
+        )
     }
 
     pub fn with_shutdown_priority(mut self, shutdown_priority: WorkerShutdownPriority) -> Self {
@@ -158,6 +163,11 @@ where
 
     /// Consume this builder and start a new Ockam [`Worker`] from the given context
     pub fn start(self, context: &Context) -> Result<()> {
+        self.start_using_router_context(&context.get_router_context())
+    }
+
+    /// Consume this builder and start a new Ockam [`Worker`] from the given context
+    pub fn start_using_router_context(self, context: &ContextRouter) -> Result<()> {
         start(
             context,
             Mailboxes::new(
@@ -218,7 +228,7 @@ where
 
 /// Consume this builder and start a new Ockam [`Worker`] from the given context
 fn start<W>(
-    context: &Context,
+    context: &ContextRouter,
     mailboxes: Mailboxes,
     shutdown_priority: WorkerShutdownPriority,
     worker: W,
@@ -235,8 +245,6 @@ where
 
     // Pass it to the context
     let (ctx, sender, ctrl_rx) = context.new_with_mailboxes(mailboxes, ContextMode::Attached);
-
-    debugger::log_inherit_context("WORKER", context, &ctx);
 
     let router = context.router()?;
     router.add_worker(


### PR DESCRIPTION
Introduce ContextRouter struct that allows starting workers and use send_and_receive without requiring to allocate excess mailbox