### PR TITLE
feat(rust): when resetting with the postgres database delete the tenant tables data

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
@@ -136,9 +136,7 @@ impl CliState {
     pub async fn reset(&self) -> Result<()> {
         if Self::make_database_configuration(&self.mode)?.database_type() == DatabaseType::Postgres
         {
-            Err(CliStateError::InvalidOperation(
-                "Cannot reset the database when using Postgres".to_string(),
-            ))
+            Ok(self.database().truncate_all_postgres_tables().await?)
         } else {
             self.delete_all_named_identities().await?;
             self.delete_all_nodes().await?;

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/postgres/20250423100000_delete_tenant_tables.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/postgres/20250423100000_delete_tenant_tables.sql
@@ -1,0 +1,54 @@
+--------------------------------------------
+-- TRUNCATE ALL TABLES FOR THE CURRENT USER
+--------------------------------------------
+
+CREATE OR REPLACE PROCEDURE delete_if_table_exists(tablename TEXT)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = tablename
+    ) THEN
+        EXECUTE format('DELETE FROM %I', tablename);
+END IF;
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE delete_tenant_tables()
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    CALL delete_if_table_exists('user_role');
+    CALL delete_if_table_exists('user_project');
+    CALL delete_if_table_exists('user_space');
+    CALL delete_if_table_exists('user');
+    CALL delete_if_table_exists('subscription');
+    CALL delete_if_table_exists('project_journey');
+    CALL delete_if_table_exists('host_journey');
+    CALL delete_if_table_exists('project');
+    CALL delete_if_table_exists('space');
+    CALL delete_if_table_exists('resource_policy');
+    CALL delete_if_table_exists('resource_type_policy');
+    CALL delete_if_table_exists('resource');
+    CALL delete_if_table_exists('authority_enrollment_token');
+    CALL delete_if_table_exists('authority_member');
+    CALL delete_if_table_exists('secure_channel');
+    CALL delete_if_table_exists('identity_enrollment');
+    CALL delete_if_table_exists('identity_attributes');
+    CALL delete_if_table_exists('purpose_key');
+    CALL delete_if_table_exists('credential');
+    CALL delete_if_table_exists('named_identity');
+    CALL delete_if_table_exists('identity');
+    CALL delete_if_table_exists('tcp_inlet');
+    CALL delete_if_table_exists('tcp_outlet_status');
+    CALL delete_if_table_exists('node');
+    CALL delete_if_table_exists('vault');
+    CALL delete_if_table_exists('signing_secret');
+    CALL delete_if_table_exists('x25519_secret');
+    CALL delete_if_table_exists('aead_secret');
+    CALL delete_if_table_exists('okta_config');
+    CALL delete_if_table_exists('kafka_config');
+END;
+$$;

--- a/implementations/rust/ockam/ockam_node/src/storage/database/sqlx_database.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/sqlx_database.rs
@@ -450,19 +450,29 @@ PRAGMA busy_timeout = 10000;
         match self.configuration.database_type() {
             DatabaseType::Sqlite => Ok(()),
             DatabaseType::Postgres => {
-                sqlx::query(
-                    format!(r#"DO $$
-                   DECLARE
-                       r RECORD;
-                   BEGIN
-                       FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public' {}) LOOP
-                           EXECUTE '{} TABLE ' || quote_ident(r.tablename) || ' CASCADE';
-                       END LOOP;
-                   END $$;"#, filter.unwrap_or(""), clean.as_str(),
-                    ).as_str())
-                    .execute(&*self.pool)
-                    .await
-                    .void()
+                match clean {
+                    Clean::Drop => {
+                        sqlx::query(
+                            format!(r#"DO $$
+                                       DECLARE
+                                           r RECORD;
+                                       BEGIN
+                                           FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public' {}) LOOP
+                                               EXECUTE 'DROP TABLE ' || quote_ident(r.tablename) || ' CASCADE';
+                                           END LOOP;
+                                       END $$;"#, filter.unwrap_or(""),
+                            ).as_str())
+                            .execute(&*self.pool)
+                            .await
+                            .void()
+
+                    },
+                    Clean::Truncate => {
+                        sqlx::query("CALL delete_tenant_tables();").execute(&*self.pool)
+                            .await
+                            .void()
+                    }
+                }
             }
         }
     }
@@ -471,15 +481,6 @@ PRAGMA busy_timeout = 10000;
 enum Clean {
     Drop,
     Truncate,
-}
-
-impl Clean {
-    fn as_str(&self) -> &str {
-        match self {
-            Clean::Drop => "DROP",
-            Clean::Truncate => "TRUNCATE",
-        }
-    }
 }
 
 /// This function can be used to run some test code with the 2 SQLite databases implementations
@@ -660,10 +661,8 @@ pub mod tests {
     #[tokio::test]
     async fn test_create_postgres_database() -> Result<()> {
         if let Some(configuration) = DatabaseConfiguration::postgres()? {
-            let db = SqlxDatabase::create_no_migration(&configuration).await?;
-            db.drop_all_postgres_tables().await?;
-
             let db = SqlxDatabase::create(&configuration).await?;
+            db.truncate_all_postgres_tables().await?;
             let inserted = insert_identity(&db).await.unwrap();
             assert_eq!(inserted.rows_affected(), 1);
         }
@@ -778,6 +777,19 @@ pub mod tests {
         );
         assert_eq!(alice_nodes, vec!["node-alice".to_string()]);
         assert_eq!(bob_nodes, vec!["node-bob".to_string()]);
+
+        // Now delete the data but only for alice
+        alice_database.truncate_all_postgres_tables().await?;
+        let admin_nodes = list_nodes(&admin_database).await?;
+        let alice_nodes = list_nodes(&alice_database).await?;
+        let bob_nodes = list_nodes(&bob_database).await?;
+
+        assert_eq!(
+            admin_nodes,
+            vec![format!("node-{admin_user}"), "node-bob".to_string()]
+        );
+        assert!(alice_nodes.is_empty());
+        assert_eq!(bob_nodes, vec!["node-bob".to_string()]);
         Ok(())
     }
 
@@ -803,7 +815,19 @@ pub mod tests {
     }
 
     async fn create_user(db: &SqlxDatabase, user: &str) -> Result<()> {
-        let q = format!("CREATE ROLE {user} with LOGIN PASSWORD '{user}'");
+        let q = format!(
+            r#"
+        DO $$
+           BEGIN
+              IF NOT EXISTS (
+                 SELECT FROM pg_catalog.pg_roles
+                 WHERE rolname = '{user}'
+              ) THEN
+                 CREATE USER {user} WITH PASSWORD '{user}';
+              END IF;
+           END
+        $$;"#
+        );
         query(&q).bind(user).execute(&*db.pool).await.void()?;
 
         let q = format!("GRANT USAGE ON SCHEMA public TO {user}");


### PR DESCRIPTION
Now that the Postgres schema segregates all data by `tenant_id`, the `reset` command can safely delete all the tenant data by calling `DELETE` on each table.