### PR TITLE
feat(rust): cluster ticket command going through provisioner

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/orchestrator/ai_platform/api.rs
+++ b/implementations/rust/ockam/ockam_api/src/orchestrator/ai_platform/api.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use crate::orchestrator::ai_platform::responses::{Cluster, EcrCredentials, Secret, Zone};
 use ockam_core::async_trait;
 use ockam_core::compat::collections::HashMap;
@@ -52,6 +54,15 @@ pub trait AiPlatformApi {
         zone_name: &str,
         secret_name: &str,
     ) -> miette::Result<()>;
+
+    async fn create_enrollment_token(
+        &self,
+        ctx: &Context,
+        cluster: &str,
+        zone_name: &str,
+        attributes: BTreeMap<String, String>,
+        relay: Option<String>,
+    ) -> miette::Result<String>;
 
     async fn get_cluster(&self, ctx: &Context) -> miette::Result<Cluster>;
 

--- a/implementations/rust/ockam/ockam_api/src/orchestrator/ai_platform/controller_client.rs
+++ b/implementations/rust/ockam/ockam_api/src/orchestrator/ai_platform/controller_client.rs
@@ -1,6 +1,8 @@
+use std::collections::BTreeMap;
+
 use crate::orchestrator::ai_platform::api::AiPlatformApi;
 use crate::orchestrator::ai_platform::requests::{
-    CreateSecret, CreateZone, DeployZone, ListZones, ProvisionEcr,
+    CreateEnrollmentToken, CreateSecret, CreateZone, DeployZone, ListZones, ProvisionEcr,
 };
 use crate::orchestrator::ai_platform::responses::{
     Cluster, EcrCredentials, Secret, SecretList, Zone, ZoneList,
@@ -164,5 +166,25 @@ impl AiPlatformApi for ControllerClient {
             .into_diagnostic()?
             .miette_success("provision ecr")?;
         Ok(ecr_creds)
+    }
+
+    async fn create_enrollment_token(
+        &self,
+        ctx: &Context,
+        cluster: &str,
+        zone_name: &str,
+        attributes: BTreeMap<String, String>,
+        relay: Option<String>,
+    ) -> miette::Result<String> {
+        trace!(%cluster, %zone_name, ?attributes, ?relay, "creating enrollment token");
+        let req = Request::post(format!("/v0/zone/{zone_name}/token"))
+            .body(CreateEnrollmentToken::new(attributes.clone(), relay)?);
+        let token: String = self
+            .get_secure_client()
+            .ask(ctx, "tokens", req)
+            .await
+            .into_diagnostic()?
+            .miette_success("create enrollment token")?;
+        Ok(token)
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/orchestrator/ai_platform/node_service_client.rs
+++ b/implementations/rust/ockam/ockam_api/src/orchestrator/ai_platform/node_service_client.rs
@@ -1,6 +1,8 @@
+use std::collections::BTreeMap;
+
 use crate::nodes::InMemoryNode;
 use crate::orchestrator::ai_platform::api::AiPlatformApi;
-use crate::orchestrator::ai_platform::responses::{Cluster, EcrCredentials, Secret, Zone};
+use crate::orchestrator::ai_platform::responses::{Cluster, EcrCredentials, Secret, Token, Zone};
 use ockam_core::async_trait;
 use ockam_core::compat::collections::HashMap;
 use ockam_core::env::get_env_with_default_ignore_error;
@@ -245,5 +247,53 @@ impl AiPlatformApi for InMemoryNode {
             .map_err(|e| miette::miette!("Failed to parse response: {}", e))?;
 
         Ok(ecr_credentials)
+    }
+
+    async fn create_enrollment_token(
+        &self,
+        _ctx: &Context,
+        cluster: &str,
+        zone_name: &str,
+        attributes: BTreeMap<String, String>,
+        relay: Option<String>,
+    ) -> miette::Result<String> {
+        let url = format!(
+            "{}/api/{}/zone/{}/token",
+            *AI_API_BASE_URL, cluster, zone_name
+        );
+
+        let mut body = serde_json::json!({
+            "attributes": attributes
+            .into_iter()
+            .map(|(name, value)| serde_json::json!({ "name": name, "value": value }))
+            .collect::<Vec<_>>(),
+        });
+
+        if let Some(relay_value) = relay {
+            body["relay"] = serde_json::Value::String(relay_value);
+        }
+
+        let client = reqwest::Client::new();
+        let response = client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| miette::miette!("Failed to send request: {}", e))?;
+
+        if !response.status().is_success() {
+            return Err(miette::miette!(
+                "Failed to create enrollment token: HTTP {}: {}",
+                response.status(),
+                response.text().await.unwrap_or_default()
+            ));
+        }
+        let token = response
+            .json::<Token>()
+            .await
+            .map_err(|e| miette::miette!("Failed to parse response: {}", e))?;
+
+        Ok(token.token)
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/orchestrator/ai_platform/requests.rs
+++ b/implementations/rust/ockam/ockam_api/src/orchestrator/ai_platform/requests.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use miette::IntoDiagnostic;
 use minicbor::{CborLen, Decode, Encode};
 use ockam::Message;
@@ -177,5 +179,38 @@ impl ProvisionEcr {
             is_public,
             region,
         }
+    }
+}
+
+#[derive(Encode, Decode, CborLen, Debug, Message)]
+#[cfg_attr(test, derive(Clone))]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct CreateEnrollmentToken {
+    #[n(1)] pub attributes: Vec<u8>,
+    #[n(2)] pub relay: Option<String>,
+}
+
+impl Encodable for CreateEnrollmentToken {
+    fn encode(self) -> ockam_core::Result<Encoded> {
+        cbor_encode_preallocate(self)
+    }
+}
+
+impl Decodable for CreateEnrollmentToken {
+    fn decode(e: &[u8]) -> ockam_core::Result<Self> {
+        Ok(minicbor::decode(e)?)
+    }
+}
+
+impl CreateEnrollmentToken {
+    pub fn new(
+        attributes: BTreeMap<String, String>,
+        relay: Option<String>,
+    ) -> miette::Result<Self> {
+        Ok(Self {
+            attributes: serde_json::to_vec(&attributes).into_diagnostic()?,
+            relay,
+        })
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/orchestrator/ai_platform/responses.rs
+++ b/implementations/rust/ockam/ockam_api/src/orchestrator/ai_platform/responses.rs
@@ -132,3 +132,22 @@ impl Decodable for EcrCredentials {
         Ok(minicbor::decode(e)?)
     }
 }
+
+#[derive(Encode, Decode, CborLen, Serialize, Deserialize, Debug, Default, Clone, Message)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct Token {
+    #[n(1)] pub token: String,
+}
+
+impl Encodable for Token {
+    fn encode(self) -> ockam_core::Result<Encoded> {
+        cbor_encode_preallocate(self)
+    }
+}
+
+impl Decodable for Token {
+    fn decode(e: &[u8]) -> ockam_core::Result<Self> {
+        Ok(minicbor::decode(e)?)
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/cluster/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/ticket.rs
@@ -1,9 +1,17 @@
+use std::{collections::BTreeMap, sync::Arc};
+
 use async_trait::async_trait;
 
 use clap::Args;
+use miette::{miette, IntoDiagnostic};
+use ockam_api::{
+    nodes::InMemoryNode, orchestrator::ai_platform::node_service_client::AI_API_BASE_URL_ENV,
+};
 use ockam_node::Context;
 
-use crate::{docs, Command, CommandGlobalOpts, Result};
+use crate::{docs, node_command::InMemoryNodeCommand, Command, CommandGlobalOpts, Result};
+
+use super::utils::get_api_client;
 
 const LONG_ABOUT: &str = include_str!("./static/ticket/long_about.txt");
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
@@ -17,8 +25,78 @@ before_help = docs::before_help(PREVIEW_TAG),
 after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct AiTicketCommand {
-    #[command(flatten)]
-    inner: crate::project::TicketCommand,
+    // === Specific args for the HTTP API endpoint
+    /// The Cluster that will be used
+    /// If not set, it will be retrieved from the enrolled user data.
+    #[arg(long)]
+    pub cluster: Option<String>,
+
+    /// The name of the Zone
+    #[arg(long)]
+    pub zone_name: String,
+
+    /// Force the command to use the HTTP API.
+    /// By default, the command will use the Orchestrator API.
+    #[arg(long)]
+    pub use_http_api: bool,
+
+    /// The API endpoint of the Ockam AI Platform.
+    /// Defaults to `http://localhost:30080`.
+    #[arg(long)]
+    pub api_endpoint: Option<String>,
+
+    /// Attributes in `key=value` format to be attached to the member. You can specify this option multiple times for multiple attributes
+    #[arg(short, long = "attribute", value_name = "ATTRIBUTE")]
+    attributes: Vec<String>,
+
+    /// Name of the relay that the identity using the ticket will be allowed to create. This name is transformed into attributes to prevent collisions when creating relay names. For example: `--relay foo` is shorthand for `--attribute ockam-relay=foo`
+    #[arg(long = "relay", value_name = "ENROLLEE_ALLOWED_RELAY_NAME")]
+    allowed_relay_name: Option<String>,
+}
+
+#[derive(Clone)]
+struct TicketNodeCommand {
+    opts: CommandGlobalOpts,
+    command: AiTicketCommand,
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for TicketNodeCommand {
+    async fn init(&self) -> miette::Result<()> {
+        if let Some(api_endpoint) = &self.command.api_endpoint {
+            std::env::set_var(AI_API_BASE_URL_ENV, api_endpoint);
+        }
+        Ok(())
+    }
+
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let ctx = node.ctx();
+        let use_http_api = self.command.use_http_api || self.command.api_endpoint.is_some();
+        let api_client = get_api_client(&node, use_http_api).await?;
+        let cluster = match &self.command.cluster {
+            None => api_client.get_cluster(ctx).await?.into_inner(),
+            Some(cluster) => cluster.to_string(),
+        };
+        let ticket = api_client
+            .create_enrollment_token(
+                ctx,
+                &cluster,
+                &self.command.zone_name,
+                self.command.attributes()?,
+                self.command.allowed_relay_name.clone(),
+            )
+            .await?;
+
+        self.opts
+            .terminal
+            .clone()
+            .to_stdout()
+            .plain(format!("\n{ticket}"))
+            .machine(&ticket)
+            .json(&serde_json::to_string(&ticket).into_diagnostic()?)
+            .write_line()?;
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -26,6 +104,26 @@ impl Command for AiTicketCommand {
     const NAME: &'static str = "cluster ticket";
 
     async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
-        self.inner.run(ctx, opts).await
+        let command = TicketNodeCommand {
+            opts: opts.clone(),
+            command: self.clone(),
+        };
+        command.execute(ctx, opts.state.clone()).await?;
+        Ok(())
+    }
+}
+
+impl AiTicketCommand {
+    //a bit of copy-pasted from project ticket command. But no tls, enroller, etc.
+    fn attributes(&self) -> Result<BTreeMap<String, String>> {
+        let mut attributes = BTreeMap::new();
+        for attr in &self.attributes {
+            let mut parts = attr.splitn(2, '=');
+            let key = parts.next().ok_or(miette!("key expected"))?;
+            // If no value is provided we assume that the attribute is a boolean attribute set to "true"
+            let value = parts.next().unwrap_or("true");
+            attributes.insert(key.to_string(), value.to_string());
+        }
+        Ok(attributes)
     }
 }


### PR DESCRIPTION
user won't be able to create enrollment tickets by itself, it must create them through the controller/provisioner.

The controller endpoint is not ready yet,  but can be tested with direct provisioner calls.   
```
./ockam cluster ticket --zone-name z1 --cluster c1 --attribute test=yes --attribute other=2 --relay tt  --use-http-api  

[ .. output some ticket...]
```

Then use that ticket to see what attributes and relay get set:
```
 OCKAM_HOME=/tmp/trash ./ockam project enroll [ ..ticket created above ..]
 
  ✔ Successfully enrolled identity renewed-maggot to the ockam-agent-project project.

    The identity has a credential in this project
    created at 2025-04-23T15:35:34Z that expires at 2025-04-23T16:05:34Z

    The following attributes are attested by the project's membership authority:
      "cluster=c1"
      "ockam-relay=c1-z1-tt"
      "other=2"
      "test=yes"
      "zone=z1"
```
