### PR TITLE
feat(rust): full separate postgres data by tenant_id

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,7 @@ indent_style = space
 indent_size = 2
 
 # Let the corresponding language formatters deal with indent size
-[{{*.{ex,exs,erl,c,h,rs,cmake,cmake.in,stderr,ts,md,plist,ipynb},CMakeLists.txt,Cargo.lock}}]
+[{{*.{ex,exs,erl,c,h,rs,cmake,cmake.in,stderr,ts,md,plist,ipynb,sql},CMakeLists.txt,Cargo.lock}}]
 indent_size = unset
 
 [*.{drawio,svg}]

--- a/implementations/rust/ockam/ockam_abac/src/policy/storage/resource_policy_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy/storage/resource_policy_repository_sql.rs
@@ -58,7 +58,7 @@ impl ResourcePoliciesRepository for ResourcePolicySqlxDatabase {
         let query = query(
             r#"INSERT INTO resource_policy (resource_name, action, expression, node_name, tenant_id)
             VALUES ($1, $2, $3, $4, $5)
-            ON CONFLICT (resource_name, action, node_name)
+            ON CONFLICT (tenant_id, resource_name, action, node_name)
             DO UPDATE SET expression = $3, tenant_id = $5"#,
         )
         .bind(resource_name)

--- a/implementations/rust/ockam/ockam_abac/src/policy/storage/resource_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy/storage/resource_repository_sql.rs
@@ -56,7 +56,7 @@ impl ResourcesRepository for ResourcesSqlxDatabase {
             r#"
             INSERT INTO resource (resource_name, resource_type, node_name, tenant_id)
             VALUES ($1, $2, $3, $4)
-            ON CONFLICT (resource_name, node_name)
+            ON CONFLICT (tenant_id, resource_name, node_name)
             DO UPDATE SET resource_type = $2"#,
         )
         .bind(&resource.resource_name)

--- a/implementations/rust/ockam/ockam_abac/src/policy/storage/resource_type_policy_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy/storage/resource_type_policy_repository_sql.rs
@@ -63,7 +63,7 @@ impl ResourceTypePoliciesRepository for ResourceTypePolicySqlxDatabase {
             r#"INSERT INTO
             resource_type_policy (resource_type, action, expression, node_name, tenant_id)
             VALUES ($1, $2, $3, $4, $5)
-            ON CONFLICT (node_name, resource_type, action)
+            ON CONFLICT (tenant_id, node_name, resource_type, action)
             DO UPDATE SET expression = $3, tenant_id = $5"#,
         )
         .bind(resource_type)

--- a/implementations/rust/ockam/ockam_api/src/authenticator/storage/authority_enrollment_token_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/storage/authority_enrollment_token_repository_sql.rs
@@ -105,7 +105,7 @@ impl AuthorityEnrollmentTokenRepository for AuthorityEnrollmentTokenSqlxDatabase
             r#"
             INSERT INTO authority_enrollment_token (one_time_code, reference, issued_by, created_at, expires_at, ttl_count, attributes, tenant_id)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-            ON CONFLICT (one_time_code)
+            ON CONFLICT (tenant_id, one_time_code)
             DO UPDATE SET reference = $2, issued_by = $3, created_at = $4, expires_at = $5, ttl_count = $6, attributes = $7, tenant_id = $8"#,
         )
             .bind(token.one_time_code)

