### PR TITLE
feat(rust): remove the drop instance for the in memory node

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
@@ -1,7 +1,7 @@
+use std::future::Future;
 use std::ops::Deref;
 use std::time::Duration;
 
-use futures::executor;
 use miette::IntoDiagnostic;
 use tracing::Level;
 
@@ -11,6 +11,7 @@ use ockam::tcp::{TcpListenerOptions, TcpTransport};
 use ockam::{Context, Result};
 use ockam_core::compat::{string::String, sync::Arc};
 use ockam_core::errcode::Kind;
+use ockam_core::TryClone;
 use ockam_multiaddr::MultiAddr;
 
 use crate::cli_state::random_name;
@@ -55,80 +56,37 @@ impl Deref for InMemoryNode {
     }
 }
 
-impl Drop for InMemoryNode {
-    fn drop(&mut self) {
-        // Most of the InMemoryNodes should clean-up their resources when their process
-        // stops. Except if they have been started with the `ockam node create` command
-        // because in that case they can be restarted
-        if !self.persistent {
-            // TODO: Should be a better way to do that, e.g. send a signal to a background async
-            //  task to do the job, or shutdown the node manually before dropping this value
-            executor::block_on(async {
-                let result = self.cli_state.remove_node(&self.node_name).await;
-                if let Err(err) = result {
-                    // code: 1032 maps to SQLITE_READONLY_DBMOVED - meaning the database has been
-                    // moved to another directory, most likely already deleted
-                    if !err.to_string().contains("code: 1032") {
-                        error!("Cannot delete the node {}: {err:?}", self.node_name);
-                    }
-                }
-            });
-        }
-    }
-}
-
 impl InMemoryNode {
+    /// Return the current Context
+    pub fn ctx(&self) -> &Context {
+        self.node_manager.ctx()
+    }
+
+    pub fn state(&self) -> Arc<CliState> {
+        self.node_manager.state()
+    }
+
     /// Return a clone of the inner NodeManager
     pub fn inner_clone(&self) -> Arc<NodeManager> {
         self.node_manager.clone()
     }
 
-    /// Start an in memory node
-    pub async fn start(ctx: &Context, cli_state: Arc<CliState>) -> miette::Result<Self> {
-        Self::start_with_project_name(ctx, cli_state, None).await
-    }
-
-    /// Start an in memory node with some project
-    pub async fn start_with_project_name(
-        ctx: &Context,
-        cli_state: Arc<CliState>,
-        project_name: Option<String>,
-    ) -> miette::Result<Self> {
-        let default_identity_name = cli_state
-            .get_or_create_default_named_identity()
-            .await?
-            .name();
-        Self::start_node(
-            ctx,
-            cli_state,
-            &default_identity_name,
-            None,
-            project_name,
-            None,
-            None,
-        )
-        .await
-    }
-
-    /// Start an in memory node with some identity and project
-    pub async fn start_with_identity_and_project_name(
-        ctx: &Context,
-        cli_state: Arc<CliState>,
-        identity: Option<String>,
-        project_name: Option<String>,
-    ) -> miette::Result<Self> {
-        let identity = cli_state.get_identity_name_or_default(&identity).await?;
-        Self::start_node(ctx, cli_state, &identity, None, project_name, None, None).await
-    }
-
-    /// Start an in memory node with a specific identity
-    pub async fn start_with_identity(
-        ctx: &Context,
-        cli_state: Arc<CliState>,
-        identity: Option<String>,
-    ) -> miette::Result<InMemoryNode> {
-        let identity = cli_state.get_identity_name_or_default(&identity).await?;
-        Self::start_node(ctx, cli_state, &identity, None, None, None, None).await
+    /// Shutdown an in memory node
+    pub(crate) async fn shutdown(&self) -> miette::Result<()> {
+        // Most of the InMemoryNodes should clean-up their resources when their process
+        // stops. Except if they have been started with the `ockam node create` command
+        // because in that case they can be restarted
+        if !self.persistent {
+            let result = self.cli_state.remove_node(&self.node_name).await;
+            if let Err(err) = result {
+                // code: 1032 maps to SQLITE_READONLY_DBMOVED - meaning the database has been
+                // moved to another directory, most likely already deleted
+                if !err.to_string().contains("code: 1032") {
+                    error!("Cannot delete the node {}: {err:?}", self.node_name);
+                }
+            };
+        };
+        Ok(())
     }
 
     /// Start an in memory node
@@ -322,6 +280,114 @@ impl InMemoryNode {
     }
 }
 
+pub struct InMemoryNodeBuilder {
+    ctx: Context,
+    cli_state: Arc<CliState>,
+    identity_name: Option<String>,
+    project_name: Option<String>,
+    timeout: Option<Duration>,
+    status_endpoint: Option<BindAddress>,
+    authority_identity: Option<ChangeHistory>,
+    authority_route: Option<MultiAddr>,
+}
+
+impl InMemoryNodeBuilder {
+    pub fn create(ctx: &Context, cli_state: Arc<CliState>) -> Result<Self> {
+        Ok(Self {
+            ctx: ctx.try_clone()?,
+            cli_state: cli_state.clone(),
+            identity_name: None,
+            project_name: None,
+            timeout: None,
+            status_endpoint: None,
+            authority_identity: None,
+            authority_route: None,
+        })
+    }
+
+    pub fn with_identity_name(self, identity_name: Option<String>) -> Self {
+        Self {
+            identity_name,
+            ..self
+        }
+    }
+
+    pub fn with_project_name(self, project_name: Option<String>) -> Self {
+        Self {
+            project_name,
+            ..self
+        }
+    }
+
+    pub fn with_timeout(self, timeout: Option<Duration>) -> Self {
+        Self { timeout, ..self }
+    }
+
+    pub fn with_status_endpoint(self, status_endpoint: Option<BindAddress>) -> Self {
+        Self {
+            status_endpoint,
+            ..self
+        }
+    }
+
+    pub fn with_authority_identity(self, authority_identity: Option<ChangeHistory>) -> Self {
+        Self {
+            authority_identity,
+            ..self
+        }
+    }
+
+    pub fn with_authority_route(self, authority_route: Option<MultiAddr>) -> Self {
+        Self {
+            authority_route,
+            ..self
+        }
+    }
+
+    pub async fn start(&self) -> miette::Result<Arc<InMemoryNode>> {
+        let identity_name = if self.identity_name.is_none() {
+            self.cli_state
+                .get_or_create_default_named_identity()
+                .await?
+                .name()
+        } else {
+            self.cli_state
+                .get_identity_name_or_default(&self.identity_name)
+                .await?
+        };
+        let node = InMemoryNode::start_node(
+            &self.ctx,
+            self.cli_state.clone(),
+            &identity_name,
+            self.status_endpoint.clone(),
+            self.project_name.clone(),
+            self.authority_identity.clone(),
+            self.authority_route.clone(),
+        )
+        .await?;
+
+        let node = if let Some(timeout) = self.timeout {
+            node.with_timeout(timeout)
+        } else {
+            node
+        };
+        Ok(Arc::new(node))
+    }
+
+    pub async fn run<F, R>(
+        &self,
+        future: impl (Fn(Arc<InMemoryNode>) -> F) + Send,
+    ) -> miette::Result<R>
+    where
+        F: Future<Output = miette::Result<R>>,
+    {
+        let node = self.start().await?;
+        let result = future(node.clone()).await;
+        node.shutdown().await?;
+        result
+    }
+}
+
 pub struct NodeManagerDefaults {
     pub node_name: String,
     pub tcp_listener_address: String,
@@ -344,13 +410,20 @@ mod tests {
     async fn test_start_twice(ctx: &mut Context) -> Result<()> {
         let cli = Arc::new(CliState::test().await?);
 
-        let node_manager1 = InMemoryNode::start(ctx, cli.clone()).await;
+        let node_manager1 = start(ctx, cli.clone()).await;
         assert!(node_manager1.is_ok());
 
-        let node_manager2 = InMemoryNode::start(ctx, cli).await;
+        let node_manager2 = start(ctx, cli).await;
         if let Err(e) = node_manager2 {
             panic!("cannot start the node manager a second time: {e:?}");
         }
         Ok(())
+    }
+
+    // HELPERS
+    async fn start(ctx: &Context, cli_state: Arc<CliState>) -> miette::Result<Arc<InMemoryNode>> {
+        InMemoryNodeBuilder::create(ctx, cli_state.clone())?
+            .start()
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
@@ -665,6 +665,11 @@ impl NodeManager {
     pub fn ctx(&self) -> &Context {
         self.tcp_transport.ctx()
     }
+
+    /// CliState
+    pub fn state(&self) -> Arc<CliState> {
+        self.cli_state.clone()
+    }
 }
 
 #[derive(Debug)]

--- a/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
@@ -1,17 +1,17 @@
-use std::path::PathBuf;
-
+use crate::node_command::InMemoryNodeCommand;
+use crate::shared_args::IdentityOpts;
+use crate::subscription::get_subscription_by_id_or_space_id;
+use crate::{docs, CommandGlobalOpts};
+use async_trait::async_trait;
 use clap::builder::NonEmptyStringValueParser;
 use clap::{Args, Subcommand};
 use miette::{Context as _, IntoDiagnostic};
-
 use ockam::Context;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::subscription::Subscriptions;
 use ockam_api::output::Output;
-
-use crate::shared_args::IdentityOpts;
-use crate::subscription::get_subscription_by_id_or_space_id;
-use crate::{docs, CommandGlobalOpts};
+use std::path::PathBuf;
+use std::sync::Arc;
 
 const HELP_DETAIL: &str = "";
 
@@ -130,13 +130,21 @@ enum SubscriptionUpdateSubcommand {
     },
 }
 
-impl SubscriptionCommand {
-    pub fn name(&self) -> String {
-        "admin subscription".into()
-    }
+#[derive(Clone)]
+struct SubscriptionNodeCommand {
+    opts: CommandGlobalOpts,
+    subcommand: SubscriptionSubcommand,
+}
 
-    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
+impl SubscriptionNodeCommand {
+    fn new(opts: CommandGlobalOpts, subcommand: SubscriptionSubcommand) -> Self {
+        Self { opts, subcommand }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for SubscriptionNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
         let controller = node.create_controller().await?;
 
         match &self.subcommand {
@@ -149,16 +157,17 @@ impl SubscriptionCommand {
                     .context(format!("failed to read {:?}", &json))?;
 
                 let response = controller
-                    .activate_subscription(ctx, space.clone(), json)
+                    .activate_subscription(node.ctx(), space.clone(), json)
                     .await?;
-                opts.terminal.write_line(&response.item()?)?
+                self.opts.terminal.write_line(&response.item()?)?
             }
             SubscriptionSubcommand::List => {
-                let response = controller.get_subscriptions(ctx).await?;
-                let output = opts
+                let response = controller.get_subscriptions(node.ctx()).await?;
+                let output = self
+                    .opts
                     .terminal
                     .build_list(&response, "No Subscriptions found")?;
-                opts.terminal.write_line(output)?
+                self.opts.terminal.write_line(output)?
             }
             SubscriptionSubcommand::Unsubscribe {
                 subscription_id,
@@ -166,17 +175,18 @@ impl SubscriptionCommand {
             } => {
                 match get_subscription_by_id_or_space_id(
                     &controller,
-                    ctx,
+                    node.ctx(),
                     subscription_id.clone(),
                     space_id.clone(),
                 )
                 .await?
                 {
                     Some(subscription) => {
-                        let response = controller.unsubscribe(ctx, subscription.id).await?;
-                        opts.terminal.write_line(&response.item()?)?
+                        let response = controller.unsubscribe(node.ctx(), subscription.id).await?;
+                        self.opts.terminal.write_line(&response.item()?)?
                     }
-                    None => opts
+                    None => self
+                        .opts
                         .terminal
                         .write_line("Please specify either a space id or a subscription id")?,
                 }
@@ -194,7 +204,7 @@ impl SubscriptionCommand {
                             .context(format!("failed to read {:?}", &json))?;
                         match get_subscription_by_id_or_space_id(
                             &controller,
-                            ctx,
+                            node.ctx(),
                             subscription_id.clone(),
                             space_id.clone(),
                         )
@@ -202,11 +212,15 @@ impl SubscriptionCommand {
                         {
                             Some(subscription) => {
                                 let response = controller
-                                    .update_subscription_contact_info(ctx, subscription.id, json)
+                                    .update_subscription_contact_info(
+                                        node.ctx(),
+                                        subscription.id,
+                                        json,
+                                    )
                                     .await?;
-                                opts.terminal.write_line(&response.item()?)?
+                                self.opts.terminal.write_line(&response.item()?)?
                             }
-                            None => opts.terminal.write_line(
+                            None => self.opts.terminal.write_line(
                                 "Please specify either a space id or a subscription id",
                             )?,
                         }
@@ -218,7 +232,7 @@ impl SubscriptionCommand {
                     } => {
                         match get_subscription_by_id_or_space_id(
                             &controller,
-                            ctx,
+                            node.ctx(),
                             subscription_id.clone(),
                             space_id.clone(),
                         )
@@ -227,14 +241,14 @@ impl SubscriptionCommand {
                             Some(subscription) => {
                                 let response = controller
                                     .update_subscription_space(
-                                        ctx,
+                                        node.ctx(),
                                         subscription.id,
                                         new_space_id.clone(),
                                     )
                                     .await?;
-                                opts.terminal.write_line(&response.item()?)?
+                                self.opts.terminal.write_line(&response.item()?)?
                             }
-                            None => opts.terminal.write_line(
+                            None => self.opts.terminal.write_line(
                                 "Please specify either a space id or a subscription id",
                             )?,
                         }
@@ -243,5 +257,17 @@ impl SubscriptionCommand {
             }
         };
         Ok(())
+    }
+}
+
+impl SubscriptionCommand {
+    pub fn name(&self) -> String {
+        "admin subscription".into()
+    }
+
+    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        SubscriptionNodeCommand::new(opts.clone(), self.subcommand.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -1,9 +1,4 @@
-use std::collections::HashMap;
-use std::io::stdin;
-use std::process;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-
+use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
 use miette::{miette, IntoDiagnostic, WrapErr};
@@ -11,12 +6,18 @@ use r3bl_rs_utils_core::UnicodeString;
 use r3bl_tui::{
     ColorWheel, ColorWheelConfig, ColorWheelSpeed, GradientGenerationPolicy, TextColorizationPolicy,
 };
+use std::collections::HashMap;
+use std::io::stdin;
+use std::process;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::try_join;
 use tracing::{error, info, instrument, warn, Level};
 
 use crate::enroll::OidcServiceExt;
 use crate::error::Error;
+use crate::node_command::InMemoryNodeCommand;
 use crate::operation::util::check_for_project_completion;
 use crate::project::util::check_project_readiness;
 use crate::{docs, CommandGlobalOpts, Result};
@@ -33,8 +34,7 @@ use ockam_api::orchestrator::space::{Space, Spaces};
 use ockam_api::orchestrator::subscription::subscription_page;
 use ockam_api::orchestrator::ControllerClient;
 use ockam_api::terminal::notification::NotificationHandler;
-use ockam_api::{fmt_err, fmt_log, fmt_ok, fmt_warn};
-use ockam_api::{fmt_separator, CliState};
+use ockam_api::{fmt_err, fmt_log, fmt_ok, fmt_separator, fmt_warn};
 
 const LONG_ABOUT: &str = include_str!("./static/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/after_long_help.txt");
@@ -78,62 +78,151 @@ pub struct EnrollCommand {
     pub skip_orchestrator_resources_creation: bool,
 }
 
-impl EnrollCommand {
-    pub fn name(&self) -> String {
-        "enroll".to_string()
+#[derive(Clone)]
+struct EnrollNodeCommand {
+    opts: CommandGlobalOpts,
+    command: EnrollCommand,
+}
+
+impl EnrollNodeCommand {
+    fn new(opts: CommandGlobalOpts, command: EnrollCommand) -> Self {
+        Self { opts, command }
     }
 
-    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        if opts.global_args.output_format().is_json() {
-            return Err(miette::miette!(
-            "This command is interactive and requires you to open a web browser to complete enrollment. \
-            Please try running it again without '--output json'."
-        ));
+    /// Check if the identity is already enrolled and display a message to the user.
+    async fn is_already_enrolled(&self) -> miette::Result<bool> {
+        let mut is_already_enrolled = !self
+            .opts
+            .state
+            .identity_should_enroll(&self.command.identity, false)
+            .await?;
+        if is_already_enrolled {
+            match &self.command.identity {
+                // Use default identity.
+                None => {
+                    if let Ok(named_identity) =
+                        self.opts.state.get_or_create_default_named_identity().await
+                    {
+                        let name = named_identity.name();
+                        let identifier = named_identity.identifier();
+                        let message = format!(
+                            "Your {} Identity {}\nwith Identifier {}\nis already enrolled as one of the Identities associated with your Ockam account.",
+                            "default".to_string().dim(),
+                            color_primary(name),
+                            color_primary(identifier.to_string())
+                        );
+                        message.split('\n').for_each(|line| {
+                            self.opts.terminal.write_line(fmt_log!("{}", line)).unwrap();
+                        });
+                    }
+                }
+                // Identity specified.
+                Some(ref name) => {
+                    let named_identity = self.opts.state.get_named_identity(name).await?;
+                    let name = named_identity.name();
+                    let identifier = named_identity.identifier();
+                    let message = format!(
+                        "Your Identity {}\nwith Identifier {}\nis already enrolled as one of the Identities associated with your Ockam account.",
+                        color_primary(name),
+                        color_primary(identifier.to_string())
+                    );
+                    message.split('\n').for_each(|line| {
+                        self.opts.terminal.write_line(fmt_log!("{}", line)).unwrap();
+                    });
+                }
+            };
         }
-        self.run_impl(ctx, opts.clone()).await?;
-        Ok(())
+
+        // Check if the default space is available and has a valid subscription
+        let default_space = match self.opts.state.get_default_space().await {
+            Ok(space) => space,
+            Err(_) => {
+                // If there is no default space, we want to continue with the enrollment process
+                return Ok(false);
+            }
+        };
+        is_already_enrolled &= default_space.has_valid_subscription();
+
+        Ok(is_already_enrolled)
     }
 
-    // Creates one span in the trace
-    #[instrument(
-        skip_all, // Drop all args that passed in, as Context doesn't play nice
-        fields(
-        enroller = ? self.identity, // https://docs.rs/tracing/latest/tracing/
-        authorization_code_flow = % self.authorization_code_flow,
-        force = % self.force,
-        skip_orchestrator_resources_creation = % self.skip_orchestrator_resources_creation,
-        ), level = Level::TRACE)]
-    async fn run_impl(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        ctrlc_handler(opts.clone());
+    async fn enroll_identity(&self, node: Arc<InMemoryNode>) -> miette::Result<UserInfo> {
+        if !self
+            .opts
+            .state
+            .identity_should_enroll(&self.command.identity, self.command.force)
+            .await?
+        {
+            if let Ok(user_info) = self.opts.state.get_default_user().await {
+                return Ok(user_info);
+            }
+        }
 
-        if self.is_already_enrolled(opts.state.clone(), &opts).await? {
+        self.opts.terminal.write_line(fmt_log!(
+            "Enrolling your Identity with Ockam Orchestrator..."
+        ))?;
+
+        // Run OIDC service
+        let oidc_service = OidcService::new()?;
+        let token = if self.command.authorization_code_flow {
+            oidc_service.get_token_with_pkce().await.into_diagnostic()?
+        } else {
+            oidc_service.get_token_interactively(&self.opts).await?
+        };
+
+        // Store user info retrieved from OIDC service
+        let user_info = oidc_service
+            .wait_for_email_verification(&token, Some(&self.opts.terminal))
+            .await?;
+        self.opts.state.store_user(&user_info).await?;
+
+        // Enroll the identity with the Orchestrator
+        let controller = node.create_controller().await?;
+        enroll_with_node(&controller, node.ctx(), token)
+            .await
+            .wrap_err("Failed to enroll your local Identity with Ockam Orchestrator")?;
+        self.opts
+            .state
+            .set_identifier_as_enrolled(&node.identifier(), &user_info.email)
+            .await
+            .wrap_err("Unable to set your local Identity as enrolled")?;
+
+        Ok(user_info)
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for EnrollNodeCommand {
+    async fn init(&self) -> miette::Result<()> {
+        ctrlc_handler(self.opts.clone());
+
+        if self.is_already_enrolled().await? {
             return Ok(());
         }
 
-        display_header(&opts);
+        display_header(&self.opts);
 
-        let identity = {
-            let _notification_handler =
-                NotificationHandler::start(opts.state.clone(), opts.terminal.clone());
-            opts.state
-                .get_named_identity_or_default(&self.identity)
-                .await?
-        };
+        let _notification_handler =
+            NotificationHandler::start(self.opts.state.clone(), self.opts.terminal.clone());
+        self.opts
+            .state
+            .get_named_identity_or_default(&self.command.identity)
+            .await?;
+        Ok(())
+    }
 
-        let identity_name = identity.name();
-        let identifier = identity.identifier();
-        let node =
-            InMemoryNode::start_with_identity(ctx, opts.state.clone(), Some(identity_name.clone()))
-                .await?;
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let user_info = self.enroll_identity(node.clone()).await?;
 
-        let user_info = self.enroll_identity(ctx, &opts, &node).await?;
-
-        if let Err(error) =
-            retrieve_user_space_and_project(&opts, &node, self.skip_orchestrator_resources_creation)
-                .await
+        if let Err(error) = retrieve_user_space_and_project(
+            &self.opts,
+            &node,
+            self.command.skip_orchestrator_resources_creation,
+        )
+        .await
         {
             // Display output to user
-            opts.terminal
+            self.opts.terminal
                 .write_line("")?
                 .write_line(fmt_warn!(
                     "There was a problem retrieving your space and project: {}",
@@ -164,19 +253,27 @@ impl EnrollCommand {
         attributes.insert(USER_EMAIL, user_info.email.to_string());
         // this event formally only happens on the host journey
         // but we add it here for better rendering of the project journey
-        opts.state
+        self.opts
+            .state
             .add_journey_event(JourneyEvent::ok("enroll".to_string()), attributes.clone())
             .await?;
-        opts.state
+        self.opts
+            .state
             .add_journey_event(JourneyEvent::Enrolled, attributes)
             .await?;
 
+        let identity = self
+            .opts
+            .state
+            .get_named_identity_or_default(&self.command.identity)
+            .await?;
+
         // Output
-        opts.terminal
+        self.opts.terminal
             .write_line(fmt_log!(
                 "Your Identity {}, with Identifier {} is now enrolled with Ockam Orchestrator.",
-                color_primary(identity_name),
-                color_primary(identifier.to_string())
+                color_primary(identity.name()),
+                color_primary(identity.identifier().to_string())
             ))?
             .write_line(fmt_log!(
                 "You also now have an Orchestrator Project that offers a Project Membership Authority service and a Relay service.\n"
@@ -191,111 +288,34 @@ impl EnrollCommand {
 
         Ok(())
     }
+}
 
-    /// Check if the identity is already enrolled and display a message to the user.
-    async fn is_already_enrolled(
-        &self,
-        cli_state: Arc<CliState>,
-        opts: &CommandGlobalOpts,
-    ) -> miette::Result<bool> {
-        let mut is_already_enrolled = !cli_state
-            .identity_should_enroll(&self.identity, false)
-            .await?;
-        if is_already_enrolled {
-            match &self.identity {
-                // Use default identity.
-                None => {
-                    if let Ok(named_identity) =
-                        cli_state.get_or_create_default_named_identity().await
-                    {
-                        let name = named_identity.name();
-                        let identifier = named_identity.identifier();
-                        let message = format!(
-                            "Your {} Identity {}\nwith Identifier {}\nis already enrolled as one of the Identities associated with your Ockam account.",
-                            "default".to_string().dim(),
-                            color_primary(name),
-                            color_primary(identifier.to_string())
-                        );
-                        message.split('\n').for_each(|line| {
-                            opts.terminal.write_line(fmt_log!("{}", line)).unwrap();
-                        });
-                    }
-                }
-                // Identity specified.
-                Some(ref name) => {
-                    let named_identity = cli_state.get_named_identity(name).await?;
-                    let name = named_identity.name();
-                    let identifier = named_identity.identifier();
-                    let message = format!(
-                        "Your Identity {}\nwith Identifier {}\nis already enrolled as one of the Identities associated with your Ockam account.",
-                        color_primary(name),
-                        color_primary(identifier.to_string())
-                    );
-                    message.split('\n').for_each(|line| {
-                        opts.terminal.write_line(fmt_log!("{}", line)).unwrap();
-                    });
-                }
-            };
-        }
-
-        // Check if the default space is available and has a valid subscription
-        let default_space = match cli_state.get_default_space().await {
-            Ok(space) => space,
-            Err(_) => {
-                // If there is no default space, we want to continue with the enrollment process
-                return Ok(false);
-            }
-        };
-        is_already_enrolled &= default_space.has_valid_subscription();
-
-        Ok(is_already_enrolled)
+impl EnrollCommand {
+    pub fn name(&self) -> String {
+        "enroll".to_string()
     }
 
-    async fn enroll_identity(
-        &self,
-        ctx: &Context,
-        opts: &CommandGlobalOpts,
-        node: &InMemoryNode,
-    ) -> miette::Result<UserInfo> {
-        if !opts
-            .state
-            .identity_should_enroll(&self.identity, self.force)
-            .await?
-        {
-            if let Ok(user_info) = opts.state.get_default_user().await {
-                return Ok(user_info);
-            }
+    // Creates one span in the trace
+    #[instrument(
+        skip_all, // Drop all args that passed in, as Context doesn't play nice
+        fields(
+        enroller = ? self.identity, // https://docs.rs/tracing/latest/tracing/
+        authorization_code_flow = % self.authorization_code_flow,
+        force = % self.force,
+        skip_orchestrator_resources_creation = % self.skip_orchestrator_resources_creation,
+        ), level = Level::TRACE)]
+    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        if opts.global_args.output_format().is_json() {
+            return Err(miette::miette!(
+            "This command is interactive and requires you to open a web browser to complete enrollment. \
+            Please try running it again without '--output json'."
+        ));
         }
 
-        opts.terminal.write_line(fmt_log!(
-            "Enrolling your Identity with Ockam Orchestrator..."
-        ))?;
-
-        // Run OIDC service
-        let oidc_service = OidcService::new()?;
-        let token = if self.authorization_code_flow {
-            oidc_service.get_token_with_pkce().await.into_diagnostic()?
-        } else {
-            oidc_service.get_token_interactively(opts).await?
-        };
-
-        // Store user info retrieved from OIDC service
-        let user_info = oidc_service
-            .wait_for_email_verification(&token, Some(&opts.terminal))
+        EnrollNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
             .await?;
-        opts.state.store_user(&user_info).await?;
-
-        // Enroll the identity with the Orchestrator
-        let controller = node.create_controller().await?;
-        enroll_with_node(&controller, ctx, token)
-            .await
-            .wrap_err("Failed to enroll your local Identity with Ockam Orchestrator")?;
-        opts.state
-            .set_identifier_as_enrolled(&node.identifier(), &user_info.email)
-            .await
-            .wrap_err("Unable to set your local Identity as enrolled")?;
-
-        Ok(user_info)
+        Ok(())
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/lease/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/create.rs
@@ -1,3 +1,4 @@
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::{IdentityOpts, TimeoutArg, TrustOpts};
 use crate::{docs, Command, CommandGlobalOpts};
 use async_trait::async_trait;
@@ -9,6 +10,8 @@ use ockam_api::nodes::InMemoryNode;
 use ockam_api::{fmt_log, fmt_ok};
 use ockam_multiaddr::MultiAddr;
 use ockam_node::Context;
+use std::sync::Arc;
+use std::time::Duration;
 
 const HELP_DETAIL: &str = "";
 
@@ -30,26 +33,40 @@ pub struct CreateCommand {
     trust_opts: TrustOpts,
 }
 
+#[derive(Clone)]
+struct CreateNodeCommand {
+    opts: CommandGlobalOpts,
+    command: CreateCommand,
+}
+
+impl CreateNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: CreateCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
 #[async_trait]
-impl Command for CreateCommand {
-    const NAME: &'static str = "lease create";
+impl InMemoryNodeCommand for CreateNodeCommand {
+    fn project_name(&self) -> Option<String> {
+        self.command.trust_opts.project_name.clone()
+    }
 
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        let cmd = self.parse_args(&opts).await?;
+    fn identity_name(&self) -> Option<String> {
+        self.command.identity_opts.identity_name.clone()
+    }
 
-        let node = InMemoryNode::start_with_identity_and_project_name(
-            ctx,
-            opts.state.clone(),
-            cmd.identity_opts.identity_name.clone(),
-            cmd.trust_opts.project_name.clone(),
-        )
-        .await?
-        .with_timeout(cmd.timeout.timeout);
+    fn timeout(&self) -> Option<Duration> {
+        Some(self.command.timeout.timeout)
+    }
 
-        opts.terminal
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let cmd = self.command.clone().parse_args(&self.opts).await?;
+
+        self.opts
+            .terminal
             .write_line(fmt_log!("Creating influxdb token...\n"))?;
 
-        let res = node.create_token(ctx, &cmd.at).await?;
+        let res = node.create_token(node.ctx(), &cmd.at).await?;
 
         let plain = fmt_ok!("A token with id {}\n", color_primary(&res.id))
             + &fmt_log!(
@@ -58,7 +75,9 @@ impl Command for CreateCommand {
             )
             + &fmt_log!("and will expire at {}", color_primary(res.expires_at()?));
 
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .machine(&res.token)
             .plain(plain)
@@ -66,6 +85,17 @@ impl Command for CreateCommand {
             .write_line()?;
 
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Command for CreateCommand {
+    const NAME: &'static str = "lease create";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        CreateNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/lease/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/list.rs
@@ -1,3 +1,4 @@
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::{IdentityOpts, TimeoutArg, TrustOpts};
 use crate::util::clean_nodes_multiaddr;
 use crate::{docs, Command, CommandGlobalOpts};
@@ -8,6 +9,8 @@ use ockam_api::fmt_log;
 use ockam_api::influxdb::lease_issuer::InfluxDBTokenLessorNodeServiceTrait;
 use ockam_api::nodes::InMemoryNode;
 use ockam_multiaddr::MultiAddr;
+use std::sync::Arc;
+use std::time::Duration;
 
 const HELP_DETAIL: &str = "";
 
@@ -29,37 +32,64 @@ pub struct ListCommand {
     trust_opts: TrustOpts,
 }
 
+#[derive(Clone)]
+struct ListNodeCommand {
+    opts: CommandGlobalOpts,
+    command: ListCommand,
+}
+
+impl ListNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: ListCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
 #[async_trait]
-impl Command for ListCommand {
-    const NAME: &'static str = "lease list";
+impl InMemoryNodeCommand for ListNodeCommand {
+    fn project_name(&self) -> Option<String> {
+        self.command.trust_opts.project_name.clone()
+    }
 
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        let cmd = self.parse_args(&opts).await?;
+    fn identity_name(&self) -> Option<String> {
+        self.command.identity_opts.identity_name.clone()
+    }
 
-        let node = InMemoryNode::start_with_identity_and_project_name(
-            ctx,
-            opts.state.clone(),
-            cmd.identity_opts.identity_name.clone(),
-            cmd.trust_opts.project_name.clone(),
-        )
-        .await?
-        .with_timeout(cmd.timeout.timeout);
+    fn timeout(&self) -> Option<Duration> {
+        Some(self.command.timeout.timeout)
+    }
 
-        opts.terminal
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let cmd = self.command.clone().parse_args(&self.opts).await?;
+
+        self.opts
+            .terminal
             .write_line(fmt_log!("Listing influxdb tokens...\n"))?;
 
-        let (at, _meta) = clean_nodes_multiaddr(&cmd.at, opts.state.clone()).await?;
-        let res = node.list_tokens(ctx, &at).await?;
+        let (at, _meta) = clean_nodes_multiaddr(&cmd.at, self.opts.state.clone()).await?;
+        let res = node.list_tokens(node.ctx(), &at).await?;
 
-        let plain = &opts.terminal.build_list(&res, "No tokens found")?;
+        let plain = &self.opts.terminal.build_list(&res, "No tokens found")?;
 
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(plain)
             .json_obj(res)?
             .write_line()?;
 
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Command for ListCommand {
+    const NAME: &'static str = "lease list";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        ListNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
@@ -1,3 +1,4 @@
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::{IdentityOpts, TimeoutArg, TrustOpts};
 use crate::util::clean_nodes_multiaddr;
 use crate::{docs, Command, CommandGlobalOpts};
@@ -10,6 +11,8 @@ use ockam_api::influxdb::lease_issuer::InfluxDBTokenLessorNodeServiceTrait;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::{fmt_log, fmt_ok};
 use ockam_multiaddr::MultiAddr;
+use std::sync::Arc;
+use std::time::Duration;
 
 const HELP_DETAIL: &str = "";
 
@@ -35,29 +38,44 @@ pub struct RevokeCommand {
     trust_opts: TrustOpts,
 }
 
+#[derive(Clone)]
+struct RevokeNodeCommand {
+    opts: CommandGlobalOpts,
+    command: RevokeCommand,
+}
+
+impl RevokeNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: RevokeCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
 #[async_trait]
-impl Command for RevokeCommand {
-    const NAME: &'static str = "lease revoke";
+impl InMemoryNodeCommand for RevokeNodeCommand {
+    fn project_name(&self) -> Option<String> {
+        self.command.trust_opts.project_name.clone()
+    }
 
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        let cmd = self.parse_args(&opts).await?;
+    fn identity_name(&self) -> Option<String> {
+        self.command.identity_opts.identity_name.clone()
+    }
 
-        let node = InMemoryNode::start_with_identity_and_project_name(
-            ctx,
-            opts.state.clone(),
-            cmd.identity_opts.identity_name.clone(),
-            cmd.trust_opts.project_name.clone(),
-        )
-        .await?
-        .with_timeout(cmd.timeout.timeout);
+    fn timeout(&self) -> Option<Duration> {
+        Some(self.command.timeout.timeout)
+    }
 
-        opts.terminal
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let cmd = self.command.clone().parse_args(&self.opts).await?;
+        self.opts
+            .terminal
             .write_line(fmt_log!("Revoking influxdb token {}...\n", cmd.token_id))?;
 
-        let (at, _meta) = clean_nodes_multiaddr(&cmd.at, opts.state.clone()).await?;
-        node.revoke_token(ctx, &at, &cmd.token_id).await?;
+        let (at, _meta) = clean_nodes_multiaddr(&cmd.at, self.opts.state.clone()).await?;
+        node.revoke_token(node.ctx(), &at, &cmd.token_id).await?;
 
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(fmt_ok!(
                 "Token with id {} has been revoked.",
@@ -68,6 +86,17 @@ impl Command for RevokeCommand {
             .write_line()?;
 
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Command for RevokeCommand {
+    const NAME: &'static str = "lease revoke";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        RevokeNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/lease/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/show.rs
@@ -1,3 +1,4 @@
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::{IdentityOpts, TimeoutArg, TrustOpts};
 use crate::util::clean_nodes_multiaddr;
 use crate::{docs, Command, CommandGlobalOpts};
@@ -9,6 +10,8 @@ use ockam_api::influxdb::lease_issuer::InfluxDBTokenLessorNodeServiceTrait;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::output::Output;
 use ockam_multiaddr::MultiAddr;
+use std::sync::Arc;
+use std::time::Duration;
 
 const HELP_DETAIL: &str = "";
 
@@ -34,29 +37,52 @@ pub struct ShowCommand {
     trust_opts: TrustOpts,
 }
 
+impl ShowCommand {
+    async fn parse_args(mut self, opts: &CommandGlobalOpts) -> crate::Result<Self> {
+        self.at = super::resolve_at_arg(&self.at, opts.state.clone()).await?;
+        Ok(self)
+    }
+}
+
+#[derive(Clone)]
+struct ShowNodeCommand {
+    opts: CommandGlobalOpts,
+    command: ShowCommand,
+}
+
+impl ShowNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: ShowCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
 #[async_trait]
-impl Command for ShowCommand {
-    const NAME: &'static str = "lease show";
+impl InMemoryNodeCommand for ShowNodeCommand {
+    fn project_name(&self) -> Option<String> {
+        self.command.trust_opts.project_name.clone()
+    }
 
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        let cmd = self.parse_args(&opts).await?;
+    fn identity_name(&self) -> Option<String> {
+        self.command.identity_opts.identity_name.clone()
+    }
 
-        let node = InMemoryNode::start_with_identity_and_project_name(
-            ctx,
-            opts.state.clone(),
-            cmd.identity_opts.identity_name.clone(),
-            cmd.trust_opts.project_name.clone(),
-        )
-        .await?
-        .with_timeout(cmd.timeout.timeout);
+    fn timeout(&self) -> Option<Duration> {
+        Some(self.command.timeout.timeout)
+    }
 
-        opts.terminal
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let cmd = self.command.clone().parse_args(&self.opts).await?;
+
+        self.opts
+            .terminal
             .write_line(fmt_log!("Retrieving influxdb token...\n"))?;
 
-        let (at, _meta) = clean_nodes_multiaddr(&cmd.at, opts.state.clone()).await?;
-        let res = node.get_token(ctx, &at, &cmd.token_id).await?;
+        let (at, _meta) = clean_nodes_multiaddr(&cmd.at, self.opts.state.clone()).await?;
+        let res = node.get_token(node.ctx(), &at, &cmd.token_id).await?;
 
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .machine(res.token.to_string())
             .plain(res.item()?)
@@ -67,9 +93,13 @@ impl Command for ShowCommand {
     }
 }
 
-impl ShowCommand {
-    async fn parse_args(mut self, opts: &CommandGlobalOpts) -> crate::Result<Self> {
-        self.at = super::resolve_at_arg(&self.at, opts.state.clone()).await?;
-        Ok(self)
+#[async_trait]
+impl Command for ShowCommand {
+    const NAME: &'static str = "lease show";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        ShowNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -52,6 +52,7 @@ mod markdown;
 mod message;
 mod migrate_database;
 pub mod node;
+mod node_command;
 mod operation;
 mod output;
 pub mod pager;

--- a/implementations/rust/ockam/ockam_command/src/node_command.rs
+++ b/implementations/rust/ockam/ockam_command/src/node_command.rs
@@ -1,0 +1,104 @@
+use async_trait::async_trait;
+use ockam_api::nodes::{InMemoryNode, InMemoryNodeBuilder};
+use ockam_api::CliState;
+
+use ockam_api::cli_state::NamedIdentity;
+use ockam_api::orchestrator::project::Project;
+use ockam_api::orchestrator::AuthorityNodeClient;
+use ockam_node::Context;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// This supports the instantiation and shutdown of an in-memory node
+/// which can be used to execute a command.
+///
+/// Some optional values can be provided:
+///
+///  - A project name (used to access the controller for example)
+///  - An identity name (used to create secure channels)
+///  - A default timeout for creating secure channels
+///
+/// The `run` must be implemented by the command that uses this trait.
+/// It is also possible to provide an init method that will be called before the run method,
+/// for example to create the identity which will be used to create the in-memory node.
+///
+#[async_trait]
+pub trait InMemoryNodeCommand: Clone + Send + Sync + 'static {
+    /// Optional project name
+    fn project_name(&self) -> Option<String> {
+        None
+    }
+
+    /// Optional identity name
+    fn identity_name(&self) -> Option<String> {
+        None
+    }
+
+    /// Optional default timeout for creating secure channels
+    fn timeout(&self) -> Option<Duration> {
+        None
+    }
+
+    /// This method is called before the run method.
+    async fn init(&self) -> miette::Result<()> {
+        Ok(())
+    }
+
+    /// This method needs to be implemented. It guarantees that the in-memory node is properly shutdown
+    /// when the command is finished or raises an error.
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()>;
+
+    /// The default execute method ensures that the command code will be executed with a node that is properly shutdown
+    async fn execute(&self, ctx: &Context, state: Arc<CliState>) -> miette::Result<()> {
+        self.init().await?;
+        let self_clone = Arc::new(self.clone());
+        InMemoryNodeBuilder::create(ctx, state)?
+            .with_identity_name(self.identity_name())
+            .with_project_name(self.project_name())
+            .with_timeout(self.timeout())
+            .run({
+                let self_clone = self_clone.clone();
+                move |n| {
+                    let self_clone = self_clone.clone();
+                    Box::pin(async move { self_clone.run(n).await })
+                }
+            })
+            .await
+    }
+
+    /// Return an authority client for the given project and identity
+    async fn authority_client(
+        &self,
+        node: Arc<InMemoryNode>,
+    ) -> miette::Result<AuthorityNodeClient> {
+        let identity = node
+            .state()
+            .get_identity_name_or_default(&self.identity_name())
+            .await?;
+
+        let project = node
+            .state()
+            .projects()
+            .get_project_by_name_or_default(&self.project_name())
+            .await?;
+        node.create_authority_client_with_project(&project, Some(identity), false)
+            .await
+    }
+
+    /// Return the project specified by this command
+    async fn get_project(&self, node: Arc<InMemoryNode>) -> miette::Result<Project> {
+        Ok(node
+            .state()
+            .projects()
+            .get_project_by_name_or_default(&self.project_name())
+            .await?)
+    }
+
+    /// Return the identity specified by this command
+    async fn get_identity(&self, node: Arc<InMemoryNode>) -> miette::Result<NamedIdentity> {
+        Ok(node
+            .state()
+            .get_named_identity_or_default(&self.identity_name())
+            .await?)
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
@@ -1,9 +1,10 @@
-use std::path::PathBuf;
-
+use async_trait::async_trait;
 use clap::builder::NonEmptyStringValueParser;
 use clap::Args;
 use colorful::Colorful;
 use miette::{miette, IntoDiagnostic};
+use std::path::PathBuf;
+use std::sync::Arc;
 
 use ockam::Context;
 use ockam_api::fmt_ok;
@@ -11,6 +12,7 @@ use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::addon::Addons;
 use ockam_api::orchestrator::project::models::InfluxDBTokenLeaseManagerConfig;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::project::addon::check_configuration_completion;
 use crate::{docs, CommandGlobalOpts};
 
@@ -112,21 +114,31 @@ pub struct AddonConfigureInfluxdbSubcommand {
     admin_access_role: Option<String>,
 }
 
-impl AddonConfigureInfluxdbSubcommand {
-    pub fn name(&self) -> String {
-        "project addon configure influxdb".into()
-    }
+#[derive(Clone)]
+pub struct AddonConfigureInfluxdbNodeCommand {
+    opts: CommandGlobalOpts,
+    command: AddonConfigureInfluxdbSubcommand,
+}
 
-    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        let project_id = opts
+impl AddonConfigureInfluxdbNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: AddonConfigureInfluxdbSubcommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for AddonConfigureInfluxdbNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let project_id = self
+            .opts
             .state
             .projects()
-            .get_project_by_name(&self.project_name)
+            .get_project_by_name(&self.command.project_name)
             .await?
             .project_id()
             .to_string();
 
-        let perms = match (&self.permissions, &self.permissions_path) {
+        let perms = match (&self.command.permissions, &self.command.permissions_path) {
             (_, Some(p)) => std::fs::read_to_string(p).into_diagnostic()?,
             (Some(perms), _) => perms.to_string(),
             _ => {
@@ -137,25 +149,38 @@ impl AddonConfigureInfluxdbSubcommand {
         };
 
         let config = InfluxDBTokenLeaseManagerConfig::new(
-            self.endpoint_url.clone(),
-            self.token.clone(),
-            self.org_id.clone(),
+            self.command.endpoint_url.clone(),
+            self.command.token.clone(),
+            self.command.org_id.clone(),
             perms,
-            self.max_ttl_secs,
-            self.user_access_role.clone(),
-            self.admin_access_role.clone(),
+            self.command.max_ttl_secs,
+            self.command.user_access_role.clone(),
+            self.command.admin_access_role.clone(),
         );
 
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
         let controller = node.create_controller().await?;
 
         let response = controller
-            .configure_influxdb_addon(ctx, &project_id, config)
+            .configure_influxdb_addon(node.ctx(), &project_id, config)
             .await?;
-        check_configuration_completion(&opts, &node, &project_id, &response.operation_id).await?;
+        check_configuration_completion(&self.opts, &node, &project_id, &response.operation_id)
+            .await?;
 
-        opts.terminal
+        self.opts
+            .terminal
             .write_line(fmt_ok!("InfluxDB addon configured successfully"))?;
         Ok(())
+    }
+}
+
+impl AddonConfigureInfluxdbSubcommand {
+    pub fn name(&self) -> String {
+        "project addon configure influxdb".into()
+    }
+
+    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        AddonConfigureInfluxdbNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka.rs
@@ -1,6 +1,8 @@
+use async_trait::async_trait;
 use clap::builder::NonEmptyStringValueParser;
 use clap::Args;
 use colorful::Colorful;
+use std::sync::Arc;
 
 pub use aiven::AddonConfigureAivenSubcommand;
 pub use confluent::AddonConfigureConfluentSubcommand;
@@ -12,6 +14,7 @@ use ockam_api::orchestrator::addon::{Addons, KafkaConfig};
 pub use redpanda::AddonConfigureRedpandaSubcommand;
 pub use warpstream::AddonConfigureWarpstreamSubcommand;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::project::addon::check_configuration_completion;
 use crate::{docs, CommandGlobalOpts};
 
@@ -57,6 +60,56 @@ pub struct AddonConfigureKafkaSubcommand {
     config: KafkaCommandConfig,
 }
 
+#[derive(Clone)]
+struct AddonConfigureKafkaNodeCommand {
+    opts: CommandGlobalOpts,
+    command: AddonConfigureKafkaSubcommand,
+    addon_name: String,
+}
+
+impl AddonConfigureKafkaNodeCommand {
+    pub fn new(
+        opts: CommandGlobalOpts,
+        command: AddonConfigureKafkaSubcommand,
+        addon_name: &str,
+    ) -> Self {
+        Self {
+            opts,
+            command,
+            addon_name: addon_name.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for AddonConfigureKafkaNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let project_id = self
+            .opts
+            .state
+            .projects()
+            .get_project_by_name(&self.command.config.project_name.clone())
+            .await?
+            .project_id()
+            .to_string();
+        let config = KafkaConfig::new(self.command.config.bootstrap_server.clone());
+
+        let controller = node.create_controller().await?;
+
+        let response = controller
+            .configure_confluent_addon(node.ctx(), &project_id, config)
+            .await?;
+        check_configuration_completion(&self.opts, &node, &project_id, &response.operation_id)
+            .await?;
+
+        self.opts
+            .terminal
+            .write_line(fmt_ok!("{} addon configured successfully", self.addon_name))?;
+
+        Ok(())
+    }
+}
+
 impl AddonConfigureKafkaSubcommand {
     pub fn name(&self) -> String {
         "configure kafka addon".into()
@@ -68,26 +121,8 @@ impl AddonConfigureKafkaSubcommand {
         opts: CommandGlobalOpts,
         addon_name: &str,
     ) -> miette::Result<()> {
-        let project_id = opts
-            .state
-            .projects()
-            .get_project_by_name(&self.config.project_name.clone())
-            .await?
-            .project_id()
-            .to_string();
-        let config = KafkaConfig::new(self.config.bootstrap_server.clone());
-
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
-        let controller = node.create_controller().await?;
-
-        let response = controller
-            .configure_confluent_addon(ctx, &project_id, config)
-            .await?;
-        check_configuration_completion(&opts, &node, &project_id, &response.operation_id).await?;
-
-        opts.terminal
-            .write_line(fmt_ok!("{} addon configured successfully", addon_name))?;
-
-        Ok(())
+        AddonConfigureKafkaNodeCommand::new(opts.clone(), self.clone(), addon_name)
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
@@ -1,13 +1,13 @@
-use std::net::TcpStream;
-use std::path::PathBuf;
-use std::sync::Arc;
-
+use async_trait::async_trait;
 use clap::builder::NonEmptyStringValueParser;
 use clap::Args;
 use colorful::Colorful;
 use miette::{miette, Context as _, IntoDiagnostic};
 use rustls::{ClientConfig, ClientConnection, Connection, RootCertStore, Stream};
 use rustls_pki_types::ServerName;
+use std::net::TcpStream;
+use std::path::PathBuf;
+use std::sync::Arc;
 
 use ockam::Context;
 use ockam_api::enroll::oidc_service::OidcService;
@@ -20,6 +20,7 @@ use ockam_api::orchestrator::project::models::OktaConfig;
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::Error;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::project::addon::check_configuration_completion;
 use crate::{docs, CommandGlobalOpts, Result};
 
@@ -81,28 +82,38 @@ pub struct AddonConfigureOktaSubcommand {
     attributes: Vec<String>,
 }
 
-impl AddonConfigureOktaSubcommand {
-    pub fn name(&self) -> String {
-        "project addon configure okta".into()
-    }
+#[derive(Clone)]
+struct AddonConfigureOktaNodeCommand {
+    opts: CommandGlobalOpts,
+    command: AddonConfigureOktaSubcommand,
+}
 
-    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        let project_id = opts
+impl AddonConfigureOktaNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: AddonConfigureOktaSubcommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for AddonConfigureOktaNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let project_id = self
+            .opts
             .state
             .projects()
-            .get_project_by_name(&self.project_name)
+            .get_project_by_name(&self.command.project_name)
             .await?
             .project_id()
             .to_string();
 
-        let base_url = Url::parse(self.tenant.as_str())
+        let base_url = Url::parse(self.command.tenant.as_str())
             .into_diagnostic()
             .context("could not parse tenant url")?;
         let domain = base_url
             .host_str()
             .ok_or(miette!("could not read domain from tenant url"))?;
 
-        let certificate = match (&self.certificate, &self.certificate_path) {
+        let certificate = match (&self.command.certificate, &self.command.certificate_path) {
             (Some(c), _) => c.to_string(),
             (_, Some(p)) => std::fs::read_to_string(p).into_diagnostic()?,
             _ => query_certificate_chain(domain)?,
@@ -111,8 +122,8 @@ impl AddonConfigureOktaSubcommand {
         let okta_config = OktaConfig::new(
             base_url,
             certificate,
-            self.client_id.clone(),
-            self.attributes.clone(),
+            self.command.client_id.clone(),
+            self.command.attributes.clone(),
         );
 
         // Validate okta configuration
@@ -122,18 +133,31 @@ impl AddonConfigureOktaSubcommand {
         auth0.validate_provider_config().await?;
 
         // Do request
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
         let controller = node.create_controller().await?;
 
         let response = controller
-            .configure_okta_addon(ctx, &project_id, okta_config)
+            .configure_okta_addon(node.ctx(), &project_id, okta_config)
             .await?;
-        check_configuration_completion(&opts, &node, &project_id, &response.operation_id).await?;
+        check_configuration_completion(&self.opts, &node, &project_id, &response.operation_id)
+            .await?;
 
-        opts.terminal
+        self.opts
+            .terminal
             .write_line(fmt_ok!("Okta addon configured successfully"))?;
 
         Ok(())
+    }
+}
+
+impl AddonConfigureOktaSubcommand {
+    pub fn name(&self) -> String {
+        "project addon configure okta".into()
+    }
+
+    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        AddonConfigureOktaNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
@@ -1,12 +1,15 @@
+use async_trait::async_trait;
 use clap::builder::NonEmptyStringValueParser;
 use clap::Args;
 use colorful::Colorful;
+use std::sync::Arc;
 
 use ockam::Context;
 use ockam_api::fmt_ok;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::addon::Addons;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::operation::util::check_for_operation_completion;
 use crate::CommandGlobalOpts;
 
@@ -32,30 +35,54 @@ pub struct AddonDisableSubcommand {
     addon_id: String,
 }
 
+#[derive(Clone)]
+struct AddonDisableNodeCommand {
+    opts: CommandGlobalOpts,
+    command: AddonDisableSubcommand,
+}
+
+impl AddonDisableNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: AddonDisableSubcommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for AddonDisableNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let project_id = self
+            .opts
+            .state
+            .projects()
+            .get_project_by_name(&self.command.project_name)
+            .await?
+            .project_id()
+            .to_string();
+        let controller = node.create_controller().await?;
+
+        let response = controller
+            .disable_addon(node.ctx(), &project_id, &self.command.addon_id)
+            .await?;
+        let operation_id = response.operation_id;
+        check_for_operation_completion(&self.opts, &node, &operation_id, "the addon disabling")
+            .await?;
+
+        self.opts
+            .terminal
+            .write_line(fmt_ok!("Addon disabled successfully"))?;
+
+        Ok(())
+    }
+}
+
 impl AddonDisableSubcommand {
     pub fn name(&self) -> String {
         "project addon disable".into()
     }
 
     pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        let project_id = opts
-            .state
-            .projects()
-            .get_project_by_name(&self.project_name)
-            .await?
-            .project_id()
-            .to_string();
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
-        let controller = node.create_controller().await?;
-
-        let response = controller
-            .disable_addon(ctx, &project_id, &self.addon_id)
-            .await?;
-        let operation_id = response.operation_id;
-        check_for_operation_completion(&opts, &node, &operation_id, "the addon disabling").await?;
-
-        opts.terminal
-            .write_line(fmt_ok!("Addon disabled successfully"))?;
-        Ok(())
+        AddonDisableNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/addon/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/list.rs
@@ -1,10 +1,13 @@
+use async_trait::async_trait;
 use clap::builder::NonEmptyStringValueParser;
 use clap::Args;
+use std::sync::Arc;
 
 use ockam::Context;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::addon::Addons;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::CommandGlobalOpts;
 
 /// List available addons for a project
@@ -20,14 +23,18 @@ pub struct AddonListSubcommand {
     project_name: String,
 }
 
-impl AddonListSubcommand {
-    pub fn name(&self) -> String {
-        "project addon list".into()
-    }
+#[derive(Clone)]
+struct AddonListNodeCommand {
+    opts: CommandGlobalOpts,
+    command: AddonListSubcommand,
+}
 
-    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        let project_name = self.project_name.clone();
-        let project_id = opts
+#[async_trait]
+impl InMemoryNodeCommand for AddonListNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let project_name = self.command.project_name.clone();
+        let project_id = self
+            .opts
             .state
             .projects()
             .get_project_by_name(&project_name)
@@ -35,15 +42,37 @@ impl AddonListSubcommand {
             .project_id()
             .to_string();
 
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
         let controller = node.create_controller().await?;
 
-        let addons = controller.list_addons(ctx, &project_id).await?;
-        let output = opts.terminal.build_list(
+        let addons = controller.list_addons(node.ctx(), &project_id).await?;
+        let output = self.opts.terminal.build_list(
             &addons,
             &format!("No addons enabled for project {project_name}"),
         )?;
-        opts.terminal.to_stdout().plain(output).write_line()?;
+        self.opts
+            .terminal
+            .clone()
+            .to_stdout()
+            .plain(output)
+            .write_line()?;
         Ok(())
+    }
+}
+
+impl AddonListNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: AddonListSubcommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+impl AddonListSubcommand {
+    pub fn name(&self) -> String {
+        "project addon list".into()
+    }
+
+    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        AddonListNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -1,10 +1,13 @@
+use async_trait::async_trait;
 use clap::Args;
+use std::sync::Arc;
 
 use ockam::Context;
 use ockam_api::cli_state::random_name;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::project::ProjectsOrchestratorApi;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::operation::util::check_for_project_completion;
 use crate::project::util::check_project_readiness;
 use crate::shared_args::IdentityOpts;
@@ -35,23 +38,45 @@ pub struct CreateCommand {
     //TODO:  list of admins
 }
 
+#[derive(Clone)]
+struct CreateNodeCommand {
+    opts: CommandGlobalOpts,
+    command: CreateCommand,
+}
+
+impl CreateNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: CreateCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for CreateNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let project = node
+            .create_project(&self.command.space_name, &self.command.project_name, vec![])
+            .await?;
+        let project = check_for_project_completion(&self.opts, &node, project).await?;
+        let project = check_project_readiness(&self.opts, &node, project).await?;
+        self.opts
+            .terminal
+            .clone()
+            .to_stdout()
+            .plain(project.item()?)
+            .json(serde_json::json!(&project))
+            .write_line()?;
+        Ok(())
+    }
+}
+
 impl CreateCommand {
     pub fn name(&self) -> String {
         "project create".into()
     }
 
     pub(crate) async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
-        let project = node
-            .create_project(&self.space_name, &self.project_name, vec![])
-            .await?;
-        let project = check_for_project_completion(&opts, &node, project).await?;
-        let project = check_project_readiness(&opts, &node, project).await?;
-        opts.terminal
-            .to_stdout()
-            .plain(project.item()?)
-            .json(serde_json::json!(&project))
-            .write_line()?;
-        Ok(())
+        CreateNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -1,11 +1,14 @@
+use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
+use std::sync::Arc;
 
 use ockam::Context;
 use ockam_api::fmt_ok;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::project::ProjectsOrchestratorApi;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::{docs, CommandGlobalOpts};
 
@@ -35,30 +38,51 @@ pub struct DeleteCommand {
     yes: bool,
 }
 
+#[derive(Clone)]
+struct DeleteNodeCommand {
+    opts: CommandGlobalOpts,
+    command: DeleteCommand,
+}
+
+impl DeleteNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: DeleteCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for DeleteNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        if self.opts.terminal.confirmed_with_flag_or_prompt(
+            self.command.yes,
+            "Are you sure you want to delete this project?",
+        )? {
+            node.delete_project_by_name(&self.command.space_name, &self.command.project_name)
+                .await?;
+            self.opts
+                .terminal
+                .clone()
+                .to_stdout()
+                .plain(fmt_ok!(
+                    "Project with name '{}' has been deleted.",
+                    &self.command.project_name
+                ))
+                .machine(&self.command.project_name)
+                .json(serde_json::json!({ "name": &self.command.project_name }))
+                .write_line()?;
+        }
+        Ok(())
+    }
+}
+
 impl DeleteCommand {
     pub fn name(&self) -> String {
         "project delete".into()
     }
 
     pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        if opts.terminal.confirmed_with_flag_or_prompt(
-            self.yes,
-            "Are you sure you want to delete this project?",
-        )? {
-            let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
-
-            node.delete_project_by_name(&self.space_name, &self.project_name)
-                .await?;
-            opts.terminal
-                .to_stdout()
-                .plain(fmt_ok!(
-                    "Project with name '{}' has been deleted.",
-                    &self.project_name
-                ))
-                .machine(&self.project_name)
-                .json(serde_json::json!({ "name": &self.project_name }))
-                .write_line()?;
-        }
-        Ok(())
+        DeleteNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -11,6 +11,7 @@ use serde::Serialize;
 
 use crate::credential::CredentialOutput;
 use crate::enroll::OidcServiceExt;
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::{IdentityOpts, RetryOpts, TrustOpts};
 use crate::util::parsers::duration_parser;
 use crate::value_parsers::parse_enrollment_ticket;
@@ -81,71 +82,100 @@ impl Debug for EnrollCommand {
     }
 }
 
-#[async_trait]
-impl Command for EnrollCommand {
-    const NAME: &'static str = "project enroll";
+#[derive(Clone)]
+struct EnrollNodeCommand {
+    opts: CommandGlobalOpts,
+    command: EnrollCommand,
+}
 
-    fn retry_opts(&self) -> Option<RetryOpts> {
-        Some(self.retry_opts.clone())
+impl EnrollNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: EnrollCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for EnrollNodeCommand {
+    fn project_name(&self) -> Option<String> {
+        self.command.trust_opts.project_name.clone()
     }
 
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+    fn timeout(&self) -> Option<Duration> {
+        Some(self.command.timeout)
+    }
+
+    async fn init(&self) -> miette::Result<()> {
         // Store project if an enrollment ticket is passed
-        let (project, enrollment_ticket) = if let Some(enrollment_ticket) = &self.enrollment_ticket
-        {
-            let enrollment_ticket = parse_enrollment_ticket(&opts, enrollment_ticket).await?;
-            let project = opts
+        if let Some(enrollment_ticket) = &self.command.enrollment_ticket {
+            let enrollment_ticket = parse_enrollment_ticket(&self.opts, enrollment_ticket).await?;
+            self.opts
                 .state
                 .projects()
                 .import_and_store_project(enrollment_ticket.project()?)
                 .await?;
-            (project, Some(enrollment_ticket))
         } else {
-            let enrollment_ticket = None;
-            let project = opts.state
-                .projects().get_project_by_name_or_default(&self.trust_opts.project_name)
+            self.opts.state
+                .projects().get_project_by_name_or_default(&self.command.trust_opts.project_name)
                 .await
                 .context("A default project or project parameter is required. Run 'ockam project list' to get a list of available projects. You might also need to pass an enrollment ticket or path to the command.")?;
-            (project, enrollment_ticket)
         };
 
         // Create authority client
-        let identity = opts
+        self.opts
             .state
-            .get_named_identity_or_default(&self.identity_opts.identity_name)
+            .get_named_identity_or_default(&self.command.identity_opts.identity_name)
             .await?;
-        let node = InMemoryNode::start_with_project_name(
-            ctx,
-            opts.state.clone(),
-            Some(project.name().to_string()),
-        )
-        .await?
-        .with_timeout(self.timeout);
+        Ok(())
+    }
+
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let project = self
+            .opts
+            .state
+            .projects()
+            .get_project_by_name_or_default(&self.project_name())
+            .await?;
+        let identity = self
+            .opts
+            .state
+            .get_named_identity_or_default(&self.command.identity_opts.identity_name)
+            .await?;
+
         let authority_node_client = node
             .create_authority_client_with_project(&project, Some(identity.name()), false)
             .await?;
 
         // Enroll if applicable
-        if self.okta {
-            self.use_okta(ctx, &opts, &authority_node_client).await?;
-        } else if let Some(enrollment_ticket) = enrollment_ticket {
-            self.use_enrollment_ticket(ctx, &opts, &authority_node_client, enrollment_ticket)
+        if self.command.okta {
+            self.command
+                .use_okta(node.ctx(), &self.opts, &authority_node_client)
+                .await?;
+        } else if let Some(enrollment_ticket) = self.command.enrollment_ticket.as_deref() {
+            let enrollment_ticket = parse_enrollment_ticket(&self.opts, enrollment_ticket).await?;
+            self.command
+                .use_enrollment_ticket(
+                    node.ctx(),
+                    &self.opts,
+                    &authority_node_client,
+                    enrollment_ticket,
+                )
                 .await?;
         }
 
         // Issue credential
-        let credential = if opts.state.is_using_in_memory_database()? || self.skip_credential_issue
+        let credential = if self.opts.state.is_using_in_memory_database()?
+            || self.command.skip_credential_issue
         {
             // When using an in-memory database, the credential issued in this command will be discarded,
             // so we skip this step
             None
         } else {
-            let pb = opts.terminal.spinner();
+            let pb = self.opts.terminal.spinner();
             if let Some(pb) = pb.as_ref() {
                 pb.set_message("Issuing credential...");
             }
             let credential = authority_node_client
-                .issue_credential(ctx)
+                .issue_credential(node.ctx())
                 .await
                 .map_err(Error::Retry)
                 .into_diagnostic()
@@ -155,17 +185,19 @@ impl Command for EnrollCommand {
 
         // Get the project name to display to the user.
         let project_name = {
-            let project = opts
+            let project = self
+                .opts
                 .state
                 .projects()
-                .get_project_by_name_or_default(&self.trust_opts.project_name.clone())
+                .get_project_by_name_or_default(&self.command.trust_opts.project_name.clone())
                 .await?;
             project.name().to_string()
         };
 
         // Output
         let output = ProjectEnrollOutput::new(identity, project_name, credential);
-        opts.terminal
+        self.opts
+            .terminal
             .clone()
             .to_stdout()
             .plain(output.item()?)
@@ -173,6 +205,21 @@ impl Command for EnrollCommand {
             .write_line()?;
 
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Command for EnrollCommand {
+    const NAME: &'static str = "project enroll";
+
+    fn retry_opts(&self) -> Option<RetryOpts> {
+        Some(self.retry_opts.clone())
+    }
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        EnrollNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/info.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/info.rs
@@ -1,11 +1,14 @@
+use async_trait::async_trait;
 use clap::Args;
 use miette::IntoDiagnostic;
+use std::sync::Arc;
 
 use ockam::Context;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::project::ProjectsOrchestratorApi;
 use ockam_api::output::Output;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::{docs, CommandGlobalOpts};
 
@@ -21,19 +24,41 @@ pub struct InfoCommand {
     pub identity_opts: IdentityOpts,
 }
 
+#[derive(Clone)]
+struct InfoNodeCommand {
+    opts: CommandGlobalOpts,
+    command: InfoCommand,
+}
+
+impl InfoNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: InfoCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for InfoNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let project = node.get_project_by_name(&self.command.name).await?;
+        self.opts
+            .terminal
+            .clone()
+            .to_stdout()
+            .plain(project.item()?)
+            .json(serde_json::to_string(&project).into_diagnostic()?)
+            .write_line()?;
+        Ok(())
+    }
+}
+
 impl InfoCommand {
     pub fn name(&self) -> String {
         "project information".into()
     }
 
     pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
-        let project = node.get_project_by_name(&self.name).await?;
-        opts.terminal
-            .to_stdout()
-            .plain(project.item()?)
-            .json(serde_json::to_string(&project).into_diagnostic()?)
-            .write_line()?;
-        Ok(())
+        InfoNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -1,6 +1,8 @@
+use async_trait::async_trait;
 use clap::Args;
 use miette::IntoDiagnostic;
 use opentelemetry::trace::FutureExt;
+use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::try_join;
 
@@ -8,6 +10,7 @@ use ockam::Context;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::project::ProjectsOrchestratorApi;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::{docs, CommandGlobalOpts};
 
@@ -27,13 +30,20 @@ pub struct ListCommand {
     pub identity_opts: IdentityOpts,
 }
 
-impl ListCommand {
-    pub fn name(&self) -> String {
-        "project list".into()
-    }
+#[derive(Clone)]
+struct ListNodeCommand {
+    opts: CommandGlobalOpts,
+}
 
-    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
+impl ListNodeCommand {
+    pub fn new(opts: CommandGlobalOpts) -> Self {
+        Self { opts }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for ListNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
         let is_finished: Mutex<bool> = Mutex::new(false);
         let get_projects = async {
             let projects = node.get_admin_projects().await?;
@@ -42,19 +52,39 @@ impl ListCommand {
         }
         .with_current_context();
 
-        let output_messages = vec![format!("Listing projects...\n",)];
-        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
+        let output_messages = vec!["Listing projects...\n".to_string()];
+        let progress_output = self
+            .opts
+            .terminal
+            .loop_messages(&output_messages, &is_finished);
 
         let (projects, _) = try_join!(get_projects, progress_output)?;
 
-        let plain = &opts.terminal.build_list(&projects, "No projects found")?;
+        let plain = self
+            .opts
+            .terminal
+            .build_list(&projects, "No projects found")?;
         let json = serde_json::to_string(&projects).into_diagnostic()?;
 
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(plain)
             .json(json)
             .write_line()?;
         Ok(())
+    }
+}
+
+impl ListCommand {
+    pub fn name(&self) -> String {
+        "project list".into()
+    }
+
+    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        ListNodeCommand::new(opts.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -1,19 +1,18 @@
 use async_trait::async_trait;
 use clap::Args;
-use miette::IntoDiagnostic;
+use std::sync::Arc;
 use tracing::{instrument, Level};
 
+use crate::node_command::InMemoryNodeCommand;
+use crate::shared_args::{IdentityOpts, RetryOpts};
+use crate::terminal::tui::ShowCommandTui;
+use crate::tui::PluralTerm;
+use crate::{docs, Command, CommandGlobalOpts, Error};
 use ockam::Context;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::project::ProjectsOrchestratorApi;
 use ockam_api::output::Output;
 use ockam_api::terminal::{Terminal, TerminalStream};
-use ockam_core::TryClone;
-
-use crate::shared_args::{IdentityOpts, RetryOpts};
-use crate::terminal::tui::ShowCommandTui;
-use crate::tui::PluralTerm;
-use crate::{docs, Command, CommandGlobalOpts, Error};
 
 const LONG_ABOUT: &str = include_str!("./static/show/long_about.txt");
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
@@ -43,33 +42,43 @@ impl Command for ShowCommand {
     const NAME: &'static str = "project show";
 
     async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        Ok(ShowTui::run(ctx.try_clone().into_diagnostic()?, opts, self.name.clone()).await?)
+        ShowTuiNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }
 
-pub struct ShowTui {
+#[derive(Clone)]
+pub struct ShowTuiNodeCommand {
     opts: CommandGlobalOpts,
-    project_name: Option<String>,
-    node: InMemoryNode,
+    command: ShowCommand,
 }
 
-impl ShowTui {
-    pub async fn run(
-        ctx: Context,
-        opts: CommandGlobalOpts,
-        project_name: Option<String>,
-    ) -> miette::Result<()> {
-        let node = InMemoryNode::start(&ctx, opts.state.clone()).await?;
-        let tui = Self {
-            opts,
-            project_name,
+impl ShowTuiNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: ShowCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for ShowTuiNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let tui = ShowTui {
+            opts: self.opts.clone(),
+            project_name: self.command.name.clone(),
             node,
         };
         tui.show().await
     }
 }
 
-#[ockam_core::async_trait]
+struct ShowTui {
+    opts: CommandGlobalOpts,
+    project_name: Option<String>,
+    node: Arc<InMemoryNode>,
+}
+
+#[async_trait]
 impl ShowCommandTui for ShowTui {
     const ITEM_NAME: PluralTerm = PluralTerm::Project;
 

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -8,6 +9,7 @@ use colorful::Colorful;
 use miette::{miette, IntoDiagnostic};
 use tracing::debug;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::{IdentityOpts, RetryOpts, TrustOpts};
 use crate::util::parsers::{duration_parser, duration_to_human_format};
 use crate::{docs, Command, CommandGlobalOpts, Error, Result};
@@ -87,25 +89,34 @@ pub struct TicketCommand {
     skip_controller_call: bool,
 }
 
-#[async_trait]
-impl Command for TicketCommand {
-    const NAME: &'static str = "project ticket";
+#[derive(Clone)]
+struct TicketNodeCommand {
+    opts: CommandGlobalOpts,
+    command: TicketCommand,
+}
 
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
-        let cmd = self.parse_args(&opts).await?;
-        let identity = opts
+impl TicketNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: TicketCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for TicketNodeCommand {
+    fn project_name(&self) -> Option<String> {
+        self.command.trust_opts.project_name.clone()
+    }
+
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let cmd = self.command.clone().parse_args(&self.opts).await?;
+        let identity = self
+            .opts
             .state
             .get_identity_name_or_default(&cmd.identity_opts.identity_name)
             .await?;
 
-        let node = InMemoryNode::start_with_project_name(
-            ctx,
-            opts.state.clone(),
-            cmd.trust_opts.project_name.clone(),
-        )
-        .await?;
-
-        let project = opts
+        let project = self
+            .opts
             .state
             .projects()
             .get_project_by_name_or_default(&cmd.trust_opts.project_name)
@@ -125,12 +136,17 @@ impl Command for TicketCommand {
         // Request an enrollment token that a future member can use to get a
         // credential.
         let token = {
-            let pb = opts.terminal.spinner();
+            let pb = self.opts.terminal.spinner();
             if let Some(pb) = pb.as_ref() {
                 pb.set_message("Creating an enrollment ticket...");
             }
             authority_node_client
-                .create_token(ctx, attributes.clone(), cmd.expires_in, cmd.usage_count)
+                .create_token(
+                    node.ctx(),
+                    attributes.clone(),
+                    cmd.expires_in,
+                    cmd.usage_count,
+                )
                 .await
                 .map_err(Error::Retry)?
         };
@@ -194,7 +210,7 @@ impl Command for TicketCommand {
             attributes_msg += "\n";
             attributes_msg
         };
-        opts.terminal.write_line(
+        self.opts.terminal.write_line(
             fmt_ok!("Created enrollment ticket\n\n")
                 + &attributes_msg
                 + &fmt_info!(
@@ -214,7 +230,9 @@ impl Command for TicketCommand {
                 ),
         )?;
 
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(format!("\n{encoded_ticket}"))
             .machine(encoded_ticket)
@@ -222,6 +240,17 @@ impl Command for TicketCommand {
             .write_line()?;
 
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Command for TicketCommand {
+    const NAME: &'static str = "project ticket";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
+        TicketNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/version.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/version.rs
@@ -1,12 +1,15 @@
+use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
 use miette::IntoDiagnostic;
+use std::sync::Arc;
 
 use ockam::Context;
 use ockam_api::colors::color_primary;
 use ockam_api::fmt_ok;
 use ockam_api::nodes::InMemoryNode;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::{docs, CommandGlobalOpts};
 
@@ -24,16 +27,23 @@ pub struct VersionCommand {
     pub identity_opts: IdentityOpts,
 }
 
-impl VersionCommand {
-    pub fn name(&self) -> String {
-        "project version".into()
-    }
+#[derive(Clone)]
+struct VersionNodeCommand {
+    opts: CommandGlobalOpts,
+}
 
-    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+impl VersionNodeCommand {
+    pub fn new(opts: CommandGlobalOpts) -> Self {
+        Self { opts }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for VersionNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
         // Send request
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
         let controller = node.create_controller().await?;
-        let project_version = controller.get_orchestrator_version_info(ctx).await?;
+        let project_version = controller.get_orchestrator_version_info(node.ctx()).await?;
 
         let json = serde_json::to_string(&project_version).into_diagnostic()?;
         let project_version = project_version
@@ -44,12 +54,26 @@ impl VersionCommand {
             color_primary(project_version.clone())
         );
 
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(plain)
             .machine(project_version)
             .json(json)
             .write_line()?;
         Ok(())
+    }
+}
+
+impl VersionCommand {
+    pub fn name(&self) -> String {
+        "project version".into()
+    }
+
+    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        VersionNodeCommand::new(opts.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project_admin/add.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_admin/add.rs
@@ -1,3 +1,4 @@
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::{Command, CommandGlobalOpts};
 use async_trait::async_trait;
@@ -9,6 +10,7 @@ use ockam_api::fmt_ok;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::email_address::EmailAddress;
 use ockam_api::orchestrator::project::ProjectsOrchestratorApi;
+use std::sync::Arc;
 
 /// Add a new Admin to a Project
 #[derive(Clone, Debug, Args)]
@@ -25,37 +27,57 @@ pub struct AddCommand {
     identity_opts: IdentityOpts,
 }
 
+#[derive(Clone)]
+struct AddNodeCommand {
+    opts: CommandGlobalOpts,
+    command: AddCommand,
+}
+
+impl AddNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: AddCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
 #[async_trait]
-impl Command for AddCommand {
-    const NAME: &'static str = "project-admin add";
+impl InMemoryNodeCommand for AddNodeCommand {
+    fn project_name(&self) -> Option<String> {
+        self.command.name.clone()
+    }
 
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        let project = opts
-            .state
-            .projects()
-            .get_project_by_name_or_default(&self.name)
-            .await?;
-        let node = InMemoryNode::start_with_identity_and_project_name(
-            ctx,
-            opts.state.clone(),
-            self.identity_opts.identity_name,
-            Some(project.project_name().to_string()),
-        )
-        .await?;
+    fn identity_name(&self) -> Option<String> {
+        self.command.identity_opts.identity_name.clone()
+    }
+
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let project = self.get_project(node.clone()).await?;
         let admin = node
-            .add_project_admin(project.project_id(), &self.email)
+            .add_project_admin(project.project_id(), &self.command.email)
             .await?;
 
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(fmt_ok!(
                 "Email {} added as an admin to project {}",
-                color_primary(self.email.to_string()),
+                color_primary(self.command.email.to_string()),
                 color_primary(project.project_name())
             ))
             .machine(admin.email.to_string())
             .json_obj(admin)?
             .write_line()?;
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Command for AddCommand {
+    const NAME: &'static str = "project-admin add";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        AddNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project_admin/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_admin/delete.rs
@@ -1,3 +1,4 @@
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::tui::{DeleteCommandTui, PluralTerm};
 use crate::{Command, CommandGlobalOpts};
@@ -43,46 +44,52 @@ impl Command for DeleteCommand {
     const NAME: &'static str = "project-admin delete";
 
     async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        Ok(DeleteTui::run(ctx, opts, self).await?)
+        DeleteNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
+    }
+}
+
+#[derive(Clone)]
+struct DeleteNodeCommand {
+    opts: CommandGlobalOpts,
+    command: DeleteCommand,
+}
+
+impl DeleteNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: DeleteCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for DeleteNodeCommand {
+    fn project_name(&self) -> Option<String> {
+        self.command.name.clone()
+    }
+
+    fn identity_name(&self) -> Option<String> {
+        self.command.identity_opts.identity_name.clone()
+    }
+
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let project = self.get_project(node.clone()).await?;
+        let tui = DeleteTui {
+            opts: self.opts.clone(),
+            node: node.clone(),
+            command: self.command.clone(),
+            project: project.clone(),
+        };
+        tui.delete().await
     }
 }
 
 #[derive(TryClone)]
 pub struct DeleteTui {
-    ctx: Context,
     opts: CommandGlobalOpts,
+    command: DeleteCommand,
     node: Arc<InMemoryNode>,
-    cmd: DeleteCommand,
     project: Project,
-}
-
-impl DeleteTui {
-    pub async fn run(
-        ctx: &Context,
-        opts: CommandGlobalOpts,
-        cmd: DeleteCommand,
-    ) -> miette::Result<()> {
-        let project = opts
-            .state
-            .projects()
-            .get_project_by_name_or_default(&cmd.name)
-            .await?;
-        let node = InMemoryNode::start_with_identity_and_project_name(
-            ctx,
-            opts.state.clone(),
-            cmd.identity_opts.identity_name.clone(),
-            Some(project.project_name().to_string()),
-        )
-        .await?;
-        let tui = Self {
-            ctx: ctx.try_clone()?,
-            opts,
-            node: Arc::new(node),
-            cmd,
-            project,
-        };
-        tui.delete().await
-    }
 }
 
 #[ockam_core::async_trait]
@@ -90,15 +97,15 @@ impl DeleteCommandTui for DeleteTui {
     const ITEM_NAME: PluralTerm = PluralTerm::ProjectAdmin;
 
     fn cmd_arg_item_name(&self) -> Option<String> {
-        self.cmd.email.as_ref().map(|e| e.to_string())
+        self.command.email.as_ref().map(|e| e.to_string())
     }
 
     fn cmd_arg_delete_all(&self) -> bool {
-        self.cmd.all
+        self.command.all
     }
 
     fn cmd_arg_confirm_deletion(&self) -> bool {
-        self.cmd.yes
+        self.command.yes
     }
 
     fn terminal(&self) -> Terminal<TerminalStream<Term>> {

--- a/implementations/rust/ockam/ockam_command/src/project_admin/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_admin/list.rs
@@ -1,3 +1,4 @@
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::{Command, CommandGlobalOpts};
 use async_trait::async_trait;
@@ -5,6 +6,7 @@ use clap::Args;
 use ockam::Context;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::project::ProjectsOrchestratorApi;
+use std::sync::Arc;
 
 /// List the Admins of a Project
 #[derive(Clone, Debug, Args)]
@@ -17,31 +19,49 @@ pub struct ListCommand {
     identity_opts: IdentityOpts,
 }
 
+#[derive(Clone)]
+struct ListNodeCommand {
+    opts: CommandGlobalOpts,
+    command: ListCommand,
+}
+impl ListNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: ListCommand) -> Self {
+        Self { opts, command }
+    }
+}
 #[async_trait]
-impl Command for ListCommand {
-    const NAME: &'static str = "project-admin list";
+impl InMemoryNodeCommand for ListNodeCommand {
+    fn project_name(&self) -> Option<String> {
+        self.command.name.clone()
+    }
 
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        let project = opts
-            .state
-            .projects()
-            .get_project_by_name_or_default(&self.name)
-            .await?;
-        let node = InMemoryNode::start_with_identity_and_project_name(
-            ctx,
-            opts.state.clone(),
-            self.identity_opts.identity_name,
-            Some(project.project_name().to_string()),
-        )
-        .await?;
+    fn identity_name(&self) -> Option<String> {
+        self.command.identity_opts.identity_name.clone()
+    }
+
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let project = self.get_project(node.clone()).await?;
         let admins = node.list_project_admins(project.project_id()).await?;
 
-        let list = &opts.terminal.build_list(&admins, "No admins found")?;
-        opts.terminal
+        let list = &self.opts.terminal.build_list(&admins, "No admins found")?;
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(list)
             .json_obj(admins)?
             .write_line()?;
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Command for ListCommand {
+    const NAME: &'static str = "project-admin list";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        ListNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project_member/add.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/add.rs
@@ -1,19 +1,20 @@
+use crate::node_command::InMemoryNodeCommand;
+use crate::project_member::create_member_attributes;
+use crate::shared_args::{IdentityOpts, RetryOpts};
+use crate::{docs, Command, CommandGlobalOpts, Error};
 use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
-use serde::Serialize;
-use std::collections::BTreeMap;
-use std::fmt::Display;
-
 use ockam::identity::Identifier;
 use ockam::Context;
 use ockam_api::authenticator::direct::Members;
 use ockam_api::colors::color_primary;
+use ockam_api::nodes::InMemoryNode;
 use ockam_api::{fmt_log, fmt_ok};
-
-use crate::project_member::{authority_client, create_member_attributes};
-use crate::shared_args::{IdentityOpts, RetryOpts};
-use crate::{docs, Command, CommandGlobalOpts, Error};
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::fmt::Display;
+use std::sync::Arc;
 
 const LONG_ABOUT: &str = include_str!("./static/add/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/add/after_long_help.txt");
@@ -63,6 +64,65 @@ pub struct AddCommand {
     retry_opts: RetryOpts,
 }
 
+#[derive(Clone)]
+struct AddNodeCommand {
+    opts: CommandGlobalOpts,
+    command: AddCommand,
+}
+
+impl AddNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: AddCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for AddNodeCommand {
+    fn project_name(&self) -> Option<String> {
+        self.command.project_name.clone()
+    }
+
+    fn identity_name(&self) -> Option<String> {
+        self.command.identity_opts.identity_name.clone()
+    }
+
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let authority_node_client = self.authority_client(node.clone()).await?;
+        let project = node
+            .state()
+            .projects()
+            .get_project_by_name_or_default(&self.command.project_name)
+            .await?;
+
+        let attributes = create_member_attributes(
+            &self.command.attributes,
+            &self.command.allowed_relay_name,
+            self.command.enroller,
+        )?;
+
+        authority_node_client
+            .add_member(node.ctx(), self.command.member.clone(), attributes.clone())
+            .await
+            .map_err(Error::Retry)?;
+
+        let output = AddMemberOutput {
+            project: project.name().to_string(),
+            identifier: self.command.member.clone(),
+            attributes,
+        };
+
+        self.opts
+            .terminal
+            .clone()
+            .to_stdout()
+            .plain(output.to_string())
+            .json_obj(&output)?
+            .write_line()?;
+
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl Command for AddCommand {
     const NAME: &'static str = "project-member add";
@@ -72,30 +132,9 @@ impl Command for AddCommand {
     }
 
     async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        let (authority_node_client, project_name) =
-            authority_client(ctx, &opts, &self.identity_opts, &self.project_name).await?;
-
-        let attributes =
-            create_member_attributes(&self.attributes, &self.allowed_relay_name, self.enroller)?;
-
-        authority_node_client
-            .add_member(ctx, self.member.clone(), attributes.clone())
+        AddNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
             .await
-            .map_err(Error::Retry)?;
-
-        let output = AddMemberOutput {
-            project: project_name,
-            identifier: self.member.clone(),
-            attributes,
-        };
-
-        opts.terminal
-            .to_stdout()
-            .plain(output.to_string())
-            .json_obj(&output)?
-            .write_line()?;
-
-        Ok(())
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project_member/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/delete.rs
@@ -1,4 +1,4 @@
-use super::authority_client;
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::{docs, Command, CommandGlobalOpts};
 use async_trait::async_trait;
@@ -9,10 +9,12 @@ use ockam::identity::Identifier;
 use ockam::Context;
 use ockam_api::authenticator::direct::Members;
 use ockam_api::colors::color_primary;
+use ockam_api::nodes::InMemoryNode;
 use ockam_api::{fmt_info, fmt_ok};
 use ockam_core::TryClone;
 use serde::Serialize;
 use std::fmt::Display;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::task::JoinSet;
 use tokio::time::sleep;
@@ -44,38 +46,65 @@ pub struct DeleteCommand {
     all: bool,
 }
 
-#[async_trait]
-impl Command for DeleteCommand {
-    const NAME: &'static str = "project-member delete";
+#[derive(Clone)]
+struct DeleteNodeCommand {
+    opts: CommandGlobalOpts,
+    command: DeleteCommand,
+}
 
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        if self.member.is_none() && !self.all {
+impl DeleteNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: DeleteCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for DeleteNodeCommand {
+    fn project_name(&self) -> Option<String> {
+        self.command.project_name.clone()
+    }
+
+    fn identity_name(&self) -> Option<String> {
+        self.command.identity_opts.identity_name.clone()
+    }
+
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        if self.command.member.is_none() && !self.command.all {
             return Err(miette!(
                 "You need to specify either an identifier to delete or use the --all flag to delete all the members from a project."
             ));
         }
 
-        let (authority_node_client, project_name) =
-            authority_client(ctx, &opts, &self.identity_opts, &self.project_name).await?;
-
-        let identity = opts
-            .state
-            .get_named_identity_or_default(&self.identity_opts.identity_name)
+        let authority_node_client = self.authority_client(node.clone()).await?;
+        let project = node
+            .state()
+            .projects()
+            .get_project_by_name_or_default(&self.project_name())
             .await?;
 
+        let identity = self
+            .opts
+            .state
+            .get_named_identity_or_default(&self.command.identity_opts.identity_name)
+            .await?;
+
+        let project_name = project.name();
         let mut output = DeleteMemberOutput {
-            project: project_name.clone(),
+            project: project_name.to_string(),
             identifiers: vec![],
         };
 
         // Delete the passed member
-        if let Some(member) = &self.member {
-            authority_node_client.delete_member(ctx, member).await?;
+        if let Some(member) = &self.command.member {
+            authority_node_client
+                .delete_member(node.ctx(), member)
+                .await?;
             output.identifiers.push(member.clone());
         }
         // Try to delete all members except the current default identity
-        else if self.all {
-            if !opts
+        else if self.command.all {
+            if !self
+                .opts
                 .state
                 .is_identity_enrolled(&Some(identity.name()))
                 .await?
@@ -85,9 +114,9 @@ impl Command for DeleteCommand {
                     ));
             }
             let self_identifier = identity.identifier();
-            let member_identifiers = authority_node_client.list_member_ids(ctx).await?;
+            let member_identifiers = authority_node_client.list_member_ids(node.ctx()).await?;
             if !member_identifiers.is_empty() {
-                opts.terminal.write_line(fmt_info!(
+                self.opts.terminal.write_line(fmt_info!(
                     "Found {} members in the Project {}",
                     member_identifiers.len(),
                     project_name
@@ -99,7 +128,7 @@ impl Command for DeleteCommand {
                 .filter(|id| id != &self_identifier)
                 .collect::<Vec<_>>();
 
-            let pb = opts.terminal.spinner();
+            let pb = self.opts.terminal.spinner();
             if let Some(pb) = &pb {
                 pb.set_message("Deleting members...");
             }
@@ -107,7 +136,7 @@ impl Command for DeleteCommand {
                 let mut set: JoinSet<Option<Identifier>> = JoinSet::new();
                 for identifier in chunk {
                     let authority_node_client = authority_node_client.clone();
-                    let ctx = ctx.try_clone()?;
+                    let ctx = node.ctx().try_clone()?;
                     set.spawn(async move {
                         sleep(tokio_retry::strategy::jitter(Duration::from_millis(500))).await;
                         if let Err(e) = authority_node_client.delete_member(&ctx, &identifier).await
@@ -132,13 +161,26 @@ impl Command for DeleteCommand {
             unreachable!("Either a member or the --all flag should be set");
         }
 
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(output.to_string())
             .json_obj(&output)?
             .write_line()?;
 
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Command for DeleteCommand {
+    const NAME: &'static str = "project-member delete";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        DeleteNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project_member/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/list.rs
@@ -1,15 +1,16 @@
 use async_trait::async_trait;
 use clap::Args;
+use std::sync::Arc;
 
+use super::MemberOutput;
+use crate::node_command::InMemoryNodeCommand;
+use crate::shared_args::IdentityOpts;
+use crate::{docs, Command, CommandGlobalOpts, Result};
 use ockam::Context;
 use ockam_api::authenticator::direct::{
     Members, OCKAM_ROLE_ATTRIBUTE_ENROLLER_VALUE, OCKAM_ROLE_ATTRIBUTE_KEY,
 };
-
-use crate::shared_args::IdentityOpts;
-use crate::{docs, Command, CommandGlobalOpts, Result};
-
-use super::{authority_client, MemberOutput};
+use ockam_api::nodes::InMemoryNode;
 
 const LONG_ABOUT: &str = include_str!("./static/list/long_about.txt");
 
@@ -31,20 +32,37 @@ pub struct ListCommand {
     enrollers: bool,
 }
 
-#[async_trait]
-impl Command for ListCommand {
-    const NAME: &'static str = "project-member list";
+#[derive(Clone)]
+struct ListNodeCommand {
+    opts: CommandGlobalOpts,
+    command: ListCommand,
+}
 
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
-        let (authority_node_client, _) =
-            authority_client(ctx, &opts, &self.identity_opts, &self.project_name).await?;
+impl ListNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: ListCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for ListNodeCommand {
+    fn project_name(&self) -> Option<String> {
+        self.command.project_name.clone()
+    }
+
+    fn identity_name(&self) -> Option<String> {
+        self.command.identity_opts.identity_name.clone()
+    }
+
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let authority_node_client = self.authority_client(node.clone()).await?;
 
         let members = authority_node_client
-            .list_members(ctx)
+            .list_members(node.ctx())
             .await?
             .into_iter()
             .filter(|(_, a)| {
-                !self.enrollers
+                !self.command.enrollers
                     || a.deserialized_key_value_attrs().contains(&format!(
                         "{}={}",
                         OCKAM_ROLE_ATTRIBUTE_KEY, OCKAM_ROLE_ATTRIBUTE_ENROLLER_VALUE
@@ -53,15 +71,29 @@ impl Command for ListCommand {
             .map(|(i, a)| MemberOutput::new(i, a))
             .collect::<Vec<_>>();
 
-        let plain = opts
+        let plain = self
+            .opts
             .terminal
             .build_list(&members, "No members found on the Authority node")?;
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(plain)
             .json_obj(&members)?
             .write_line()?;
 
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Command for ListCommand {
+    const NAME: &'static str = "project-member list";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
+        ListNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project_member/list_ids.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/list_ids.rs
@@ -1,14 +1,15 @@
 use async_trait::async_trait;
 use clap::Args;
 use serde::Serialize;
+use std::sync::Arc;
 
+use crate::node_command::InMemoryNodeCommand;
+use crate::shared_args::IdentityOpts;
+use crate::{docs, Command, CommandGlobalOpts, Result};
 use ockam::identity::Identifier;
 use ockam::Context;
 use ockam_api::authenticator::direct::Members;
-
-use super::authority_client;
-use crate::shared_args::IdentityOpts;
-use crate::{docs, Command, CommandGlobalOpts, Result};
+use ockam_api::nodes::InMemoryNode;
 use ockam_api::output::Output;
 
 const LONG_ABOUT: &str = include_str!("./static/list_ids/long_about.txt");
@@ -27,31 +28,62 @@ pub struct ListIdsCommand {
     project_name: Option<String>,
 }
 
-#[async_trait]
-impl Command for ListIdsCommand {
-    const NAME: &'static str = "project-member list-ids";
+#[derive(Clone)]
+struct ListIdsNodeCommand {
+    opts: CommandGlobalOpts,
+    command: ListIdsCommand,
+}
 
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
-        let (authority_node_client, _) =
-            authority_client(ctx, &opts, &self.identity_opts, &self.project_name).await?;
+impl ListIdsNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: ListIdsCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for ListIdsNodeCommand {
+    fn project_name(&self) -> Option<String> {
+        self.command.project_name.clone()
+    }
+
+    fn identity_name(&self) -> Option<String> {
+        self.command.identity_opts.identity_name.clone()
+    }
+
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let authority_node_client = self.authority_client(node.clone()).await?;
 
         let member_ids = authority_node_client
-            .list_member_ids(ctx)
+            .list_member_ids(node.ctx())
             .await?
             .into_iter()
             .map(|identifier| ListIdsOutput { identifier })
             .collect::<Vec<_>>();
 
-        let plain = opts
+        let plain = self
+            .opts
             .terminal
             .build_list(&member_ids, "No members found on the Authority node")?;
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(plain)
             .json_obj(&member_ids)?
             .write_line()?;
 
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Command for ListIdsCommand {
+    const NAME: &'static str = "project-member list-ids";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
+        ListIdsNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project_member/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/mod.rs
@@ -12,19 +12,13 @@ use ockam_api::authenticator::direct::{
     OCKAM_ROLE_ATTRIBUTE_ENROLLER_VALUE, OCKAM_ROLE_ATTRIBUTE_KEY,
 };
 use ockam_api::colors::{color_primary, color_warn};
-use ockam_api::nodes::{InMemoryNode, NodeManager};
-use ockam_api::orchestrator::project::Project;
-use ockam_api::orchestrator::AuthorityNodeClient;
 use ockam_api::output::Output;
 use ockam_api::terminal::fmt;
-use ockam_api::CliState;
 use ockam_node::Context;
 use serde::Serialize;
 use std::fmt::Write;
-use std::sync::Arc;
 
 use crate::project_member::show::ShowCommand;
-use crate::shared_args::IdentityOpts;
 use crate::{docs, Command, CommandGlobalOpts};
 
 mod add;
@@ -82,39 +76,6 @@ pub enum ProjectMemberSubcommand {
     Show(ShowCommand),
     #[command(display_order = 800)]
     Delete(DeleteCommand),
-}
-
-pub(super) async fn authority_client(
-    ctx: &Context,
-    opts: &CommandGlobalOpts,
-    identity_opts: &IdentityOpts,
-    project_name: &Option<String>,
-) -> crate::Result<(AuthorityNodeClient, String)> {
-    let node = InMemoryNode::start_with_project_name(ctx, opts.state.clone(), project_name.clone())
-        .await?;
-    let project = opts
-        .state
-        .projects()
-        .get_project_by_name_or_default(project_name)
-        .await?;
-    Ok((
-        create_authority_client(&node, opts.state.clone(), identity_opts, &project).await?,
-        project.name().to_string(),
-    ))
-}
-
-pub(super) async fn create_authority_client(
-    node: &NodeManager,
-    cli_state: Arc<CliState>,
-    identity_opts: &IdentityOpts,
-    project: &Project,
-) -> crate::Result<AuthorityNodeClient> {
-    let identity = cli_state
-        .get_identity_name_or_default(&identity_opts.identity_name)
-        .await?;
-
-    node.create_authority_client_with_project(project, Some(identity), false)
-        .await
 }
 
 pub(crate) fn create_member_attributes(

--- a/implementations/rust/ockam/ockam_command/src/project_member/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/show.rs
@@ -2,17 +2,19 @@ use async_trait::async_trait;
 use clap::Args;
 use console::Term;
 use miette::{miette, IntoDiagnostic};
-use std::str::FromStr;
-
 use ockam::identity::Identifier;
 use ockam::Context;
 use ockam_api::authenticator::direct::Members;
+use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::AuthorityNodeClient;
 use ockam_api::output::Output;
 use ockam_api::terminal::{Terminal, TerminalStream};
 use ockam_core::TryClone;
+use std::str::FromStr;
+use std::sync::Arc;
 
-use crate::project_member::{authority_client, MemberOutput};
+use crate::node_command::InMemoryNodeCommand;
+use crate::project_member::MemberOutput;
 use crate::shared_args::IdentityOpts;
 use crate::tui::{PluralTerm, ShowCommandTui};
 use crate::{docs, Command, CommandGlobalOpts};
@@ -40,12 +42,47 @@ pub struct ShowCommand {
     member: Option<Identifier>,
 }
 
+#[derive(Clone)]
+struct ShowNodeCommand {
+    opts: CommandGlobalOpts,
+    command: ShowCommand,
+}
+
+impl ShowNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: ShowCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for ShowNodeCommand {
+    fn project_name(&self) -> Option<String> {
+        self.command.project_name.clone()
+    }
+
+    fn identity_name(&self) -> Option<String> {
+        self.command.identity_opts.identity_name.clone()
+    }
+
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let tui = ShowTui {
+            ctx: node.ctx().try_clone().into_diagnostic()?,
+            opts: self.opts.clone(),
+            member: self.command.member.clone(),
+            client: self.authority_client(node).await?,
+        };
+        tui.show().await
+    }
+}
+
 #[async_trait]
 impl Command for ShowCommand {
     const NAME: &'static str = "project-member show";
 
     async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        Ok(ShowTui::run(ctx.try_clone().into_diagnostic()?, opts, self).await?)
+        ShowNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }
 
@@ -54,24 +91,6 @@ pub struct ShowTui {
     opts: CommandGlobalOpts,
     member: Option<Identifier>,
     client: AuthorityNodeClient,
-}
-
-impl ShowTui {
-    pub async fn run(
-        ctx: Context,
-        opts: CommandGlobalOpts,
-        cmd: ShowCommand,
-    ) -> miette::Result<()> {
-        let (authority_node_client, _) =
-            authority_client(&ctx, &opts, &cmd.identity_opts, &cmd.project_name).await?;
-        let tui = Self {
-            ctx,
-            opts,
-            member: cmd.member,
-            client: authority_node_client,
-        };
-        tui.show().await
-    }
 }
 
 #[async_trait]

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -239,7 +239,7 @@ impl CreateCommand {
 mod tests {
     use super::*;
     use crate::run::parser::resource::utils::parse_cmd_from_args;
-    use ockam_api::nodes::InMemoryNode;
+    use ockam_api::nodes::InMemoryNodeBuilder;
 
     #[test]
     fn command_can_be_parsed_from_name() {
@@ -280,7 +280,10 @@ mod tests {
         assert_eq!(res, addr);
 
         // The user provides the name of a node
-        let node = InMemoryNode::start(ctx, state.clone()).await.unwrap();
+        let node = InMemoryNodeBuilder::create(ctx, state.clone())?
+            .start()
+            .await
+            .unwrap();
         let res = CreateCommand::parse_arg_at(state, &node.node_name(), default_project_name)
             .await
             .unwrap()

--- a/implementations/rust/ockam/ockam_command/src/reset/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/reset/mod.rs
@@ -1,6 +1,8 @@
+use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
 use miette::{miette, WrapErr};
+use std::sync::Arc;
 use tracing::error;
 
 use crate::CommandGlobalOpts;
@@ -14,6 +16,7 @@ use ockam_node::Context;
 
 use crate::branding::BrandingCompileEnvVars;
 use crate::docs;
+use crate::node_command::InMemoryNodeCommand;
 
 const LONG_ABOUT: &str = include_str!("./static/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/after_long_help.txt");
@@ -96,39 +99,58 @@ impl ResetCommand {
     }
 }
 
+#[derive(Clone)]
+struct DeleteOrchestratorNodeCommand {
+    opts: CommandGlobalOpts,
+}
+
+impl DeleteOrchestratorNodeCommand {
+    pub fn new(opts: CommandGlobalOpts) -> Self {
+        Self { opts }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for DeleteOrchestratorNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let spaces = node
+            .get_spaces()
+            .await
+            .wrap_err("Failed to retrieve spaces from the Orchestrator")?;
+        if spaces.is_empty() {
+            return Ok(());
+        }
+        let pb = self.opts.terminal.spinner();
+        if let Some(s) = pb.as_ref() {
+            s.set_message("Deleting spaces from the Orchestrator..")
+        };
+        for space in spaces {
+            if let Some(s) = pb.as_ref() {
+                s.set_message(format!(
+                    "Deleting space {}...",
+                    color!(space.name, OckamColor::PrimaryResource)
+                ))
+            };
+            node.delete_space(&space.id).await?;
+            if let Some(s) = pb.as_ref() {
+                s.set_message(format!(
+                    "Space {} deleted from the Orchestrator",
+                    color!(space.name, OckamColor::PrimaryResource)
+                ))
+            };
+        }
+        if let Some(s) = pb {
+            s.finish_with_message("Orchestrator spaces deleted")
+        }
+        Ok(())
+    }
+}
+
 async fn delete_orchestrator_resources_impl(
     ctx: &Context,
     opts: CommandGlobalOpts,
 ) -> miette::Result<()> {
-    let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
-    let spaces = node
-        .get_spaces()
+    DeleteOrchestratorNodeCommand::new(opts.clone())
+        .execute(ctx, opts.state)
         .await
-        .wrap_err("Failed to retrieve spaces from the Orchestrator")?;
-    if spaces.is_empty() {
-        return Ok(());
-    }
-    let pb = opts.terminal.spinner();
-    if let Some(s) = pb.as_ref() {
-        s.set_message("Deleting spaces from the Orchestrator..")
-    };
-    for space in spaces {
-        if let Some(s) = pb.as_ref() {
-            s.set_message(format!(
-                "Deleting space {}...",
-                color!(space.name, OckamColor::PrimaryResource)
-            ))
-        };
-        node.delete_space(&space.id).await?;
-        if let Some(s) = pb.as_ref() {
-            s.set_message(format!(
-                "Space {} deleted from the Orchestrator",
-                color!(space.name, OckamColor::PrimaryResource)
-            ))
-        };
-    }
-    if let Some(s) = pb {
-        s.finish_with_message("Orchestrator spaces deleted")
-    }
-    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
@@ -10,6 +10,7 @@ use ockam_api::nodes::{BackgroundNodeClient, InMemoryNode};
 use ockam_api::{CliState, ReverseLocalConverter};
 use ockam_core::Address;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::{IdentityOpts, TimeoutArg};
 use crate::{docs, util::api, Command, CommandGlobalOpts};
 use ockam_api::output::Output;
@@ -40,75 +41,96 @@ pub struct ShowCommand {
     pub timeout: TimeoutArg,
 }
 
+#[derive(Clone)]
+struct ShowNodeCommand {
+    opts: CommandGlobalOpts,
+    command: ShowCommand,
+}
+
+impl ShowNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: ShowCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
 #[async_trait]
-impl Command for ShowCommand {
-    const NAME: &'static str = "secure-channel show";
+impl InMemoryNodeCommand for ShowNodeCommand {
+    fn identity_name(&self) -> Option<String> {
+        self.command.identity_opts.identity_name.clone()
+    }
 
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        let response =
-            match extract_node_name_and_service_from_multiaddr(&self.at, opts.state.clone()).await?
-            {
-                // Get the secure channel from a local node
-                Some((node_name, sc_address)) => {
-                    let node =
-                        BackgroundNodeClient::create(ctx, opts.state.clone(), &Some(node_name))
-                            .await?;
-                    let response: ShowSecureChannelResponse =
-                        node.ask(ctx, api::show_secure_channel(&sc_address)).await?;
-                    response
-                }
-                // Get the secure channel given a multiaddr
-                None => {
-                    let identity = opts
-                        .state
-                        .get_named_identity_or_default(&self.identity_opts.identity_name)
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let response = match extract_node_name_and_service_from_multiaddr(
+            &self.command.at.clone(),
+            node.state(),
+        )
+        .await?
+        {
+            // Get the secure channel from a local node
+            Some((node_name, sc_address)) => {
+                let node_client =
+                    BackgroundNodeClient::create(node.ctx(), node.state(), &Some(node_name))
                         .await?;
+                let response: ShowSecureChannelResponse = node_client
+                    .ask(node.ctx(), api::show_secure_channel(&sc_address))
+                    .await?;
+                response
+            }
+            // Get the secure channel given a multiaddr
+            None => {
+                let identity = self.get_identity(node.clone()).await?;
 
-                    let node = InMemoryNode::start_with_identity(
-                        ctx,
-                        opts.state.clone(),
+                let secure_channel = node
+                    .create_secure_channel(
+                        self.command.at.clone(),
                         Some(identity.name()),
+                        None,
+                        None,
+                        Some(self.command.timeout.timeout),
+                        SecureChannelType::KeyExchangeAndMessages,
                     )
                     .await?;
 
-                    let secure_channel = node
-                        .create_secure_channel(
-                            self.at.clone(),
-                            Some(identity.name()),
-                            None,
-                            None,
-                            Some(self.timeout.timeout),
-                            SecureChannelType::KeyExchangeAndMessages,
-                        )
-                        .await?;
+                let peer_identifier = secure_channel.their_identifier();
 
-                    let peer_identifier = secure_channel.their_identifier();
+                let change_history = node
+                    .secure_channels()
+                    .identities()
+                    .get_change_history(peer_identifier)
+                    .await?;
 
-                    let change_history = node
-                        .secure_channels()
-                        .identities()
-                        .get_change_history(peer_identifier)
-                        .await?;
-
-                    ShowSecureChannelResponse {
-                        address: ReverseLocalConverter::convert_address(
-                            secure_channel.encryptor_address(),
-                        )?,
-                        route: self.at,
-                        authorized_identifiers: None,
-                        flow_control_id: secure_channel.flow_control_id().clone(),
-                        their_identifier: secure_channel.their_identifier().clone(),
-                        their_change_history: Some(change_history.export_as_string()?),
-                    }
+                ShowSecureChannelResponse {
+                    address: ReverseLocalConverter::convert_address(
+                        secure_channel.encryptor_address(),
+                    )?,
+                    route: self.command.at.clone(),
+                    authorized_identifiers: None,
+                    flow_control_id: secure_channel.flow_control_id().clone(),
+                    their_identifier: secure_channel.their_identifier().clone(),
+                    their_change_history: Some(change_history.export_as_string()?),
                 }
-            };
+            }
+        };
 
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(response.item()?)
             .json_obj(response)?
             .write_line()?;
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Command for ShowCommand {
+    const NAME: &'static str = "secure-channel show";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        ShowNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/share/accept.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/accept.rs
@@ -1,5 +1,7 @@
+use async_trait::async_trait;
 use clap::Args;
 use miette::IntoDiagnostic;
+use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::try_join;
 
@@ -7,6 +9,7 @@ use ockam::Context;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::share::Invitations;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::{docs, CommandGlobalOpts};
 
@@ -22,25 +25,38 @@ pub struct AcceptCommand {
     pub id: String,
 }
 
-impl AcceptCommand {
-    pub fn name(&self) -> String {
-        "accept invitation".into()
-    }
+#[derive(Clone)]
+struct AcceptNodeCommand {
+    opts: CommandGlobalOpts,
+    command: AcceptCommand,
+}
 
-    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+impl AcceptNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: AcceptCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for AcceptNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
         let is_finished: Mutex<bool> = Mutex::new(false);
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
         let controller = node.create_controller().await?;
 
         let get_accepted_invitation = async {
-            let invitation = controller.accept_invitation(ctx, self.id.clone()).await?;
+            let invitation = controller
+                .accept_invitation(node.ctx(), self.command.id.clone())
+                .await?;
             *is_finished.lock().await = true;
             Ok(invitation)
         };
 
-        let output_messages = vec![format!("Accepting share invitation...\n",)];
+        let output_messages = vec!["Accepting share invitation...\n".to_string()];
 
-        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
+        let progress_output = self
+            .opts
+            .terminal
+            .loop_messages(&output_messages, &is_finished);
 
         let (accepted, _) = try_join!(get_accepted_invitation, progress_output)?;
 
@@ -49,12 +65,26 @@ impl AcceptCommand {
             accepted.id, accepted.scope, accepted.target_id
         );
         let json = serde_json::to_string(&accepted).into_diagnostic()?;
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(plain)
             .json(json)
             .write_line()?;
 
         Ok(())
+    }
+}
+
+impl AcceptCommand {
+    pub fn name(&self) -> String {
+        "accept invitation".into()
+    }
+
+    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        AcceptNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/share/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/create.rs
@@ -1,6 +1,8 @@
+use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
 use miette::IntoDiagnostic;
+use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::try_join;
 use tracing::debug;
@@ -11,6 +13,7 @@ use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::email_address::EmailAddress;
 use ockam_api::orchestrator::share::{Invitations, RoleInShare, ShareScope};
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::{docs, CommandGlobalOpts};
 
@@ -34,35 +37,46 @@ pub struct CreateCommand {
     pub expires_at: Option<String>,
 }
 
-impl CreateCommand {
-    pub fn name(&self) -> String {
-        "create invitation".into()
-    }
+#[derive(Clone)]
+struct CreateNodeCommand {
+    opts: CommandGlobalOpts,
+    command: CreateCommand,
+}
 
-    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+impl CreateNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: CreateCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for CreateNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
         let is_finished: Mutex<bool> = Mutex::new(false);
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
         let controller = node.create_controller().await?;
 
         let get_sent_invitation = async {
             let invitation = controller
                 .create_invitation(
-                    ctx,
-                    self.expires_at.clone(),
-                    self.grant_role.clone(),
-                    self.recipient_email.clone(),
+                    node.ctx(),
+                    self.command.expires_at.clone(),
+                    self.command.grant_role.clone(),
+                    self.command.recipient_email.clone(),
                     None,
-                    self.scope.clone(),
-                    self.target_id.clone(),
+                    self.command.scope.clone(),
+                    self.command.target_id.clone(),
                 )
                 .await?;
             *is_finished.lock().await = true;
             Ok(invitation)
         };
 
-        let output_messages = vec![format!("Creating invitation...\n",)];
+        let output_messages = vec!["Creating invitation...\n".to_string()];
 
-        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
+        let progress_output = self
+            .opts
+            .terminal
+            .loop_messages(&output_messages, &is_finished);
 
         let (sent, _) = try_join!(get_sent_invitation, progress_output)?;
 
@@ -77,12 +91,26 @@ impl CreateCommand {
             sent.recipient_email
         );
         let json = serde_json::to_string(&sent).into_diagnostic()?;
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(plain)
             .json(json)
             .write_line()?;
 
         Ok(())
+    }
+}
+
+impl CreateCommand {
+    pub fn name(&self) -> String {
+        "create invitation".into()
+    }
+
+    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        CreateNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/share/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/list.rs
@@ -1,5 +1,7 @@
+use async_trait::async_trait;
 use clap::Args;
 use miette::IntoDiagnostic;
+use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::try_join;
 
@@ -7,6 +9,7 @@ use ockam::Context;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::share::{InvitationListKind, Invitations};
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::{docs, CommandGlobalOpts};
 
@@ -23,35 +26,49 @@ pub struct ListCommand {
     // pub kind: InvitationListKind,
 }
 
-impl ListCommand {
-    pub fn name(&self) -> String {
-        "list invitations".into()
-    }
+#[derive(Clone)]
+struct ListNodeCommand {
+    opts: CommandGlobalOpts,
+}
 
-    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+impl ListNodeCommand {
+    pub fn new(opts: CommandGlobalOpts) -> Self {
+        Self { opts }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for ListNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
         let is_finished: Mutex<bool> = Mutex::new(false);
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
         let controller = node.create_controller().await?;
 
         let get_invitations = async {
             let invitations = controller
-                .list_invitations(ctx, InvitationListKind::All)
+                .list_invitations(node.ctx(), InvitationListKind::All)
                 .await?;
             *is_finished.lock().await = true;
             Ok(invitations)
         };
 
-        let output_messages = vec![format!("Listing shares...\n",)];
+        let output_messages = vec!["Listing shares...\n".to_string()];
 
-        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
+        let progress_output = self
+            .opts
+            .terminal
+            .loop_messages(&output_messages, &is_finished);
 
         let (shares, _) = try_join!(get_invitations, progress_output)?;
 
         if let Some(sent) = shares.sent.as_ref() {
-            let opts = opts.clone();
-            let plain = opts.terminal.build_list(sent, "No sent shares found.")?;
+            let plain = self
+                .opts
+                .terminal
+                .build_list(sent, "No sent shares found.")?;
             let json = serde_json::to_string(sent).into_diagnostic()?;
-            opts.terminal
+            self.opts
+                .terminal
+                .clone()
                 .to_stdout()
                 .plain(plain)
                 .json(json)
@@ -59,12 +76,14 @@ impl ListCommand {
         }
 
         if let Some(received) = shares.received.as_ref() {
-            let opts = opts.clone();
-            let plain = opts
+            let plain = self
+                .opts
                 .terminal
                 .build_list(received, "No received shares found.")?;
             let json = serde_json::to_string(received).into_diagnostic()?;
-            opts.terminal
+            self.opts
+                .terminal
+                .clone()
                 .to_stdout()
                 .plain(plain)
                 .json(json)
@@ -72,5 +91,16 @@ impl ListCommand {
         }
 
         Ok(())
+    }
+}
+impl ListCommand {
+    pub fn name(&self) -> String {
+        "list invitations".into()
+    }
+
+    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        ListNodeCommand::new(opts.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/share/service.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/service.rs
@@ -1,6 +1,8 @@
+use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
 use miette::IntoDiagnostic;
+use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::try_join;
 use tracing::debug;
@@ -12,6 +14,7 @@ use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::email_address::EmailAddress;
 use ockam_api::orchestrator::share::{CreateServiceInvitation, Invitations};
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::{docs, CommandGlobalOpts};
 
@@ -41,39 +44,50 @@ pub struct ServiceCreateCommand {
     pub expires_at: Option<String>,
 }
 
-impl ServiceCreateCommand {
-    pub fn name(&self) -> String {
-        "create shared service".into()
-    }
+#[derive(Clone)]
+struct ServiceCreateNodeCommand {
+    opts: CommandGlobalOpts,
+    command: ServiceCreateCommand,
+}
 
-    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+impl ServiceCreateNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: ServiceCreateCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for ServiceCreateNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
         let is_finished: Mutex<bool> = Mutex::new(false);
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
         let controller = node.create_controller().await?;
 
         let get_sent_invitation = async {
             let invitation = controller
                 .create_service_invitation(
-                    ctx,
-                    self.expires_at.clone(),
-                    self.project_id.clone(),
-                    self.recipient_email.clone(),
-                    self.project_identity.clone(),
-                    self.project_route.clone(),
-                    self.project_authority_identity.clone(),
-                    self.project_authority_route.clone(),
-                    self.shared_node_identity.clone(),
-                    self.shared_node_route.clone(),
-                    self.enrollment_ticket.clone(),
+                    node.ctx(),
+                    self.command.expires_at.clone(),
+                    self.command.project_id.clone(),
+                    self.command.recipient_email.clone(),
+                    self.command.project_identity.clone(),
+                    self.command.project_route.clone(),
+                    self.command.project_authority_identity.clone(),
+                    self.command.project_authority_route.clone(),
+                    self.command.shared_node_identity.clone(),
+                    self.command.shared_node_route.clone(),
+                    self.command.enrollment_ticket.clone(),
                 )
                 .await?;
             *is_finished.lock().await = true;
             Ok(invitation)
         };
 
-        let output_messages = vec![format!("Creating invitation...\n",)];
+        let output_messages = vec!["Creating invitation...\n".to_string()];
 
-        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
+        let progress_output = self
+            .opts
+            .terminal
+            .loop_messages(&output_messages, &is_finished);
 
         let (sent, _) = try_join!(get_sent_invitation, progress_output)?;
 
@@ -88,13 +102,27 @@ impl ServiceCreateCommand {
             sent.recipient_email
         );
         let json = serde_json::to_string(&sent).into_diagnostic()?;
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(plain)
             .json(json)
             .write_line()?;
 
         Ok(())
+    }
+}
+
+impl ServiceCreateCommand {
+    pub fn name(&self) -> String {
+        "create shared service".into()
+    }
+
+    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        ServiceCreateNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/share/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/show.rs
@@ -1,6 +1,8 @@
+use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
 use miette::IntoDiagnostic;
+use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::try_join;
 
@@ -9,6 +11,7 @@ use ockam_api::fmt_ok;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::share::Invitations;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::{docs, CommandGlobalOpts};
 
@@ -24,39 +27,64 @@ pub struct ShowCommand {
     pub invitation_id: String,
 }
 
-impl ShowCommand {
-    pub fn name(&self) -> String {
-        "show invitation".into()
-    }
+#[derive(Clone)]
+struct ShowNodeCommand {
+    opts: CommandGlobalOpts,
+    command: ShowCommand,
+}
 
-    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+impl ShowNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: ShowCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for ShowNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
         let is_finished: Mutex<bool> = Mutex::new(false);
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
         let controller = node.create_controller().await?;
 
         let get_invitation_with_access = async {
             let invitation_with_access = controller
-                .show_invitation(ctx, self.invitation_id.clone())
+                .show_invitation(node.ctx(), self.command.invitation_id.clone())
                 .await?;
             *is_finished.lock().await = true;
             Ok(invitation_with_access)
         };
 
-        let output_messages = vec![format!("Showing invitation...\n",)];
+        let output_messages = vec!["Showing invitation...\n".to_string()];
 
-        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
+        let progress_output = self
+            .opts
+            .terminal
+            .loop_messages(&output_messages, &is_finished);
 
         let (response, _) = try_join!(get_invitation_with_access, progress_output)?;
 
         // TODO: Emit connection details
         let plain = fmt_ok!("Invite {}", response.invitation.id);
         let json = serde_json::to_string(&response).into_diagnostic()?;
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(plain)
             .json(json)
             .write_line()?;
 
         Ok(())
+    }
+}
+
+impl ShowCommand {
+    pub fn name(&self) -> String {
+        "show invitation".into()
+    }
+
+    pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        ShowNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use clap::Args;
 use miette::miette;
+use std::sync::Arc;
 
 use ockam::Context;
 use ockam_api::cli_state::random_name;
@@ -8,6 +9,7 @@ use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::space::Spaces;
 use ockam_api::output::Output;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::util::validators::cloud_resource_name_validator;
 use crate::{docs, Command, CommandGlobalOpts, Result};
@@ -35,14 +37,25 @@ pub struct CreateCommand {
     pub identity_opts: IdentityOpts,
 }
 
-#[async_trait]
-impl Command for CreateCommand {
-    const NAME: &'static str = "space create";
+#[derive(Clone)]
+struct CreateNodeCommand {
+    opts: CommandGlobalOpts,
+    command: CreateCommand,
+}
 
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
-        if !opts
+impl CreateNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: CreateCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for CreateNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        if !self
+            .opts
             .state
-            .is_identity_enrolled(&self.identity_opts.identity_name)
+            .is_identity_enrolled(&self.command.identity_opts.identity_name)
             .await?
         {
             return Err(miette!(
@@ -50,25 +63,39 @@ impl Command for CreateCommand {
             ));
         };
 
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
-
         let space = {
-            let pb = opts.terminal.spinner();
+            let pb = self.opts.terminal.spinner();
             if let Some(pb) = pb.as_ref() {
                 pb.set_message("Creating a Space for you...");
             }
-            node.create_space(&self.name, self.admins.iter().map(|a| a.as_ref()).collect())
-                .await?
+            node.create_space(
+                &self.command.name,
+                self.command.admins.iter().map(|a| a.as_ref()).collect(),
+            )
+            .await?
         };
         if let Ok(msg) = space.subscription_status_message() {
-            opts.terminal.write_line(msg)?;
+            self.opts.terminal.write_line(msg)?;
         }
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(space.item()?)
             .json_obj(&space)?
             .write_line()?;
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Command for CreateCommand {
+    const NAME: &'static str = "space create";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
+        CreateNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -4,6 +4,7 @@ use colorful::Colorful;
 use console::Term;
 use std::sync::Arc;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::terminal::tui::DeleteCommandTui;
 use crate::tui::PluralTerm;
@@ -44,33 +45,41 @@ impl Command for DeleteCommand {
     const NAME: &'static str = "space delete";
 
     async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        Ok(DeleteTui::run(ctx, opts, self).await?)
+        DeleteNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
+    }
+}
+
+#[derive(Clone)]
+struct DeleteNodeCommand {
+    opts: CommandGlobalOpts,
+    command: DeleteCommand,
+}
+
+impl DeleteNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: DeleteCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for DeleteNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let tui = DeleteTui {
+            opts: self.opts.clone(),
+            cmd: self.command.clone(),
+            node,
+        };
+        tui.delete().await
     }
 }
 
 #[derive(TryClone)]
 pub struct DeleteTui {
-    ctx: Context,
     opts: CommandGlobalOpts,
-    node: Arc<InMemoryNode>,
     cmd: DeleteCommand,
-}
-
-impl DeleteTui {
-    pub async fn run(
-        ctx: &Context,
-        opts: CommandGlobalOpts,
-        cmd: DeleteCommand,
-    ) -> miette::Result<()> {
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
-        let tui = Self {
-            ctx: ctx.try_clone()?,
-            opts,
-            node: Arc::new(node),
-            cmd,
-        };
-        tui.delete().await
-    }
+    node: Arc<InMemoryNode>,
 }
 
 #[ockam_core::async_trait]

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -1,10 +1,12 @@
 use async_trait::async_trait;
 use clap::Args;
+use std::sync::Arc;
 
 use ockam::Context;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::space::Spaces;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::{docs, Command, CommandGlobalOpts};
 
@@ -24,31 +26,49 @@ pub struct ListCommand {
     pub identity_opts: IdentityOpts,
 }
 
+#[derive(Clone)]
+struct ListNodeCommand {
+    opts: CommandGlobalOpts,
+}
+impl ListNodeCommand {
+    pub fn new(opts: CommandGlobalOpts) -> Self {
+        Self { opts }
+    }
+}
 #[async_trait]
-impl Command for ListCommand {
-    const NAME: &'static str = "space list";
-
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
-
+impl InMemoryNodeCommand for ListNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
         let spaces = {
-            let pb = opts.terminal.spinner();
+            let pb = self.opts.terminal.spinner();
             if let Some(pb) = pb.as_ref() {
                 pb.set_message("Listing spaces...");
             }
             node.get_spaces().await?
         };
 
-        let plain = opts.terminal.build_list(
+        let plain = self.opts.terminal.build_list(
             &spaces,
             "No spaces found. Run 'ockam enroll' to get a space and a project",
         )?;
 
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(plain)
             .json_obj(&spaces)?
             .write_line()?;
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Command for ListCommand {
+    const NAME: &'static str = "space list";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        ListNodeCommand::new(opts.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use clap::Args;
 use console::Term;
+use std::sync::Arc;
 
 use crate::{docs, Command, CommandGlobalOpts};
 use ockam::Context;
@@ -8,6 +9,7 @@ use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::space::Spaces;
 use ockam_api::terminal::{Terminal, TerminalStream};
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::terminal::tui::ShowCommandTui;
 use crate::tui::PluralTerm;
@@ -38,30 +40,40 @@ impl Command for ShowCommand {
     const NAME: &'static str = "space show";
 
     async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        Ok(ShowTui::run(ctx, opts, self).await?)
+        ShowNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
+    }
+}
+
+#[derive(Clone)]
+struct ShowNodeCommand {
+    opts: CommandGlobalOpts,
+    command: ShowCommand,
+}
+
+impl ShowNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, cmd: ShowCommand) -> Self {
+        Self { opts, command: cmd }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for ShowNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let tui = ShowTui {
+            opts: self.opts.clone(),
+            space_name: self.command.name.clone(),
+            node,
+        };
+        tui.show().await
     }
 }
 
 pub struct ShowTui {
     opts: CommandGlobalOpts,
     space_name: Option<String>,
-    node: InMemoryNode,
-}
-
-impl ShowTui {
-    pub async fn run(
-        ctx: &Context,
-        opts: CommandGlobalOpts,
-        cmd: ShowCommand,
-    ) -> miette::Result<()> {
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
-        let tui = Self {
-            opts,
-            space_name: cmd.name,
-            node,
-        };
-        tui.show().await
-    }
+    node: Arc<InMemoryNode>,
 }
 
 #[ockam_core::async_trait]

--- a/implementations/rust/ockam/ockam_command/src/space_admin/add.rs
+++ b/implementations/rust/ockam/ockam_command/src/space_admin/add.rs
@@ -1,3 +1,4 @@
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::{Command, CommandGlobalOpts};
 use async_trait::async_trait;
@@ -9,6 +10,7 @@ use ockam_api::fmt_ok;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::email_address::EmailAddress;
 use ockam_api::orchestrator::space::Spaces;
+use std::sync::Arc;
 
 /// Add a new Admin to a Space
 #[derive(Clone, Debug, Args)]
@@ -25,29 +27,55 @@ pub struct AddCommand {
     identity_opts: IdentityOpts,
 }
 
+#[derive(Clone)]
+struct AddNodeCommand {
+    opts: CommandGlobalOpts,
+    command: AddCommand,
+}
+
+impl AddNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: AddCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
 #[async_trait]
-impl Command for AddCommand {
-    const NAME: &'static str = "space-admin add";
+impl InMemoryNodeCommand for AddNodeCommand {
+    fn identity_name(&self) -> Option<String> {
+        self.command.identity_opts.identity_name.clone()
+    }
 
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        let space = opts.state.get_space_by_name_or_default(&self.name).await?;
-        let node = InMemoryNode::start_with_identity(
-            ctx,
-            opts.state.clone(),
-            self.identity_opts.identity_name,
-        )
-        .await?;
-        let admin = node.add_space_admin(&space.space_id(), &self.email).await?;
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let space = node
+            .state()
+            .get_space_by_name_or_default(&self.command.name)
+            .await?;
+        let admin = node
+            .add_space_admin(&space.space_id(), &self.command.email)
+            .await?;
 
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(fmt_ok!(
                 "Email {} added as an admin to space {}",
-                color_primary(self.email.to_string()),
+                color_primary(self.command.email.to_string()),
                 color_primary(space.space_name())
             ))
             .json_obj(admin)?
             .write_line()?;
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Command for AddCommand {
+    const NAME: &'static str = "space-admin add";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        AddNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/space_admin/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space_admin/delete.rs
@@ -1,3 +1,4 @@
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::tui::{DeleteCommandTui, PluralTerm};
 use crate::{Command, CommandGlobalOpts};
@@ -43,38 +44,40 @@ impl Command for DeleteCommand {
     const NAME: &'static str = "space-admin delete";
 
     async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        Ok(DeleteTui::run(ctx, opts, self).await?)
+        DeleteNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }
 
-#[derive(TryClone)]
-pub struct DeleteTui {
-    ctx: Context,
+#[derive(Clone)]
+struct DeleteNodeCommand {
     opts: CommandGlobalOpts,
-    node: Arc<InMemoryNode>,
-    cmd: DeleteCommand,
-    space: Space,
-    identity_enrolled_email: Option<EmailAddress>,
+    command: DeleteCommand,
 }
 
-impl DeleteTui {
-    pub async fn run(
-        ctx: &Context,
-        opts: CommandGlobalOpts,
-        cmd: DeleteCommand,
-    ) -> miette::Result<()> {
-        let space = opts.state.get_space_by_name_or_default(&cmd.name).await?;
-        let node = InMemoryNode::start_with_identity(
-            ctx,
-            opts.state.clone(),
-            cmd.identity_opts.identity_name.clone(),
-        )
-        .await?;
-        let identity_name = opts
+impl DeleteNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: DeleteCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for DeleteNodeCommand {
+    fn identity_name(&self) -> Option<String> {
+        self.command.identity_opts.identity_name.clone()
+    }
+
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let space = self
+            .opts
             .state
-            .get_identity_name_or_default(&cmd.identity_opts.identity_name)
+            .get_space_by_name_or_default(&self.command.name)
             .await?;
-        let identity_enrollment = opts
+
+        let identity_name = self.get_identity(node.clone()).await?.name();
+        let identity_enrollment = self
+            .opts
             .state
             .get_identity_enrollment(&identity_name)
             .await?
@@ -83,11 +86,10 @@ impl DeleteTui {
             return Err(miette!("The identity {identity_name} is not enrolled"));
         }
 
-        let tui = Self {
-            ctx: ctx.try_clone()?,
-            opts,
-            node: Arc::new(node),
-            cmd,
+        let tui = DeleteTui {
+            opts: self.opts.clone(),
+            node: node.clone(),
+            command: self.command.clone(),
             space,
             identity_enrolled_email: identity_enrollment.status().email().cloned(),
         };
@@ -95,20 +97,29 @@ impl DeleteTui {
     }
 }
 
+#[derive(TryClone)]
+pub struct DeleteTui {
+    opts: CommandGlobalOpts,
+    node: Arc<InMemoryNode>,
+    command: DeleteCommand,
+    space: Space,
+    identity_enrolled_email: Option<EmailAddress>,
+}
+
 #[ockam_core::async_trait]
 impl DeleteCommandTui for DeleteTui {
     const ITEM_NAME: PluralTerm = PluralTerm::SpaceAdmin;
 
     fn cmd_arg_item_name(&self) -> Option<String> {
-        self.cmd.email.as_ref().map(|e| e.to_string())
+        self.command.email.as_ref().map(|e| e.to_string())
     }
 
     fn cmd_arg_delete_all(&self) -> bool {
-        self.cmd.all
+        self.command.all
     }
 
     fn cmd_arg_confirm_deletion(&self) -> bool {
-        self.cmd.yes
+        self.command.yes
     }
 
     fn terminal(&self) -> Terminal<TerminalStream<Term>> {

--- a/implementations/rust/ockam/ockam_command/src/space_admin/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space_admin/list.rs
@@ -1,3 +1,4 @@
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::{Command, CommandGlobalOpts};
 use async_trait::async_trait;
@@ -5,6 +6,7 @@ use clap::Args;
 use ockam::Context;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::space::Spaces;
+use std::sync::Arc;
 
 /// List the Admins of a Space
 #[derive(Clone, Debug, Args)]
@@ -17,26 +19,51 @@ pub struct ListCommand {
     identity_opts: IdentityOpts,
 }
 
-#[async_trait]
-impl Command for ListCommand {
-    const NAME: &'static str = "space-admin list";
+#[derive(Clone)]
+struct ListNodeCommand {
+    opts: CommandGlobalOpts,
+    command: ListCommand,
+}
 
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        let space = opts.state.get_space_by_name_or_default(&self.name).await?;
-        let node = InMemoryNode::start_with_identity(
-            ctx,
-            opts.state.clone(),
-            self.identity_opts.identity_name,
-        )
-        .await?;
+impl ListNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: ListCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for ListNodeCommand {
+    fn identity_name(&self) -> Option<String> {
+        self.command.identity_opts.identity_name.clone()
+    }
+
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let space = self
+            .opts
+            .state
+            .get_space_by_name_or_default(&self.command.name)
+            .await?;
         let admins = node.list_space_admins(&space.space_id()).await?;
 
-        let list = &opts.terminal.build_list(&admins, "No admins found")?;
-        opts.terminal
+        let list = &self.opts.terminal.build_list(&admins, "No admins found")?;
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(list)
             .json_obj(admins)?
             .write_line()?;
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Command for ListCommand {
+    const NAME: &'static str = "space-admin list";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        ListNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/status/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/status/mod.rs
@@ -1,10 +1,11 @@
 use async_trait::async_trait;
-use std::fmt::Display;
-
 use clap::Args;
 use colorful::Colorful;
 use miette::IntoDiagnostic;
 use serde::Serialize;
+use std::fmt::Display;
+use std::sync::Arc;
+use std::time::Duration;
 use tracing::warn;
 
 use crate::docs;
@@ -14,6 +15,7 @@ use crate::version::Version;
 use crate::Result;
 use crate::{Command, CommandGlobalOpts};
 
+use crate::node_command::InMemoryNodeCommand;
 use ockam::Context;
 use ockam_api::cli_state::{EnrollmentFilter, IdentityEnrollment};
 use ockam_api::colors::color_primary;
@@ -39,24 +41,38 @@ pub struct StatusCommand {
     timeout: TimeoutArg,
 }
 
-#[async_trait]
-impl Command for StatusCommand {
-    const NAME: &'static str = "status";
+#[derive(Clone)]
+struct StatusNodeCommand {
+    opts: CommandGlobalOpts,
+    command: StatusCommand,
+}
 
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
-        let identities_details = self.get_identities_details(&opts).await?;
-        let nodes = self.get_nodes_resources(ctx, &opts).await?;
-        let node = InMemoryNode::start(ctx, opts.state.clone())
-            .await?
-            .with_timeout(self.timeout.timeout);
+impl StatusNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: StatusCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for StatusNodeCommand {
+    fn timeout(&self) -> Option<Duration> {
+        Some(self.command.timeout.timeout)
+    }
+
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let identities_details = self.command.get_identities_details(&self.opts).await?;
+        let nodes = self
+            .command
+            .get_nodes_resources(node.ctx(), &self.opts)
+            .await?;
         let controller = node.create_controller().await?;
         let orchestrator_version = controller
-            .get_orchestrator_version_info(ctx)
+            .get_orchestrator_version_info(node.ctx())
             .await
             .map_err(|e| warn!(%e, "Failed to retrieve orchestrator version"))
             .unwrap_or_default();
-        let spaces = opts.state.get_spaces().await?;
-        let projects = opts.state.projects().get_projects().await?;
+        let spaces = self.opts.state.get_spaces().await?;
+        let projects = self.opts.state.projects().get_projects().await?;
         let status = StatusData::from_parts(
             orchestrator_version,
             spaces,
@@ -64,12 +80,25 @@ impl Command for StatusCommand {
             identities_details,
             nodes,
         )?;
-        opts.terminal
+        self.opts
+            .terminal
+            .clone()
             .to_stdout()
             .plain(&status)
             .json(serde_json::to_string(&status).into_diagnostic()?)
             .write_line()?;
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Command for StatusCommand {
+    const NAME: &'static str = "status";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
+        StatusNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -1,14 +1,16 @@
+use async_trait::async_trait;
 use clap::builder::NonEmptyStringValueParser;
 use clap::{Args, Subcommand};
 use miette::miette;
-
 use ockam::Context;
 use ockam_api::orchestrator::subscription::{SubscriptionLegacy, Subscriptions};
 use ockam_api::orchestrator::ControllerClient;
+use std::sync::Arc;
 
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::output::Output;
 
+use crate::node_command::InMemoryNodeCommand;
 use crate::shared_args::IdentityOpts;
 use crate::{docs, CommandGlobalOpts, Result};
 
@@ -44,6 +46,48 @@ pub enum SubscriptionSubcommand {
     },
 }
 
+#[derive(Clone)]
+struct SubscriptionNodeCommand {
+    opts: CommandGlobalOpts,
+    command: SubscriptionCommand,
+}
+
+impl SubscriptionNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: SubscriptionCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for SubscriptionNodeCommand {
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let controller = node.create_controller().await?;
+
+        match &self.command.subcommand {
+            SubscriptionSubcommand::Show {
+                subscription_id,
+                space_id,
+            } => {
+                match get_subscription_by_id_or_space_id(
+                    &controller,
+                    node.ctx(),
+                    subscription_id.clone(),
+                    space_id.clone(),
+                )
+                .await?
+                {
+                    Some(subscription) => self.opts.terminal.write_line(&subscription.item()?)?,
+                    None => self
+                        .opts
+                        .terminal
+                        .write_line("Please specify either a space id or a subscription id")?,
+                }
+            }
+        };
+        Ok(())
+    }
+}
+
 impl SubscriptionCommand {
     pub fn name(&self) -> String {
         match &self.subcommand {
@@ -53,30 +97,9 @@ impl SubscriptionCommand {
     }
 
     pub async fn run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        let node = InMemoryNode::start(ctx, opts.state.clone()).await?;
-        let controller = node.create_controller().await?;
-
-        match &self.subcommand {
-            SubscriptionSubcommand::Show {
-                subscription_id,
-                space_id,
-            } => {
-                match get_subscription_by_id_or_space_id(
-                    &controller,
-                    ctx,
-                    subscription_id.clone(),
-                    space_id.clone(),
-                )
-                .await?
-                {
-                    Some(subscription) => opts.terminal.write_line(&subscription.item()?)?,
-                    None => opts
-                        .terminal
-                        .write_line("Please specify either a space id or a subscription id")?,
-                }
-            }
-        };
-        Ok(())
+        SubscriptionNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
     }
 }
 


### PR DESCRIPTION
This PR removes the `Drop` instance on the `InMemoryNode`. This code was blocking some asynchronous code and deadlocking in some cases (like enrolling with a Postgres database backing up nodes).

Instead, this PR provides:

 - An `InMemoryNodeBuilder` to collect all the parameters necessary to start an in memory node: `Context`, `CliState`, optional identity name, etc....
 
 - An `InMemoryNodeBuilder.run` method taking a future executing on an `InMemoryNode`. This method guarantees that the node is properly shutdown when the future has finished executing.
 
 - An `InMemoryNodeCommand` trait used to simplify the use of the `InMemoryNodeBuilder` when executing CLI commands requiring an `InMemoryNode`. Otherwise creating a future with the appropriate moved/cloned values to pass to `InMemoryNodeBuilder.run` is a bit tricky (and verbose).