--- a/implementations/rust/ockam/ockam_api/src/authenticator/storage/authority_members_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/storage/authority_members_repository_sql.rs
@@ -82,7 +82,7 @@ impl AuthorityMembersRepository for AuthorityMembersSqlxDatabase {
         let query = query(r#"
              INSERT INTO authority_member (identifier, added_by, added_at, is_pre_trusted, attributes, authority_id, tenant_id)
              VALUES ($1, $2, $3, $4, $5, $6, $7)
-             ON CONFLICT (identifier)
+             ON CONFLICT (tenant_id, identifier)
              DO UPDATE SET added_by = $2, added_at = $3, is_pre_trusted = $4, attributes = $5, authority_id = $6, tenant_id = $7"#)
             .bind(member.identifier())
             .bind(member.added_by())
@@ -111,7 +111,7 @@ impl AuthorityMembersRepository for AuthorityMembersSqlxDatabase {
                 query(r#"
                       INSERT INTO authority_member (identifier, added_by, added_at, is_pre_trusted, attributes, authority_id, tenant_id)
                       VALUES ($1, $2, $3, $4, $5, $6, $7)
-                      ON CONFLICT (identifier)
+                      ON CONFLICT (tenant_id, identifier)
                       DO UPDATE SET added_by = $2, added_at = $3, is_pre_trusted = $4, attributes = $5, authority_id = $6, tenant_id = $7"#)
                     .bind(identifier)
                     .bind(pre_trusted_identity.attested_by())

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/enrollments_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/enrollments_repository_sql.rs
@@ -48,7 +48,7 @@ impl EnrollmentsRepository for EnrollmentsSqlxDatabase {
             r#"
                 INSERT INTO identity_enrollment (identifier, enrolled_at, email, tenant_id)
                 VALUES ($1, $2, $3, $4)
-                ON CONFLICT (identifier)
+                ON CONFLICT (tenant_id, identifier)
                 DO UPDATE SET enrolled_at = $2, email = $3, tenant_id = $4"#,
         )
         .bind(identifier)

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/identities_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/identities_repository_sql.rs
@@ -60,7 +60,7 @@ impl IdentitiesRepository for IdentitiesSqlxDatabase {
             r#"
         INSERT INTO named_identity (identifier, name, vault_name, is_default, tenant_id)
         VALUES ($1, $2, $3, $4, $5)
-        ON CONFLICT (identifier)
+        ON CONFLICT (tenant_id, identifier)
         DO UPDATE SET name = $2, vault_name = $3, is_default = $4, tenant_id = $5"#,
         )
         .bind(identifier)

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/journeys_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/journeys_repository_sql.rs
@@ -49,7 +49,7 @@ impl JourneysRepository for JourneysSqlxDatabase {
             r#"
             INSERT INTO project_journey (project_id, opentelemetry_context, start_datetime, previous_opentelemetry_context, tenant_id)
             VALUES ($1, $2, $3, $4, $5)
-            ON CONFLICT (opentelemetry_context)
+            ON CONFLICT (tenant_id, project_id, opentelemetry_context)
             DO UPDATE SET project_id = $1, start_datetime = $3, previous_opentelemetry_context = $4, tenant_id = $5"#,
         )
         .bind(project_journey.project_id())
@@ -91,7 +91,7 @@ impl JourneysRepository for JourneysSqlxDatabase {
             r#"
          INSERT INTO host_journey (opentelemetry_context, start_datetime, previous_opentelemetry_context, tenant_id)
          VALUES ($1, $2, $3, $4)
-         ON CONFLICT (opentelemetry_context)
+         ON CONFLICT (tenant_id, opentelemetry_context)
          DO UPDATE SET start_datetime = $2, previous_opentelemetry_context = $3, tenant_id = $4"#,
         )
         .bind(host_journey.opentelemetry_context().to_string())

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/nodes_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/nodes_repository_sql.rs
@@ -47,7 +47,7 @@ impl NodesRepository for NodesSqlxDatabase {
         let query = query(r#"
         INSERT INTO node (name, identifier, verbosity, is_default, is_authority, tcp_listener_address, pid, http_server_address, tenant_id)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-        ON CONFLICT (name)
+        ON CONFLICT (tenant_id, name)
         DO UPDATE SET identifier = $2, verbosity = $3, is_default = $4, is_authority = $5, tcp_listener_address = $6, pid = $7, http_server_address = $8, tenant_id = $9"#)
             .bind(node_info.name())
             .bind(node_info.identifier())

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/projects_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/projects_repository_sql.rs
@@ -195,7 +195,7 @@ impl ProjectsRepository for ProjectsSqlxDatabase {
             r#"
             INSERT INTO project (project_id, project_name, is_default, space_id, space_name, project_identifier, project_change_history, access_route, authority_change_history, authority_access_route, version, running, operation_id, tenant_id)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-            ON CONFLICT (project_id)
+            ON CONFLICT (tenant_id, project_id)
             DO UPDATE SET project_name = $2, is_default = $3, space_id = $4, space_name = $5, project_identifier = $6, project_change_history = $7, access_route = $8, authority_change_history = $9, authority_access_route = $10, version = $11, running = $12, operation_id = $13, tenant_id = $14"#,
         )
             .bind(&project.id)
@@ -261,7 +261,7 @@ impl ProjectsRepository for ProjectsSqlxDatabase {
             r#"
           INSERT INTO space (space_id, space_name, is_default, tenant_id)
           VALUES ($1, $2, $3, $4)
-          ON CONFLICT (space_id)
+          ON CONFLICT (tenant_id, space_id)
           DO UPDATE SET space_name = $2, is_default = $3, tenant_id = $4"#,
         )
         .bind(&project.space_id)

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/spaces_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/spaces_repository_sql.rs
@@ -84,7 +84,7 @@ impl SpacesRepository for SpacesSqlxDatabase {
             r#"
              INSERT INTO space (space_id, space_name, is_default, tenant_id)
              VALUES ($1, $2, $3, $4)
-             ON CONFLICT (space_id)
+             ON CONFLICT (tenant_id, space_id)
              DO UPDATE SET space_name = $2, is_default = $3, tenant_id = $4"#,
         )
         .bind(&space.id)
@@ -123,7 +123,7 @@ impl SpacesRepository for SpacesSqlxDatabase {
                 r#"
              INSERT INTO subscription (space_id, name, is_free_trial, marketplace, start_date, end_date, tenant_id)
              VALUES ($1, $2, $3, $4, $5, $6, $7)
-             ON CONFLICT (space_id)
+             ON CONFLICT (tenant_id, space_id)
              DO UPDATE SET name = $2, is_free_trial = $3, marketplace = $4, start_date = $5, end_date = $6, tenant_id = $7"#,
             )
                 .bind(&space.id)

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/users_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/users_repository_sql.rs
@@ -94,7 +94,7 @@ impl UsersRepository for UsersSqlxDatabase {
         let query2 = query(r#"
             INSERT INTO "user" (email, sub, nickname, name, picture, updated_at, email_verified, is_default, tenant_id)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-            ON CONFLICT (email)
+            ON CONFLICT (tenant_id, email)
             DO UPDATE SET sub = $2, nickname = $3, name = $4, picture = $5, updated_at = $6, email_verified = $7, is_default = $8, tenant_id = $9"#)
             .bind(&email)
             .bind(&user.sub)

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/vaults_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/vaults_repository_sql.rs
@@ -50,7 +50,7 @@ impl VaultsRepository for VaultsSqlxDatabase {
         INSERT INTO
             vault (name, path, is_default, is_kms, tenant_id)
             VALUES ($1, $2, $3, $4, $5)
-            ON CONFLICT (name)
+            ON CONFLICT (tenant_id, name)
             DO UPDATE SET path = $2, is_default = $3, is_kms = $4, tenant_id = $5"#,
         )
         .bind(name)

--- a/implementations/rust/ockam/ockam_app_lib/src/state/model_state_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/model_state_repository_sql.rs
@@ -76,7 +76,7 @@ impl ModelStateRepository for ModelStateSqlxDatabase {
                 r#"
                  INSERT INTO incoming_service (invitation_id, enabled, name, tenant_id)
                  VALUES ($1, $2, $3, $4)
-                 ON CONFLICT (invitation_id)
+                 ON CONFLICT (tenant_id, invitation_id)
                  DO UPDATE SET enabled = $2, name = $3, tenant_id = $4"#,
             )
             .bind(&incoming_service.invitation_id)

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/change_history_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/change_history_repository_sql.rs
@@ -141,7 +141,7 @@ impl ChangeHistorySqlxDatabase {
             r#"
             INSERT INTO identity (identifier, change_history, tenant_id)
             VALUES ($1, $2, $3)
-            ON CONFLICT (identifier)
+            ON CONFLICT (tenant_id, identifier)
             DO UPDATE SET change_history = $2, tenant_id = $3"#,
         )
         .bind(identifier)

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/credential_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/credential_repository_sql.rs
@@ -105,7 +105,7 @@ impl CredentialRepository for CredentialSqlxDatabase {
         let query = query(
             r#"INSERT INTO credential (subject_identifier, issuer_identifier, scope, credential, expires_at, node_name, tenant_id)
             VALUES ($1, $2, $3, $4, $5, $6, $7)
-            ON CONFLICT (subject_identifier, issuer_identifier, scope)
+            ON CONFLICT (tenant_id, subject_identifier, issuer_identifier, scope)
             DO UPDATE SET credential = $4, expires_at = $5, node_name = $6, tenant_id = $7"#)
             .bind(subject)
             .bind(issuer)

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/identity_attributes_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/identity_attributes_repository_sql.rs
@@ -77,7 +77,7 @@ impl IdentityAttributesRepository for IdentityAttributesSqlxDatabase {
             r#"
             INSERT INTO identity_attributes (identifier, attributes, added, expires, attested_by, node_name, tenant_id)
             VALUES ($1, $2, $3, $4, $5, $6, $7)
-            ON CONFLICT (identifier, node_name)
+            ON CONFLICT (tenant_id, identifier, node_name)
             DO UPDATE SET attributes = $2, added = $3, expires = $4, attested_by = $5, node_name = $6, tenant_id = $7"#)
             .bind(subject)
             .bind(&entry)

--- a/implementations/rust/ockam/ockam_identity/src/purpose_keys/storage/purpose_keys_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_identity/src/purpose_keys/storage/purpose_keys_repository_sql.rs
@@ -58,7 +58,7 @@ impl PurposeKeysRepository for PurposeKeysSqlxDatabase {
             r#"
             INSERT INTO purpose_key (identifier, purpose, purpose_key_attestation, tenant_id)
             VALUES ($1, $2, $3, $4)
-            ON CONFLICT (identifier, purpose)
+            ON CONFLICT (tenant_id, identifier, purpose)
             DO UPDATE SET purpose_key_attestation = $3, tenant_id = $4"#,
         )
         .bind(subject)

--- a/implementations/rust/ockam/ockam_identity/src/secure_channels/storage/secure_channel_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channels/storage/secure_channel_repository_sql.rs
@@ -65,7 +65,7 @@ impl SecureChannelRepository for SecureChannelSqlxDatabase {
         let query = query(
             r#"INSERT INTO secure_channel (role, my_identifier, their_identifier, decryptor_remote_address, decryptor_api_address, decryption_key_handle, tenant_id)
             VALUES ($1, $2, $3, $4, $5, $6, $7)
-            ON CONFLICT (decryptor_remote_address)
+            ON CONFLICT (tenant_id, decryptor_remote_address)
             DO UPDATE SET role = $1, my_identifier = $2, their_identifier = $3, decryptor_api_address = $5, decryption_key_handle = $6, tenant_id = $7"#,
             )
             .bind(secure_channel.role().str())

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/application_migrations/sql/postgres/20240613110000_project_journey.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/application_migrations/sql/postgres/20240613110000_project_journey.sql
@@ -2,15 +2,17 @@ CREATE TABLE project_journey
 (
     tenant_id                      TEXT NOT NULL,
     project_id                     TEXT NOT NULL,
-    opentelemetry_context          TEXT NOT NULL UNIQUE,
+    opentelemetry_context          TEXT NOT NULL,
     start_datetime                 TEXT NOT NULL,
-    previous_opentelemetry_context TEXT
+    previous_opentelemetry_context TEXT,
+    PRIMARY KEY (tenant_id, project_id, opentelemetry_context)
 );
 
 CREATE TABLE host_journey
 (
     tenant_id                      TEXT NOT NULL,
-    opentelemetry_context          TEXT NOT NULL UNIQUE,
+    opentelemetry_context          TEXT NOT NULL,
     start_datetime                 TEXT NOT NULL,
-    previous_opentelemetry_context TEXT
+    previous_opentelemetry_context TEXT,
+    PRIMARY KEY (tenant_id, opentelemetry_context)
 );

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/application_migrations/sql/sqlite/20250407100000_tenant_id.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/application_migrations/sql/sqlite/20250407100000_tenant_id.sql
@@ -1,6 +1,35 @@
--- Add a tenant_id column to all tables
-ALTER TABLE project_journey
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
+-- project_journey
+CREATE TABLE project_journey_new
+(
+    tenant_id                      TEXT NOT NULL,
+    project_id                     TEXT NOT NULL,
+    opentelemetry_context          TEXT NOT NULL,
+    start_datetime                 TEXT NOT NULL,
+    previous_opentelemetry_context TEXT,
+    PRIMARY KEY (tenant_id, project_id, opentelemetry_context)
+);
 
-ALTER TABLE host_journey
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
+INSERT INTO project_journey_new (tenant_id, project_id, opentelemetry_context, start_datetime,
+                                 previous_opentelemetry_context)
+SELECT 'tenant-id-default', project_id, opentelemetry_context, start_datetime, previous_opentelemetry_context
+FROM project_journey;
+DROP TABLE project_journey;
+ALTER TABLE project_journey_new
+    RENAME TO project_journey;
+
+-- host_journey
+CREATE TABLE host_journey_new
+(
+    tenant_id                      TEXT NOT NULL,
+    opentelemetry_context          TEXT NOT NULL,
+    start_datetime                 TEXT NOT NULL,
+    previous_opentelemetry_context TEXT,
+    PRIMARY KEY (tenant_id, opentelemetry_context)
+);
+
+INSERT INTO host_journey_new (tenant_id, opentelemetry_context, start_datetime, previous_opentelemetry_context)
+SELECT 'tenant-id-default', opentelemetry_context, start_datetime, previous_opentelemetry_context
+FROM host_journey;
+DROP TABLE host_journey;
+ALTER TABLE host_journey_new
+    RENAME TO host_journey;

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/postgres/20250115100000_create_database.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/postgres/20250115100000_create_database.sql
@@ -21,42 +21,44 @@ CREATE UNIQUE INDEX IF NOT EXISTS name_index ON _rust_migrations (name);
 CREATE TABLE identity
 (
     tenant_id      TEXT NOT NULL, -- Tenant identifier
-    identifier     TEXT NOT NULL UNIQUE,
-    change_history TEXT NOT NULL
+    identifier     TEXT NOT NULL,
+    change_history TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, identifier)
 );
 
 -- This table some local metadata about identities
 CREATE TABLE named_identity
 (
-    tenant_id  TEXT NOT NULL,        -- Tenant identifier
-    identifier TEXT NOT NULL UNIQUE, -- Identity identifier
-    name       TEXT UNIQUE,          -- user-specified name
-    vault_name TEXT NOT NULL,        -- name of the vault used to store the identity keys
-    is_default BOOLEAN DEFAULT FALSE -- boolean indicating if this identity is the default one
+    tenant_id  TEXT NOT NULL,         -- Tenant identifier
+    identifier TEXT NOT NULL,         -- Identity identifier
+    name       TEXT NOT NULL,         -- user-specified name
+    vault_name TEXT NOT NULL,         -- name of the vault used to store the identity keys
+    is_default BOOLEAN DEFAULT FALSE, -- boolean indicating if this identity is the default one
+    PRIMARY KEY (tenant_id, identifier)
 );
 
+CREATE UNIQUE INDEX named_identity_index ON named_identity (tenant_id, name);
 
 -- This table lists attributes associated to a given identity
 CREATE TABLE identity_attributes
 (
     tenant_id   TEXT    NOT NULL, -- Tenant identifier
-    identifier  TEXT PRIMARY KEY, -- identity possessing those attributes
+    identifier  TEXT    NOT NULL, -- identity possessing those attributes
     attributes  BYTEA   NOT NULL, -- serialized list of attribute names and values for the identity
     added       INTEGER NOT NULL, -- UNIX timestamp in seconds: when those attributes were inserted in the database
     expires     INTEGER,          -- optional UNIX timestamp in seconds: when those attributes expire
     attested_by TEXT,             -- optional identifier which attested of these attributes
-    node_name   TEXT    NOT NULL  -- node name to isolate attributes that each node knows
+    node_name   TEXT    NOT NULL, -- node name to isolate attributes that each node knows
+    PRIMARY KEY (tenant_id, identifier, node_name)
 );
 
-CREATE UNIQUE INDEX identity_attributes_index ON identity_attributes (identifier, node_name);
+CREATE INDEX identity_attributes_identifier_attested_by_node_name_index ON identity_attributes (tenant_id, identifier, attested_by, node_name);
 
-CREATE INDEX identity_attributes_identifier_attested_by_node_name_index ON identity_attributes (identifier, attested_by, node_name);
+CREATE INDEX identity_attributes_expires_node_name_index ON identity_attributes (tenant_id, expires, node_name);
 
-CREATE INDEX identity_attributes_expires_node_name_index ON identity_attributes (expires, node_name);
+CREATE INDEX identity_identifier_index ON identity_attributes (tenant_id, identifier);
 
-CREATE INDEX identity_identifier_index ON identity_attributes (identifier);
-
-CREATE INDEX identity_node_name_index ON identity_attributes (node_name);
+CREATE INDEX identity_node_name_index ON identity_attributes (tenant_id, node_name);
 
 -- This table stores credentials as received by the application
 CREATE TABLE credential
@@ -67,11 +69,12 @@ CREATE TABLE credential
     scope              TEXT  NOT NULL,
     credential         BYTEA NOT NULL,
     expires_at         INTEGER,
-    node_name          TEXT  NOT NULL  -- node name to isolate credential that each node has
+    node_name          TEXT  NOT NULL,  -- node name to isolate credential that each node has
+    PRIMARY KEY (tenant_id, subject_identifier, issuer_identifier, scope)
 );
 
-CREATE UNIQUE INDEX credential_issuer_subject_scope_index ON credential (issuer_identifier, subject_identifier, scope);
-CREATE UNIQUE INDEX credential_issuer_subject_index ON credential (issuer_identifier, subject_identifier);
+CREATE UNIQUE INDEX credential_issuer_subject_scope_index ON credential (tenant_id, issuer_identifier, subject_identifier, scope);
+CREATE INDEX credential_issuer_subject_index ON credential (tenant_id, issuer_identifier, subject_identifier);
 
 -- This table stores purpose keys that have been created by a given identity
 CREATE TABLE purpose_key
@@ -79,10 +82,11 @@ CREATE TABLE purpose_key
     tenant_id               TEXT  NOT NULL, -- Tenant identifier
     identifier              TEXT  NOT NULL, -- Identity identifier
     purpose                 TEXT  NOT NULL, -- Purpose of the key: SecureChannels, or Credentials
-    purpose_key_attestation BYTEA NOT NULL  -- Encoded attestation: attestation data and attestation signature
+    purpose_key_attestation BYTEA NOT NULL, -- Encoded attestation: attestation data and attestation signature
+    PRIMARY KEY (tenant_id, identifier, purpose)
 );
 
-CREATE UNIQUE INDEX purpose_key_index ON purpose_key (identifier, purpose);
+CREATE UNIQUE INDEX purpose_key_index ON purpose_key (tenant_id, identifier, purpose);
 
 ----------
 -- VAULTS
@@ -92,27 +96,30 @@ CREATE UNIQUE INDEX purpose_key_index ON purpose_key (identifier, purpose);
 CREATE TABLE vault
 (
     tenant_id  TEXT NOT NULL,    -- Tenant identifier
-    name       TEXT PRIMARY KEY, -- User-specified name for a vault
+    name       TEXT NOT NULL,    -- User-specified name for a vault
     path       TEXT NULL,        -- If the path is specified, then the secrets are stored in a SQLite file. Otherwise secrets are stored in the *-secrets tables below.
     is_default BOOLEAN,          -- boolean indicating if this vault is the default one (0 means true)
-    is_kms     BOOLEAN           -- boolean indicating if this vault is a KMS one (0 means true). In that case only key handles are stored in the database
+    is_kms     BOOLEAN,          -- boolean indicating if this vault is a KMS one (0 means true). In that case only key handles are stored in the database
+    PRIMARY KEY (tenant_id, name)
 );
 
 -- This table stores secrets for signing data
 CREATE TABLE signing_secret
 (
     tenant_id   TEXT  NOT NULL,    -- Tenant identifier
-    handle      BYTEA PRIMARY KEY, -- Secret handle
+    handle      BYTEA NOT NULL,    -- Secret handle
     secret_type TEXT  NOT NULL,    -- Secret type (EdDSACurve25519 or ECDSASHA256CurveP256)
-    secret      BYTEA NOT NULL     -- Secret binary
+    secret      BYTEA NOT NULL,    -- Secret binary
+    PRIMARY KEY (tenant_id, handle)
 );
 
 -- This table stores secrets for encrypting / decrypting data
 CREATE TABLE x25519_secret
 (
     tenant_id TEXT  NOT NULL,    -- Tenant identifier
-    handle    BYTEA PRIMARY KEY, -- Secret handle
-    secret    BYTEA NOT NULL     -- Secret binary
+    handle    BYTEA NOT NULL,    -- Secret handle
+    secret    BYTEA NOT NULL,    -- Secret binary
+    PRIMARY KEY (tenant_id, handle)
 );
 
 -------------
@@ -122,33 +129,33 @@ CREATE TABLE x25519_secret
 CREATE TABLE authority_member
 (
     tenant_id      TEXT    NOT NULL, -- Tenant identifier
-    identifier     TEXT    NOT NULL UNIQUE,
+    identifier     TEXT    NOT NULL,
     added_by       TEXT    NOT NULL,
     added_at       INTEGER NOT NULL,
     is_pre_trusted BOOLEAN NOT NULL,
     attributes     BYTEA,
-    authority_id   TEXT    NOT NULL
+    authority_id   TEXT    NOT NULL,
+    PRIMARY KEY (tenant_id, identifier)
 );
 
-CREATE UNIQUE INDEX authority_member_identifier_index ON authority_member (identifier);
-CREATE INDEX authority_member_is_pre_trusted_index ON authority_member (is_pre_trusted);
+CREATE INDEX authority_member_is_pre_trusted_index ON authority_member (tenant_id, is_pre_trusted);
 
 -- Reference is a random string that uniquely identifies an enrollment token. However, unlike the one_time_code,
 -- it's not sensitive so can be logged and used to track a lifecycle of a specific enrollment token.
 CREATE TABLE authority_enrollment_token
 (
     tenant_id     TEXT    NOT NULL, -- Tenant identifier
-    one_time_code TEXT    NOT NULL UNIQUE,
+    one_time_code TEXT    NOT NULL,
     issued_by     TEXT    NOT NULL,
     created_at    INTEGER NOT NULL,
     expires_at    INTEGER NOT NULL,
     ttl_count     INTEGER NOT NULL,
     attributes    BYTEA,
-    reference     TEXT
+    reference     TEXT,
+    PRIMARY KEY (tenant_id, one_time_code)
 );
 
-CREATE UNIQUE INDEX authority_enrollment_token_one_time_code_index ON authority_enrollment_token (one_time_code);
-CREATE INDEX authority_enrollment_token_expires_at_index ON authority_enrollment_token (expires_at);
+CREATE INDEX authority_enrollment_token_expires_at_index ON authority_enrollment_token (tenant_id, expires_at);
 
 ------------
 -- SERVICES
@@ -163,10 +170,9 @@ CREATE TABLE resource_policy
     resource_name TEXT NOT NULL, -- resource name
     action        TEXT NOT NULL, -- action name
     expression    TEXT NOT NULL, -- encoded expression to evaluate
-    node_name     TEXT NOT NULL  -- node name
+    node_name     TEXT NOT NULL, -- node name
+    PRIMARY KEY (tenant_id, node_name, resource_name, action)
 );
-
-CREATE UNIQUE INDEX resource_policy_index ON resource_policy (node_name, resource_name, action);
 
 -- Create a new table for resource type policies
 CREATE TABLE resource_type_policy
@@ -175,9 +181,9 @@ CREATE TABLE resource_type_policy
     resource_type TEXT NOT NULL, -- resource type
     action        TEXT NOT NULL, -- action name
     expression    TEXT NOT NULL, -- encoded expression to evaluate
-    node_name     TEXT NOT NULL  -- node name
+    node_name     TEXT NOT NULL, -- node name
+    PRIMARY KEY (tenant_id, node_name, resource_type, action)
 );
-CREATE UNIQUE INDEX resource_type_policy_index ON resource_type_policy (node_name, resource_type, action);
 
 -- Create a new table for resource to resource type mapping
 CREATE TABLE resource
@@ -185,30 +191,32 @@ CREATE TABLE resource
     tenant_id     TEXT NOT NULL, -- Tenant identifier
     resource_name TEXT NOT NULL, -- resource name
     resource_type TEXT,          -- resource type
-    node_name     TEXT NOT NULL  -- node name
+    node_name     TEXT NOT NULL, -- node name
+    PRIMARY KEY (tenant_id, node_name, resource_name)
 );
-CREATE UNIQUE INDEX resource_index ON resource (node_name, resource_name);
 
 -- This table stores the current state of a TCP outlet
 CREATE TABLE tcp_outlet_status
 (
-    tenant_id   TEXT NOT NULL,        -- Tenant identifier
-    node_name   TEXT NOT NULL,        -- Node where that tcp outlet has been created
-    socket_addr TEXT NOT NULL,        -- Socket address that the outlet connects to
-    worker_addr TEXT NOT NULL,        -- Worker address for the outlet itself
-    payload     TEXT,                 -- Optional status payload
-    privileged  BOOLEAN DEFAULT FALSE -- boolean indicating if the outlet is operating in privileged mode
+    tenant_id   TEXT NOT NULL,         -- Tenant identifier
+    node_name   TEXT NOT NULL,         -- Node where that tcp outlet has been created
+    socket_addr TEXT NOT NULL,         -- Socket address that the outlet connects to
+    worker_addr TEXT NOT NULL,         -- Worker address for the outlet itself
+    payload     TEXT,                  -- Optional status payload
+    privileged  BOOLEAN DEFAULT FALSE, -- boolean indicating if the outlet is operating in privileged mode
+    PRIMARY KEY (tenant_id, node_name, socket_addr)
 );
 
 -- This table stores the current state of a TCP inlet
 CREATE TABLE tcp_inlet
 (
-    tenant_id   TEXT NOT NULL,        -- Tenant identifier
-    node_name   TEXT NOT NULL,        -- Node where that tcp inlet has been created
-    bind_addr   TEXT NOT NULL,        -- Input address to connect to
-    outlet_addr TEXT NOT NULL,        -- MultiAddress to the outlet
-    alias       TEXT NOT NULL,        -- Alias for that inlet
-    privileged  BOOLEAN DEFAULT FALSE -- boolean indicating if the inlet is operating in privileged mode
+    tenant_id   TEXT NOT NULL,         -- Tenant identifier
+    node_name   TEXT NOT NULL,         -- Node where that tcp inlet has been created
+    bind_addr   TEXT NOT NULL,         -- Input address to connect to
+    outlet_addr TEXT NOT NULL,         -- MultiAddress to the outlet
+    alias       TEXT NOT NULL,         -- Alias for that inlet
+    privileged  BOOLEAN DEFAULT FALSE, -- boolean indicating if the inlet is operating in privileged mode
+    PRIMARY KEY (tenant_id, node_name, bind_addr)
 );
 
 ---------
@@ -219,14 +227,15 @@ CREATE TABLE tcp_inlet
 CREATE TABLE node
 (
     tenant_id            TEXT    NOT NULL, -- Tenant identifier
-    name                 TEXT PRIMARY KEY, -- Node name
+    name                 TEXT    NOT NULL, -- Node name
     identifier           TEXT    NOT NULL, -- Identifier of the default identity associated to the node
     verbosity            INTEGER NOT NULL, -- Verbosity level used for logging
     is_default           BOOLEAN NOT NULL, -- boolean indicating if this node is the default one (0 means true)
     is_authority         BOOLEAN NOT NULL, -- boolean indicating if this node is an authority node (0 means true). This boolean is used to be able to show an authority node as UP even if its TCP listener cannot be accessed.
     tcp_listener_address TEXT,             -- Socket address for the node default TCP Listener (can be NULL if the node has not been started)
     pid                  INTEGER,          -- Current process id of the node if it has been started
-    http_server_address  TEXT              -- Address of the server supporting the HTTP status endpoint for the node
+    http_server_address  TEXT,             -- Address of the server supporting the HTTP status endpoint for the node
+    PRIMARY KEY (tenant_id, name)
 );
 
 -------------------
@@ -240,21 +249,21 @@ CREATE TABLE secure_channel
     role                     TEXT  NOT NULL,
     my_identifier            TEXT  NOT NULL,
     their_identifier         TEXT  NOT NULL,
-    decryptor_remote_address TEXT PRIMARY KEY,
+    decryptor_remote_address TEXT  NOT NULL,
     decryptor_api_address    TEXT  NOT NULL,
-    decryption_key_handle    BYTEA NOT NULL
+    decryption_key_handle    BYTEA NOT NULL,
+    PRIMARY KEY (tenant_id, decryptor_remote_address)
     -- TODO: Add date?
 );
-
-CREATE UNIQUE INDEX secure_channel_decryptor_api_address_index ON secure_channel (decryptor_remote_address);
 
 -- This table stores aead secrets
 CREATE TABLE aead_secret
 (
     tenant_id TEXT  NOT NULL,    -- Tenant identifier
-    handle    BYTEA PRIMARY KEY, -- Secret handle
+    handle    BYTEA NOT NULL,    -- Secret handle
     type      TEXT  NOT NULL,    -- Secret type
-    secret    BYTEA NOT NULL     -- Secret binary
+    secret    BYTEA NOT NULL,    -- Secret binary
+    PRIMARY KEY (tenant_id, handle)
 );
 
 ---------------------------
@@ -265,7 +274,7 @@ CREATE TABLE aead_secret
 CREATE TABLE project
 (
     tenant_id                TEXT    NOT NULL, -- Tenant identifier
-    project_id               TEXT PRIMARY KEY, -- Id of the project
+    project_id               TEXT    NOT NULL, -- Id of the project
     project_name             TEXT    NOT NULL, -- Name of the project
     is_default               BOOLEAN NOT NULL, -- Boolean indicating if this project is the default one (0 means true)
     space_id                 TEXT    NOT NULL, -- Id of the space associated to the project
@@ -277,7 +286,8 @@ CREATE TABLE project
     authority_access_route   TEXT,             -- Route to the authority associated to the project
     version                  TEXT,             -- Orchestrator software version
     running                  BOOLEAN,          -- Boolean indicating if this project is currently accessible
-    operation_id             TEXT              -- Optional id of the operation currently creating the project on the Controller side
+    operation_id             TEXT,             -- Optional id of the operation currently creating the project on the Controller side
+    PRIMARY KEY (tenant_id, project_id)
 );
 
 -- This table provides the list of users associated to a given project
@@ -285,7 +295,8 @@ CREATE TABLE user_project
 (
     tenant_id  TEXT NOT NULL, -- Tenant identifier
     user_email TEXT NOT NULL, -- User email
-    project_id TEXT NOT NULL  -- Project id
+    project_id TEXT NOT NULL,  -- Project id
+    PRIMARY KEY (tenant_id, user_email, project_id)
 );
 
 -- This table provides additional information for users associated to a project or a space
@@ -296,16 +307,18 @@ CREATE TABLE user_role
     project_id TEXT    NOT NULL, -- Project id
     user_email TEXT    NOT NULL, -- User email
     role       TEXT    NOT NULL, -- Role of the user: admin or member
-    scope      TEXT    NOT NULL  -- Scope of the role: space, project, or service
+    scope      TEXT    NOT NULL, -- Scope of the role: space, project, or service
+    PRIMARY KEY (tenant_id, user_id, project_id)
 );
 
 -- This table stores data about spaces as returned by the controller
 CREATE TABLE space
 (
     tenant_id  TEXT    NOT NULL, -- Tenant identifier
-    space_id   TEXT PRIMARY KEY, -- Identifier of the space
+    space_id   TEXT    NOT NULL, -- Identifier of the space
     space_name TEXT    NOT NULL, -- Name of the space
-    is_default BOOLEAN NOT NULL  -- Boolean indicating if this project is the default one (0 means true)
+    is_default BOOLEAN NOT NULL, -- Boolean indicating if this project is the default one (0 means true)
+    PRIMARY KEY (tenant_id, space_id)
 );
 
 -- This table provides the list of users associated to a given project
@@ -313,33 +326,36 @@ CREATE TABLE user_space
 (
     tenant_id  TEXT NOT NULL, -- Tenant identifier
     user_email TEXT NOT NULL, -- User email
-    space_id   TEXT NOT NULL  -- Space id
+    space_id   TEXT NOT NULL, -- Space id
+    PRIMARY KEY (tenant_id, user_email, space_id)
 );
 
 -- This table stores the subscription for a given space
 CREATE TABLE subscription
 (
     tenant_id     TEXT    NOT NULL, -- Tenant identifier
-    space_id      TEXT PRIMARY KEY, -- Space id
+    space_id      TEXT    NOT NULL, -- Space id
     name          TEXT    NOT NULL, -- Name of the subscription
     is_free_trial BOOLEAN NOT NULL, -- Boolean indicating if the subscription is a free trial
     marketplace   TEXT,             -- Marketplace where the subscription was purchased (AWS, Azure, GCP, etc.)
     start_date    INTEGER,          -- Start date of the subscription (UNIX timestamps in seconds since epoch)
-    end_date      INTEGER           -- End date of the subscription (UNIX timestamps in seconds since epoch)
+    end_date      INTEGER,          -- End date of the subscription (UNIX timestamps in seconds since epoch)
+    PRIMARY KEY (tenant_id, space_id)
 );
 
 -- This table provides additional information for users after they have been authenticated
 CREATE TABLE "user"
 (
     tenant_id      TEXT    NOT NULL, -- Tenant identifier
-    email          TEXT PRIMARY KEY, -- User email
+    email          TEXT    NOT NULL, -- User email
     sub            TEXT    NOT NULL, -- (Sub)ject: unique identifier for the user
     nickname       TEXT    NOT NULL, -- User nickname (or handle)
     name           TEXT    NOT NULL, -- User name
     picture        TEXT    NOT NULL, -- Link to a user picture
     updated_at     TEXT    NOT NULL, -- ISO-8601 date: when this user information was last updated
     email_verified BOOLEAN NOT NULL, -- Boolean indicating if the user email has been verified (0 means true)
-    is_default     BOOLEAN NOT NULL  -- Boolean indicating if this user is the default user locally (0 means true)
+    is_default     BOOLEAN NOT NULL,  -- Boolean indicating if this user is the default user locally (0 means true)
+    PRIMARY KEY (tenant_id, email)
 );
 
 -- This table stores the time when a given identity was enrolled
@@ -347,9 +363,10 @@ CREATE TABLE "user"
 CREATE TABLE identity_enrollment
 (
     tenant_id   TEXT    NOT NULL,        -- Tenant identifier
-    identifier  TEXT    NOT NULL UNIQUE, -- Identifier of the identity
+    identifier  TEXT    NOT NULL,        -- Identifier of the identity
     enrolled_at INTEGER NOT NULL,        -- UNIX timestamp in seconds
-    email       TEXT                     -- User email used for the enrollment
+    email       TEXT,                    -- User email used for the enrollment
+    PRIMARY KEY (tenant_id, identifier)
 );
 
 ----------
@@ -364,7 +381,8 @@ CREATE TABLE okta_config
     tenant_base_url TEXT NOT NULL, -- Base URL of the tenant
     client_id       TEXT NOT NULL, -- Client id
     certificate     TEXT NOT NULL, -- Certificate
-    attributes      TEXT           -- Comma-separated list of attribute names
+    attributes      TEXT,          -- Comma-separated list of attribute names
+    PRIMARY KEY (tenant_id, project_id)
 );
 
 -- This table stores the data necessary to configure the Kafka addon
@@ -372,7 +390,8 @@ CREATE TABLE kafka_config
 (
     tenant_id        TEXT NOT NULL, -- Tenant identifier
     project_id       TEXT NOT NULL, -- Project id of the project using the addon
-    bootstrap_server TEXT NOT NULL  -- URL of the bootstrap server
+    bootstrap_server TEXT NOT NULL, -- URL of the bootstrap server
+    PRIMARY KEY (tenant_id, project_id, bootstrap_server)
 );
 
 
@@ -384,17 +403,19 @@ CREATE TABLE project_journey
 (
     tenant_id                      TEXT NOT NULL,
     project_id                     TEXT NOT NULL,
-    opentelemetry_context          TEXT NOT NULL UNIQUE,
+    opentelemetry_context          TEXT NOT NULL,
     start_datetime                 TEXT NOT NULL,
-    previous_opentelemetry_context TEXT
+    previous_opentelemetry_context TEXT,
+    PRIMARY KEY (tenant_id, project_id, opentelemetry_context)
 );
 
 CREATE TABLE host_journey
 (
     tenant_id                      TEXT NOT NULL,
-    opentelemetry_context          TEXT NOT NULL UNIQUE,
+    opentelemetry_context          TEXT NOT NULL,
     start_datetime                 TEXT NOT NULL,
-    previous_opentelemetry_context TEXT
+    previous_opentelemetry_context TEXT,
+    PRIMARY KEY (tenant_id, opentelemetry_context)
 );
 
 
@@ -409,16 +430,25 @@ ALTER TABLE credential ENABLE ROW LEVEL SECURITY;
 ALTER TABLE identity ENABLE ROW LEVEL SECURITY;
 ALTER TABLE identity_attributes ENABLE ROW LEVEL SECURITY;
 ALTER TABLE identity_enrollment ENABLE ROW LEVEL SECURITY;
+ALTER TABLE kafka_config ENABLE ROW LEVEL SECURITY;
 ALTER TABLE named_identity ENABLE ROW LEVEL SECURITY;
 ALTER TABLE node ENABLE ROW LEVEL SECURITY;
+ALTER TABLE okta_config ENABLE ROW LEVEL SECURITY;
+ALTER TABLE project ENABLE ROW LEVEL SECURITY;
 ALTER TABLE purpose_key ENABLE ROW LEVEL SECURITY;
 ALTER TABLE resource ENABLE ROW LEVEL SECURITY;
 ALTER TABLE resource_policy ENABLE ROW LEVEL SECURITY;
 ALTER TABLE resource_type_policy ENABLE ROW LEVEL SECURITY;
 ALTER TABLE secure_channel ENABLE ROW LEVEL SECURITY;
 ALTER TABLE signing_secret ENABLE ROW LEVEL SECURITY;
+ALTER TABLE space ENABLE ROW LEVEL SECURITY;
+ALTER TABLE subscription ENABLE ROW LEVEL SECURITY;
 ALTER TABLE tcp_inlet ENABLE ROW LEVEL SECURITY;
 ALTER TABLE tcp_outlet_status ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "user" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_project ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_role ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_space ENABLE ROW LEVEL SECURITY;
 ALTER TABLE vault ENABLE ROW LEVEL SECURITY;
 ALTER TABLE x25519_secret ENABLE ROW LEVEL SECURITY;
 
@@ -429,20 +459,24 @@ CREATE POLICY credential_policy ON credential USING (tenant_id = current_user);
 CREATE POLICY identity_policy ON identity USING (tenant_id = current_user);
 CREATE POLICY identity_attributes_policy ON identity_attributes USING (tenant_id = current_user);
 CREATE POLICY identity_enrollment_policy ON identity_enrollment USING (tenant_id = current_user);
+CREATE POLICY kafka_config_policy ON kafka_config USING (tenant_id = current_user);
 CREATE POLICY named_identity_policy ON named_identity USING (tenant_id = current_user);
 CREATE POLICY node_policy ON node USING (tenant_id = current_user);
+CREATE POLICY okta_config_policy ON okta_config USING (tenant_id = current_user);
+CREATE POLICY project_policy ON project USING (tenant_id = current_user);
 CREATE POLICY purpose_key_policy ON purpose_key USING (tenant_id = current_user);
 CREATE POLICY resource_policy ON resource USING (tenant_id = current_user);
 CREATE POLICY resource_policy_policy ON resource_policy USING (tenant_id = current_user);
 CREATE POLICY resource_type_policy_policy ON resource_type_policy USING (tenant_id = current_user);
 CREATE POLICY secure_channel_policy ON secure_channel USING (tenant_id = current_user);
 CREATE POLICY signing_secret_policy ON signing_secret USING (tenant_id = current_user);
+CREATE POLICY space_policy ON space USING (tenant_id = current_user);
+CREATE POLICY subscription_policy ON subscription USING (tenant_id = current_user);
 CREATE POLICY tcp_inlet_policy ON tcp_inlet USING (tenant_id = current_user);
 CREATE POLICY tcp_outlet_status_policy ON tcp_outlet_status USING (tenant_id = current_user);
+CREATE POLICY user_policy ON "user" USING (tenant_id = current_user);
+CREATE POLICY user_project_policy ON user_project USING (tenant_id = current_user);
+CREATE POLICY user_role_policy ON user_role USING (tenant_id = current_user);
+CREATE POLICY user_space_policy ON user_space USING (tenant_id = current_user);
 CREATE POLICY vault_policy ON vault USING (tenant_id = current_user);
 CREATE POLICY x25519_secret_policy ON x25519_secret USING (tenant_id = current_user);
--- Vault definitions are shared between all tenants. In practice there's only the default vault defined here.
--- And each tenant creates their own keys without seeing other's keys in the keys tables.
-CREATE POLICY vault_select_policy ON vault FOR SELECT USING (true);
--- The authority identity is shared between tenants so we allow different users to select it.
-CREATE POLICY identity_select_policy ON identity FOR SELECT USING (true);

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/sqlite/20250410100000_tenant_id.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/sqlite/20250410100000_tenant_id.sql
@@ -1,59 +1,600 @@
--- Add a tenant_id column to all tables
-ALTER TABLE aead_secret
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE authority_enrollment_token
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE authority_member
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE credential
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE identity
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE identity_attributes
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE identity_enrollment
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE incoming_service
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE kafka_config
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE named_identity
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE node
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE okta_config
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE project
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE purpose_key
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE resource
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE resource_policy
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE resource_type_policy
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE secure_channel
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE signing_secret
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE space
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE subscription
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE tcp_inlet
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE tcp_outlet_status
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE "user"
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE user_project
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE user_role
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE user_space
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE vault
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
-ALTER TABLE x25519_secret
-    ADD tenant_id TEXT NOT NULL DEFAULT 'tenant-id';
+-- identity
+CREATE TABLE identity_new
+(
+    tenant_id      TEXT NOT NULL,
+    identifier     TEXT NOT NULL,
+    change_history TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, identifier)
+);
+
+INSERT INTO identity_new (tenant_id, identifier, change_history)
+SELECT 'tenant-id-default' as tenant_id, identifier, change_history
+FROM identity;
+DROP TABLE identity;
+ALTER TABLE identity_new
+    RENAME TO identity;
+
+-- named_identity
+CREATE TABLE named_identity_new
+(
+    tenant_id  TEXT NOT NULL,
+    identifier TEXT NOT NULL,
+    name       TEXT NOT NULL,
+    vault_name TEXT NOT NULL,
+    is_default INTEGER DEFAULT 0,
+    PRIMARY KEY (tenant_id, identifier)
+);
+
+INSERT INTO named_identity_new (tenant_id, identifier, name, vault_name, is_default)
+SELECT 'tenant-id-default' as tenant_id, identifier, name, vault_name, is_default
+FROM named_identity;
+DROP TABLE named_identity;
+ALTER TABLE named_identity_new
+    RENAME TO named_identity;
+
+CREATE UNIQUE INDEX named_identity_index ON named_identity (tenant_id, name);
+
+-- identity_attributes
+CREATE TABLE identity_attributes_new
+(
+    tenant_id   TEXT    NOT NULL,
+    identifier  TEXT    NOT NULL,
+    attributes  BLOB    NOT NULL,
+    added       INTEGER NOT NULL,
+    expires     INTEGER,
+    attested_by TEXT,
+    node_name   TEXT    NOT NULL,
+    PRIMARY KEY (tenant_id, identifier, node_name)
+);
+
+INSERT INTO identity_attributes_new (tenant_id, identifier, attributes, added, expires, attested_by, node_name)
+SELECT 'tenant-id-default' as tenant_id, identifier, attributes, added, expires, attested_by, node_name
+FROM identity_attributes;
+DROP TABLE identity_attributes;
+ALTER TABLE identity_attributes_new
+    RENAME TO identity_attributes;
+
+CREATE UNIQUE INDEX identity_attributes_index ON identity_attributes (tenant_id, identifier, node_name);
+CREATE INDEX identity_attributes_identifier_attested_by_node_name_index ON identity_attributes (tenant_id, identifier, attested_by, node_name);
+CREATE INDEX identity_attributes_expires_node_name_index ON identity_attributes (tenant_id, expires, node_name);
+CREATE INDEX identity_identifier_index ON identity_attributes (tenant_id, identifier);
+CREATE INDEX identity_node_name_index ON identity_attributes (tenant_id, node_name);
+
+-- credential
+CREATE TABLE credential_new
+(
+    tenant_id          TEXT NOT NULL,
+    subject_identifier TEXT NOT NULL,
+    issuer_identifier  TEXT NOT NULL,
+    scope              TEXT NOT NULL,
+    credential         BLOB NOT NULL,
+    expires_at         INTEGER,
+    node_name          TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, subject_identifier, issuer_identifier, scope)
+);
+
+INSERT INTO credential_new (tenant_id, subject_identifier, issuer_identifier, scope, credential, expires_at, node_name)
+SELECT 'tenant-id-default' as tenant_id, subject_identifier, issuer_identifier, scope, credential, expires_at, node_name
+FROM credential;
+DROP TABLE credential;
+ALTER TABLE credential_new
+    RENAME TO credential;
+
+CREATE UNIQUE INDEX credential_issuer_subject_scope_index ON credential (tenant_id, issuer_identifier, subject_identifier, scope);
+CREATE INDEX credential_issuer_subject_index ON credential (tenant_id, issuer_identifier, subject_identifier);
+
+-- purpose_key
+CREATE TABLE purpose_key_new
+(
+    tenant_id               TEXT NOT NULL,
+    identifier              TEXT NOT NULL,
+    purpose                 TEXT NOT NULL,
+    purpose_key_attestation BLOB NOT NULL,
+    PRIMARY KEY (tenant_id, identifier, purpose)
+);
+
+INSERT INTO purpose_key_new (tenant_id, identifier, purpose, purpose_key_attestation)
+SELECT 'tenant-id-default' as tenant_id, identifier, purpose, purpose_key_attestation
+FROM purpose_key;
+DROP TABLE purpose_key;
+ALTER TABLE purpose_key_new
+    RENAME TO purpose_key;
+
+CREATE UNIQUE INDEX purpose_key_index ON purpose_key (tenant_id, identifier, purpose);
+
+-- vault
+CREATE TABLE vault_new
+(
+    tenant_id  TEXT NOT NULL,
+    name       TEXT NOT NULL,
+    path       TEXT NULL,
+    is_default INTEGER,
+    is_kms     INTEGER,
+    PRIMARY KEY (tenant_id, name)
+);
+
+INSERT INTO vault_new (tenant_id, name, path, is_default, is_kms)
+SELECT 'tenant-id-default' as tenant_id, name, path, is_default, is_kms
+FROM vault;
+DROP TABLE vault;
+ALTER TABLE vault_new
+    RENAME TO vault;
+
+-- signing_secret
+CREATE TABLE signing_secret_new
+(
+    tenant_id   TEXT NOT NULL,
+    handle      BLOB NOT NULL,
+    secret_type TEXT NOT NULL,
+    secret      BLOB NOT NULL,
+    PRIMARY KEY (tenant_id, handle)
+);
+
+INSERT INTO signing_secret_new (tenant_id, handle, secret_type, secret)
+SELECT 'tenant-id-default' as tenant_id, handle, secret_type, secret
+FROM signing_secret;
+DROP TABLE signing_secret;
+ALTER TABLE signing_secret_new
+    RENAME TO signing_secret;
+
+-- x25519_secret
+CREATE TABLE x25519_secret_new
+(
+    tenant_id TEXT NOT NULL,
+    handle    BLOB NOT NULL,
+    secret    BLOB NOT NULL,
+    PRIMARY KEY (tenant_id, handle)
+);
+
+INSERT INTO x25519_secret_new (tenant_id, handle, secret)
+SELECT 'tenant-id-default' as tenant_id, handle, secret
+FROM x25519_secret;
+DROP TABLE x25519_secret;
+ALTER TABLE x25519_secret_new
+    RENAME TO x25519_secret;
+
+-- authority_member
+CREATE TABLE authority_member_new
+(
+    tenant_id      TEXT    NOT NULL,
+    identifier     TEXT    NOT NULL,
+    added_by       TEXT    NOT NULL,
+    added_at       INTEGER NOT NULL,
+    is_pre_trusted INTEGER NOT NULL,
+    attributes     BLOB,
+    authority_id   TEXT    NOT NULL,
+    PRIMARY KEY (tenant_id, identifier)
+);
+
+INSERT INTO authority_member_new (tenant_id, identifier, added_by, added_at, is_pre_trusted, attributes, authority_id)
+SELECT 'tenant-id-default' as tenant_id, identifier, added_by, added_at, is_pre_trusted, attributes, authority_id
+FROM authority_member;
+DROP TABLE authority_member;
+ALTER TABLE authority_member_new
+    RENAME TO authority_member;
+
+CREATE INDEX authority_member_is_pre_trusted_index ON authority_member (tenant_id, is_pre_trusted);
+
+-- authority_enrollment_token
+CREATE TABLE authority_enrollment_token_new
+(
+    tenant_id     TEXT    NOT NULL,
+    one_time_code TEXT    NOT NULL,
+    issued_by     TEXT    NOT NULL,
+    created_at    INTEGER NOT NULL,
+    expires_at    INTEGER NOT NULL,
+    ttl_count     INTEGER NOT NULL,
+    attributes    BLOB,
+    reference     TEXT,
+    PRIMARY KEY (tenant_id, one_time_code)
+);
+
+INSERT INTO authority_enrollment_token_new (tenant_id, one_time_code, issued_by, created_at, expires_at, ttl_count,
+                                            attributes, reference)
+SELECT 'tenant-id-default' as tenant_id,
+       one_time_code,
+       issued_by,
+       created_at,
+       expires_at,
+       ttl_count,
+       attributes,
+       reference
+FROM authority_enrollment_token;
+DROP TABLE authority_enrollment_token;
+ALTER TABLE authority_enrollment_token_new
+    RENAME TO authority_enrollment_token;
+
+CREATE INDEX authority_enrollment_token_expires_at_index ON authority_enrollment_token (tenant_id, expires_at);
+
+-- resource_policy
+CREATE TABLE resource_policy_new
+(
+    tenant_id     TEXT NOT NULL,
+    resource_name TEXT NOT NULL,
+    action        TEXT NOT NULL,
+    expression    TEXT NOT NULL,
+    node_name     TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, node_name, resource_name, action)
+);
+
+INSERT INTO resource_policy_new (tenant_id, resource_name, action, expression, node_name)
+SELECT 'tenant-id-default' as tenant_id, resource_name, action, expression, node_name
+FROM resource_policy;
+DROP TABLE resource_policy;
+ALTER TABLE resource_policy_new
+    RENAME TO resource_policy;
+
+-- resource_type_policy
+CREATE TABLE resource_type_policy_new
+(
+    tenant_id     TEXT NOT NULL,
+    resource_type TEXT NOT NULL,
+    action        TEXT NOT NULL,
+    expression    TEXT NOT NULL,
+    node_name     TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, node_name, resource_type, action)
+);
+
+INSERT INTO resource_type_policy_new (tenant_id, resource_type, action, expression, node_name)
+SELECT 'tenant-id-default' as tenant_id, resource_type, action, expression, node_name
+FROM resource_type_policy;
+DROP TABLE resource_type_policy;
+ALTER TABLE resource_type_policy_new
+    RENAME TO resource_type_policy;
+
+-- resource
+CREATE TABLE resource_new
+(
+    tenant_id     TEXT NOT NULL,
+    resource_name TEXT NOT NULL,
+    resource_type TEXT,
+    node_name     TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, node_name, resource_name)
+);
+
+INSERT INTO resource_new (tenant_id, resource_name, resource_type, node_name)
+SELECT 'tenant-id-default' as tenant_id, resource_name, resource_type, node_name
+FROM resource;
+DROP TABLE resource;
+ALTER TABLE resource_new
+    RENAME TO resource;
+
+-- tcp_outlet_status
+CREATE TABLE tcp_outlet_status_new
+(
+    tenant_id   TEXT NOT NULL,
+    node_name   TEXT NOT NULL,
+    socket_addr TEXT NOT NULL,
+    worker_addr TEXT NOT NULL,
+    payload     TEXT,
+    privileged  INTEGER DEFAULT 0,
+    PRIMARY KEY (tenant_id, node_name, socket_addr)
+);
+
+INSERT INTO tcp_outlet_status_new (tenant_id, node_name, socket_addr, worker_addr, payload, privileged)
+SELECT 'tenant-id-default' as tenant_id, node_name, socket_addr, worker_addr, payload, privileged
+FROM tcp_outlet_status;
+DROP TABLE tcp_outlet_status;
+ALTER TABLE tcp_outlet_status_new
+    RENAME TO tcp_outlet_status;
+
+-- tcp_inlet
+CREATE TABLE tcp_inlet_new
+(
+    tenant_id   TEXT NOT NULL,
+    node_name   TEXT NOT NULL,
+    bind_addr   TEXT NOT NULL,
+    outlet_addr TEXT NOT NULL,
+    alias       TEXT NOT NULL,
+    privileged  INTEGER DEFAULT 0,
+    PRIMARY KEY (tenant_id, node_name, bind_addr)
+);
+
+INSERT INTO tcp_inlet_new (tenant_id, node_name, bind_addr, outlet_addr, alias, privileged)
+SELECT 'tenant-id-default' as tenant_id, node_name, bind_addr, outlet_addr, alias, privileged
+FROM tcp_inlet;
+DROP TABLE tcp_inlet;
+ALTER TABLE tcp_inlet_new
+    RENAME TO tcp_inlet;
+
+-- node
+CREATE TABLE node_new
+(
+    tenant_id            TEXT    NOT NULL,
+    name                 TEXT    NOT NULL,
+    identifier           TEXT    NOT NULL,
+    verbosity            INTEGER NOT NULL,
+    is_default           INTEGER NOT NULL,
+    is_authority         INTEGER NOT NULL,
+    tcp_listener_address TEXT,
+    pid                  INTEGER,
+    http_server_address  TEXT,
+    PRIMARY KEY (tenant_id, name)
+);
+
+INSERT INTO node_new (tenant_id, name, identifier, verbosity, is_default, is_authority, tcp_listener_address, pid,
+                      http_server_address)
+SELECT 'tenant-id-default' as tenant_id,
+       name,
+       identifier,
+       verbosity,
+       is_default,
+       is_authority,
+       tcp_listener_address,
+       pid,
+       http_server_address
+FROM node;
+DROP TABLE node;
+ALTER TABLE node_new
+    RENAME TO node;
+
+-- secure_channel
+CREATE TABLE secure_channel_new
+(
+    tenant_id                TEXT NOT NULL,
+    role                     TEXT NOT NULL,
+    my_identifier            TEXT NOT NULL,
+    their_identifier         TEXT NOT NULL,
+    decryptor_remote_address TEXT NOT NULL,
+    decryptor_api_address    TEXT NOT NULL,
+    decryption_key_handle    BLOB NOT NULL,
+    PRIMARY KEY (tenant_id, decryptor_remote_address)
+);
+
+INSERT INTO secure_channel_new (tenant_id, role, my_identifier, their_identifier, decryptor_remote_address,
+                                decryptor_api_address, decryption_key_handle)
+SELECT 'tenant-id-default' as tenant_id,
+       role,
+       my_identifier,
+       their_identifier,
+       decryptor_remote_address,
+       decryptor_api_address,
+       decryption_key_handle
+FROM secure_channel;
+DROP TABLE secure_channel;
+ALTER TABLE secure_channel_new
+    RENAME TO secure_channel;
+
+-- aead_secret
+CREATE TABLE aead_secret_new
+(
+    tenant_id TEXT NOT NULL,
+    handle    BLOB NOT NULL,
+    type      TEXT NOT NULL,
+    secret    BLOB NOT NULL,
+    PRIMARY KEY (tenant_id, handle)
+);
+
+INSERT INTO aead_secret_new (tenant_id, handle, type, secret)
+SELECT 'tenant-id-default' as tenant_id, handle, type, secret
+FROM aead_secret;
+DROP TABLE aead_secret;
+ALTER TABLE aead_secret_new
+    RENAME TO aead_secret;
+
+-- project
+CREATE TABLE project_new
+(
+    tenant_id                TEXT    NOT NULL,
+    project_id               TEXT    NOT NULL,
+    project_name             TEXT    NOT NULL,
+    is_default               INTEGER NOT NULL,
+    space_id                 TEXT    NOT NULL,
+    space_name               TEXT    NOT NULL,
+    project_identifier       TEXT,
+    project_change_history   TEXT,
+    access_route             TEXT    NOT NULL,
+    authority_change_history TEXT,
+    authority_access_route   TEXT,
+    version                  TEXT,
+    running                  INTEGER,
+    operation_id             TEXT,
+    PRIMARY KEY (tenant_id, project_id)
+);
+
+INSERT INTO project_new (tenant_id, project_id, project_name, is_default, space_id, space_name, project_identifier,
+                         project_change_history, access_route, authority_change_history, authority_access_route,
+                         version, running, operation_id)
+SELECT 'tenant-id-default' as tenant_id,
+       project_id,
+       project_name,
+       is_default,
+       space_id,
+       space_name,
+       project_identifier,
+       project_change_history,
+       access_route,
+       authority_change_history,
+       authority_access_route,
+       version,
+       running,
+       operation_id
+FROM project;
+DROP TABLE project;
+ALTER TABLE project_new
+    RENAME TO project;
+
+-- user_project
+CREATE TABLE user_project_new
+(
+    tenant_id  TEXT NOT NULL,
+    user_email TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, user_email, project_id)
+);
+
+INSERT INTO user_project_new (tenant_id, user_email, project_id)
+SELECT 'tenant-id-default' as tenant_id, user_email, project_id
+FROM user_project;
+DROP TABLE user_project;
+ALTER TABLE user_project_new
+    RENAME TO user_project;
+
+-- user_rol
+CREATE TABLE user_role_new
+(
+    tenant_id  TEXT    NOT NULL,
+    user_id    INTEGER NOT NULL,
+    project_id TEXT    NOT NULL,
+    user_email TEXT    NOT NULL,
+    role       TEXT    NOT NULL,
+    scope      TEXT    NOT NULL,
+    PRIMARY KEY (tenant_id, user_id, project_id)
+);
+
+INSERT INTO user_role_new (tenant_id, user_id, project_id, user_email, role, scope)
+SELECT 'tenant-id-default' as tenant_id, user_id, project_id, user_email, role, scope
+FROM user_role;
+DROP TABLE user_role;
+ALTER TABLE user_role_new
+    RENAME TO user_role;
+
+-- space
+CREATE TABLE space_new
+(
+    tenant_id  TEXT    NOT NULL,
+    space_id   TEXT    NOT NULL,
+    space_name TEXT    NOT NULL,
+    is_default INTEGER NOT NULL,
+    PRIMARY KEY (tenant_id, space_id)
+);
+
+INSERT INTO space_new (tenant_id, space_id, space_name, is_default)
+SELECT 'tenant-id-default' as tenant_id, space_id, space_name, is_default
+FROM space;
+DROP TABLE space;
+ALTER TABLE space_new
+    RENAME TO space;
+
+-- user_space
+CREATE TABLE user_space_new
+(
+    tenant_id  TEXT NOT NULL,
+    user_email TEXT NOT NULL,
+    space_id   TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, user_email, space_id)
+);
+
+INSERT INTO user_space_new (tenant_id, user_email, space_id)
+SELECT 'tenant-id-default' as tenant_id, user_email, space_id
+FROM user_space;
+DROP TABLE user_space;
+ALTER TABLE user_space_new
+    RENAME TO user_space;
+
+-- subscription
+CREATE TABLE subscription_new
+(
+    tenant_id     TEXT    NOT NULL,
+    space_id      TEXT    NOT NULL,
+    name          TEXT    NOT NULL,
+    is_free_trial INTEGER NOT NULL,
+    marketplace   TEXT,
+    start_date    INTEGER,
+    end_date      INTEGER,
+    PRIMARY KEY (tenant_id, space_id)
+);
+
+INSERT INTO subscription_new (tenant_id, space_id, name, is_free_trial, marketplace, start_date, end_date)
+SELECT 'tenant-id-default' as tenant_id, space_id, name, is_free_trial, marketplace, start_date, end_date
+FROM subscription;
+DROP TABLE subscription;
+ALTER TABLE subscription_new
+    RENAME TO subscription;
+
+-- user
+CREATE TABLE "user_new"
+(
+    tenant_id      TEXT    NOT NULL,
+    email          TEXT    NOT NULL,
+    sub            TEXT    NOT NULL,
+    nickname       TEXT    NOT NULL,
+    name           TEXT    NOT NULL,
+    picture        TEXT    NOT NULL,
+    updated_at     TEXT    NOT NULL,
+    email_verified INTEGER NOT NULL,
+    is_default     INTEGER NOT NULL,
+    PRIMARY KEY (tenant_id, email)
+);
+INSERT INTO "user_new" (tenant_id, email, sub, nickname, name, picture, updated_at, email_verified, is_default)
+SELECT 'tenant-id-default' as tenant_id,
+       email,
+       sub,
+       nickname,
+       name,
+       picture,
+       updated_at,
+       email_verified,
+       is_default
+FROM "user";
+DROP TABLE "user";
+ALTER TABLE "user_new"
+    RENAME TO "user";
+
+-- identity
+CREATE TABLE identity_enrollment_new
+(
+    tenant_id   TEXT    NOT NULL,
+    identifier  TEXT    NOT NULL,
+    enrolled_at INTEGER NOT NULL,
+    email       TEXT,
+    PRIMARY KEY (tenant_id, identifier)
+);
+
+INSERT INTO identity_enrollment_new (tenant_id, identifier, enrolled_at, email)
+SELECT 'tenant-id-default' as tenant_id, identifier, enrolled_at, email
+FROM identity_enrollment;
+DROP TABLE identity_enrollment;
+ALTER TABLE identity_enrollment_new
+    RENAME TO identity_enrollment;
+
+-- okta_config
+CREATE TABLE okta_config_new
+(
+    tenant_id       TEXT NOT NULL,
+    project_id      TEXT NOT NULL,
+    tenant_base_url TEXT NOT NULL,
+    client_id       TEXT NOT NULL,
+    certificate     TEXT NOT NULL,
+    attributes      TEXT,
+    PRIMARY KEY (tenant_id, project_id)
+);
+
+INSERT INTO okta_config_new (tenant_id, project_id, tenant_base_url, client_id, certificate, attributes)
+SELECT 'tenant-id-default' as tenant_id, project_id, tenant_base_url, client_id, certificate, attributes
+FROM okta_config;
+DROP TABLE okta_config;
+ALTER TABLE okta_config_new
+    RENAME TO okta_config;
+
+-- kafka_config
+CREATE TABLE kafka_config_new
+(
+    tenant_id        TEXT NOT NULL,
+    project_id       TEXT NOT NULL,
+    bootstrap_server TEXT NOT NULL
+);
+
+INSERT INTO kafka_config_new (tenant_id, project_id, bootstrap_server)
+SELECT 'tenant-id-default' as tenant_id, project_id, bootstrap_server
+FROM kafka_config;
+DROP TABLE kafka_config;
+ALTER TABLE kafka_config_new
+    RENAME TO kafka_config;
+
+-- incoming_service
+CREATE TABLE incoming_service_new
+(
+    tenant_id     TEXT    NOT NULL,
+    invitation_id TEXT    NOT NULL,
+    enabled       INTEGER NOT NULL,
+    name          TEXT    NULL,
+    PRIMARY KEY (tenant_id, invitation_id)
+);
+
+INSERT INTO incoming_service_new (tenant_id, invitation_id, enabled, name)
+SELECT 'tenant-id-default', invitation_id, enabled, name
+FROM incoming_service;
+DROP TABLE incoming_service;
+ALTER TABLE incoming_service_new
+    RENAME TO incoming_service;

--- a/implementations/rust/ockam/ockam_vault/src/storage/secrets_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_vault/src/storage/secrets_repository_sql.rs
@@ -67,7 +67,7 @@ impl SecretsRepository for SecretsSqlxDatabase {
             r#"
             INSERT INTO signing_secret (handle, secret_type, secret, tenant_id)
             VALUES ($1, $2, $3, $4)
-            ON CONFLICT (handle)
+            ON CONFLICT (tenant_id, handle)
             DO UPDATE SET secret_type = $2, secret = $3, tenant_id = $4"#,
         )
         .bind(handle)
@@ -117,7 +117,7 @@ impl SecretsRepository for SecretsSqlxDatabase {
             r#"
         INSERT INTO x25519_secret (handle, secret, tenant_id)
         VALUES ($1, $2, $3)
-        ON CONFLICT (handle)
+        ON CONFLICT (tenant_id, handle)
         DO UPDATE SET secret = $2, tenant_id = $3"#,
         )
         .bind(handle)
@@ -164,7 +164,7 @@ impl SecretsRepository for SecretsSqlxDatabase {
             r#"
                 INSERT INTO aead_secret (handle, type, secret, tenant_id)
                 VALUES ($1, $2, $3, $4)
-                ON CONFLICT (handle)
+                ON CONFLICT (tenant_id, handle)
                 DO UPDATE SET type = $2, secret = $3, tenant_id = $4"#,
         )
         .bind(handle)


### PR DESCRIPTION
This PR adds the `tenant_id` as a primary key for all tables (SQLite or Postgres).

This should guarantee that, in the Postgres case with row-level security enabled, all tables are fully scoped to a given `tenant_id`. In that situation, each tenant id will have it own project data, even if they share the same project.