### PR TITLE
refactor: improve cluster repl

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/ui/terminal/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/terminal/mod.rs
@@ -63,6 +63,16 @@ impl<T: TerminalWriter + Debug, W> Terminal<T, W> {
         }
     }
 
+    pub fn flush(&self) -> Result<()> {
+        if self.stdout.is_tty() {
+            self.stdout.flush()?;
+        }
+        if self.stderr.is_tty() {
+            self.stderr.flush()?;
+        }
+        Ok(())
+    }
+
     pub fn stdout(&self) -> T {
         self.stdout.clone()
     }
@@ -110,6 +120,7 @@ pub trait TerminalWriter: Clone {
     fn write(&mut self, s: impl AsRef<str>) -> Result<()>;
     fn rewrite(&mut self, s: impl AsRef<str>) -> Result<()>;
     fn write_line(&self, s: impl AsRef<str>) -> Result<()>;
+    fn flush(&self) -> Result<()>;
 }
 
 // Core functions
@@ -936,6 +947,10 @@ mod test_disabled_behavior {
             let mut this = self.clone();
             std::io::Write::write(&mut this, s.as_ref().as_bytes())?;
             std::io::Write::write(&mut this, b"\n")?;
+            Ok(())
+        }
+
+        fn flush(&self) -> Result<()> {
             Ok(())
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/ui/terminal/term.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/terminal/term.rs
@@ -53,6 +53,11 @@ impl TerminalWriter for TerminalStream<Term> {
         self.writer.write_line(&s)?;
         Ok(())
     }
+
+    fn flush(&self) -> Result<()> {
+        self.writer.flush()?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/implementations/rust/ockam/ockam_command/src/base_command.rs
+++ b/implementations/rust/ockam/ockam_command/src/base_command.rs
@@ -8,16 +8,17 @@ use ockam::transport::SchemeHostnamePort;
 use ockam_api::address::get_free_address;
 use ockam_api::colors::color_primary;
 use ockam_api::orchestrator::ai_platform::node_service_client::AI_API_BASE_URL;
+use ockam_api::terminal::Terminal;
 use ockam_api::{fmt_ok, fmt_separator};
 use ockam_core::env::get_env_ignore_error;
 use ockam_core::TryClone;
 use ockam_node::Context;
-use std::io::{self, Write};
 use std::str::FromStr;
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
+use tracing::debug;
 
 #[derive(Clone, Debug, Args, Default)]
 pub struct BaseCommand {
@@ -245,17 +246,20 @@ impl BaseCommand {
 
                 // 2: Try to read initial message
                 match Self::process_server_response(
+                    &opts,
                     &mut reader,
                     &mut read_header_buffer,
                     &mut read_body_buffer,
-                    &opts,
                 )
                 .await
                 {
                     Ok(()) => {
                         // Successfully got initial message, continue to REPL
                     }
-                    Err(_) => {
+                    Err(e) => {
+                        debug!("Failed to read from server: {:?}", e);
+                        opts.terminal
+                            .write_line("Failed to read from server. Reconnecting...")?;
                         sleep(Duration::from_secs(1)).await;
                         continue 'repl;
                     }
@@ -263,10 +267,7 @@ impl BaseCommand {
 
                 // 3: Start the REPL loop for this connection
                 'connection: loop {
-                    io::stdout()
-                        .flush()
-                        .into_diagnostic()
-                        .wrap_err("Failed to flush stdout")?;
+                    Terminal::flush(&opts.terminal)?;
 
                     // Get user input
                     let user_input = match stdin_rx.recv().await {
@@ -286,22 +287,26 @@ impl BaseCommand {
                     }
 
                     // Send input to server
-                    if let Err(_e) = writer.write_all(user_input.as_bytes()).await {
-                        println!("Failed to write to server. Reconnecting...");
+                    if let Err(e) = writer.write_all(user_input.as_bytes()).await {
+                        debug!("Failed to write to server: {:?}", e);
+                        opts.terminal
+                            .write_line("Failed to write to server. Reconnecting...")?;
                         break 'connection;
                     }
                     let _ = writer.flush().await;
 
                     // Wait for server response and print it
-                    if let Err(err) = Self::process_server_response(
+                    if let Err(e) = Self::process_server_response(
+                        &opts,
                         &mut reader,
                         &mut read_header_buffer,
                         &mut read_body_buffer,
-                        &opts,
                     )
                     .await
                     {
-                        println!("Failed to read from server: {}", err);
+                        debug!("Failed to read from server: {:?}", e);
+                        opts.terminal
+                            .write_line("Failed to read from server. Reconnecting...")?;
                         break 'connection;
                     }
                 }
@@ -326,12 +331,13 @@ impl BaseCommand {
     }
 
     async fn process_server_response(
+        opts: &CommandGlobalOpts,
         reader: &mut BufReader<tokio::net::tcp::OwnedReadHalf>,
         read_header_buffer: &mut String,
         read_body_buffer: &mut Vec<u8>,
-        opts: &CommandGlobalOpts,
     ) -> miette::Result<()> {
         match Self::print_server_response(
+            opts,
             reader,
             read_header_buffer,
             read_body_buffer,
@@ -339,15 +345,9 @@ impl BaseCommand {
         )
         .await?
         {
-            ReadStatus::ConnectionClosed => {
-                println!("\nServer connection closed. Reconnecting...");
-                Err(miette!("Server connection closed"))
-            }
+            ReadStatus::ConnectionClosed => Err(miette!("Server connection closed")),
             ReadStatus::Success => Ok(()),
-            ReadStatus::IoError(e) => {
-                println!("\nError reading from server: {}", e);
-                Err(miette!("Error reading from server: {}", e))
-            }
+            ReadStatus::IoError(e) => Err(miette!(e).wrap_err("Error reading from server")),
             ReadStatus::Timeout => {
                 // Short timeout reached, notify but keep waiting
                 let spinner = opts.terminal.spinner();
@@ -357,6 +357,7 @@ impl BaseCommand {
 
                 // Continue with longer timeout
                 let res = Self::print_server_response(
+                    opts,
                     reader,
                     read_header_buffer,
                     read_body_buffer,
@@ -369,25 +370,17 @@ impl BaseCommand {
                 }
 
                 match res? {
-                    ReadStatus::ConnectionClosed => {
-                        println!("\nServer connection closed. Reconnecting...");
-                        Err(miette!("Server connection closed"))
-                    }
+                    ReadStatus::ConnectionClosed => Err(miette!("Server connection closed")),
                     ReadStatus::Success => Ok(()),
-                    ReadStatus::IoError(e) => {
-                        println!("\nError reading from server: {}", e);
-                        Err(miette!("Error reading from server: {}", e))
-                    }
-                    ReadStatus::Timeout => {
-                        println!("\nServer response timeout. Reconnecting...");
-                        Err(miette!("Server response timeout"))
-                    }
+                    ReadStatus::IoError(e) => Err(miette!(e).wrap_err("Error reading from server")),
+                    ReadStatus::Timeout => Err(miette!("Server response timeout")),
                 }
             }
         }
     }
 
     async fn print_server_response(
+        opts: &CommandGlobalOpts,
         reader: &mut BufReader<tokio::net::tcp::OwnedReadHalf>,
         read_header_buffer: &mut String,
         read_body_buffer: &mut Vec<u8>,
@@ -414,8 +407,7 @@ impl BaseCommand {
                     .await
                     .into_diagnostic()?;
                 let body = String::from_utf8_lossy(read_body_buffer).into_owned();
-                print!("{}", body);
-                io::stdout().flush().into_diagnostic()?;
+                opts.terminal.write(&body)?;
                 Ok(ReadStatus::Success)
             }
             Ok(Err(e)) => Ok(ReadStatus::IoError(e)),
@@ -434,7 +426,7 @@ enum ReadStatus {
     ConnectionClosed,
 
     /// Error occurred during reading
-    IoError(io::Error),
+    IoError(std::io::Error),
 
     /// Initial read operation timed out
     Timeout,

--- a/implementations/rust/ockam/ockam_command/src/base_command.rs
+++ b/implementations/rust/ockam/ockam_command/src/base_command.rs
@@ -5,14 +5,19 @@ use clap::Args;
 use colorful::Colorful;
 use miette::{miette, IntoDiagnostic, WrapErr};
 use ockam::transport::SchemeHostnamePort;
+use ockam_api::address::get_free_address;
 use ockam_api::colors::color_primary;
 use ockam_api::orchestrator::ai_platform::node_service_client::AI_API_BASE_URL;
 use ockam_api::{fmt_ok, fmt_separator};
 use ockam_core::env::get_env_ignore_error;
 use ockam_core::TryClone;
 use ockam_node::Context;
+use std::io::{self, Write};
 use std::str::FromStr;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::task::JoinHandle;
+use tokio::time::timeout;
 
 #[derive(Clone, Debug, Args, Default)]
 pub struct BaseCommand {
@@ -28,7 +33,10 @@ impl BaseCommand {
     async fn parse_args(mut self, _opts: &CommandGlobalOpts) -> Result<Self> {
         // load default values
         self.init_repository = "hello".to_string();
-        self.inlet_address = SchemeHostnamePort::from_str("127.0.0.1:31234")?;
+        self.inlet_address = {
+            let address = get_free_address()?;
+            SchemeHostnamePort::from_str(&address.to_string())?
+        };
 
         // load env vars
         if let Some(v) = get_env_ignore_error("INIT_REPOSITORY") {
@@ -47,6 +55,7 @@ impl BaseCommand {
         cmd.cluster_init(ctx, &opts).await?;
         let zone_config = cmd.cluster_create(ctx, &opts).await?;
         let inlet_handle = cmd.cluster_inlet(ctx, &opts, &zone_config).await?;
+        // let inlet_handle = cmd.dummy_inlet(&opts).await?;
         opts.terminal.write_line(fmt_separator!())?;
         cmd.open_repl(ctx, &opts, inlet_handle).await?;
         Ok(())
@@ -169,15 +178,12 @@ impl BaseCommand {
         opts: &CommandGlobalOpts,
         inlet_handle: JoinHandle<Result<()>>,
     ) -> miette::Result<()> {
-        use std::io::{self, Write};
-        use std::time::Duration;
-        use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
         use tokio::net::TcpStream;
         use tokio::time::{sleep, timeout};
 
         // Inlet monitor future
         let (inlet_tx, inlet_rx) = tokio::sync::oneshot::channel::<()>();
-        let _inlet_monitor = async move {
+        let _inlet_monitor = tokio::spawn(async move {
             match inlet_handle.await {
                 Ok(result) => result,
                 Err(err) => {
@@ -185,70 +191,78 @@ impl BaseCommand {
                     Err(miette!("{err:?}"))
                 }
             }
+        });
+
+        // Buffers
+        let stdin = StdinHandler::start();
+
+        // stdin quit handler
+        let mut stdin_rx = stdin.tx.subscribe();
+        let stdin_quit = async {
+            loop {
+                if let Ok(input) = stdin_rx.recv().await {
+                    if is_quit_sequence(&input) {
+                        break;
+                    }
+                }
+            }
         };
 
-        async fn connect_to_inlet(addr: &SchemeHostnamePort) -> miette::Result<TcpStream> {
-            const MAX_RETRIES: u32 = 120; // Try for about 60 seconds (120 * 500ms)
-            let mut retries = 0;
+        // Start the interactive REPL
+        let opts = opts.clone();
+        let inlet_address = self.inlet_address.clone();
+        let mut stdin_rx = stdin.tx.subscribe();
+        let repl_handle = tokio::spawn(async move {
+            async fn connect_to_inlet(addr: &SchemeHostnamePort) -> miette::Result<TcpStream> {
+                const MAX_RETRIES: u32 = 120; // Try for about 60 seconds (120 * 500ms)
+                let mut retries = 0;
 
-            while retries < MAX_RETRIES {
-                match TcpStream::connect(addr.hostname_port().to_string()).await {
-                    Ok(s) => return Ok(s),
-                    Err(_) => {
-                        retries += 1;
-                        sleep(Duration::from_millis(500)).await;
+                while retries < MAX_RETRIES {
+                    match TcpStream::connect(addr.hostname_port().to_string()).await {
+                        Ok(s) => return Ok(s),
+                        Err(_) => {
+                            retries += 1;
+                            sleep(Duration::from_millis(500)).await;
+                        }
                     }
                 }
+                Err(miette!("Failed to connect to the TCP Inlet"))
             }
-            Err(miette!("Failed to connect to the TCP Inlet"))
-        }
 
-        async fn read_initial_message(
-            reader: &mut tokio::net::tcp::OwnedReadHalf,
-        ) -> miette::Result<bool> {
-            let mut welcome_buf = Vec::new();
-            let mut tmp_buf = [0u8; 1024];
+            async fn read_initial_message(
+                reader: &mut tokio::net::tcp::OwnedReadHalf,
+                read_buffer: &mut [u8],
+            ) -> miette::Result<bool> {
+                match timeout(Duration::from_secs(5), async {
+                    loop {
+                        match reader.read(read_buffer).await {
+                            Ok(0) => break,
+                            Ok(n) => {
+                                let chunk = String::from_utf8_lossy(&read_buffer[..n]).into_owned();
+                                print!("{}", chunk);
+                                io::stdout().flush().into_diagnostic()?;
 
-            match timeout(Duration::from_secs(5), async {
-                loop {
-                    match reader.read(&mut tmp_buf).await {
-                        Ok(0) => break,
-                        Ok(n) => {
-                            welcome_buf.extend_from_slice(&tmp_buf[..n]);
-                            // Check if we've received a complete message
-                            if n < 1024 {
-                                break;
+                                // Exit if we received a partial buffer (n < buffer size)
+                                if n < read_buffer.len() {
+                                    break;
+                                }
+                            }
+                            Err(e) => {
+                                return Err(miette!("Error reading from server: {}", e));
                             }
                         }
-                        Err(_) => break,
                     }
+                    Ok::<(), miette::Error>(())
+                })
+                .await
+                {
+                    Ok(Ok(())) => Ok(true),
+                    Ok(Err(e)) => Err(e),
+                    Err(_) => Ok(false), // Timeout occurred
                 }
-            })
-            .await
-            {
-                Ok(_) => {
-                    if !welcome_buf.is_empty() {
-                        if let Ok(msg) = String::from_utf8(welcome_buf) {
-                            print!("{}", msg);
-                            io::stdout().flush().into_diagnostic()?;
-                            return Ok(true);
-                        }
-                    }
-                    Ok(false)
-                }
-                Err(_) => Ok(false), // Timeout occurred
             }
-        }
 
-        let (quit_tx, mut quit_rx) = tokio::sync::oneshot::channel();
-        let opts = opts.clone();
-
-        // Start the interactive REPL
-        let inlet_address = self.inlet_address.clone();
-        let repl_handle = tokio::spawn(async move {
-            let mut stdin = BufReader::new(tokio::io::stdin());
-            let mut string_buffer = String::new();
-            let mut byte_buffer = [0u8; 1024];
+            let mut read_buffer = [0u8; 1024];
 
             'repl: loop {
                 // 1: Try to connect to the inlet
@@ -263,7 +277,7 @@ impl BaseCommand {
                 let (mut reader, mut writer) = stream.into_split();
 
                 // 2: Try to read initial message
-                match read_initial_message(&mut reader).await {
+                match read_initial_message(&mut reader, &mut read_buffer).await {
                     Ok(true) => {
                         // Successfully got initial message, continue to REPL
                     }
@@ -281,86 +295,34 @@ impl BaseCommand {
                         .wrap_err("Failed to flush stdout")?;
 
                     // Get user input
-                    string_buffer.clear();
-                    if stdin
-                        .read_line(&mut string_buffer)
-                        .await
-                        .into_diagnostic()?
-                        == 0
-                    {
-                        // EOF reached
-                        break 'repl;
-                    }
+                    let user_input = match stdin_rx.recv().await {
+                        Ok(i) => i,
+                        Err(_) => {
+                            // stdin channel closed, exit REPL
+                            break 'repl;
+                        }
+                    };
 
-                    let input = string_buffer.trim();
-
-                    // 4: Check for quit commands
-                    if input == ":quit" || input == ":q" {
-                        let _ = quit_tx.send(());
-                        break 'repl;
-                    }
-
-                    if input.is_empty() {
+                    if user_input.is_empty() {
                         continue 'connection;
                     }
 
-                    // 5: Send command to server
-                    if let Err(_e) = writer.write_all(string_buffer.as_bytes()).await {
+                    if is_quit_sequence(&user_input) {
+                        break 'repl;
+                    }
+
+                    // Send input to server
+                    if let Err(_e) = writer.write_all(user_input.as_bytes()).await {
                         println!("Failed to write to server. Reconnecting...");
                         break 'connection;
                     }
 
-                    // Wait for response with timeout
-                    match timeout(Duration::from_secs(30), reader.read(&mut byte_buffer)).await {
-                        Ok(Ok(0)) => {
-                            // Connection closed
-                            println!("\nServer connection closed. Reconnecting...");
-                            break 'connection;
-                        }
-                        Ok(Ok(n)) => {
-                            if let Ok(s) = std::str::from_utf8(&byte_buffer[..n]) {
-                                print!("{}", s);
-                                io::stdout().flush().into_diagnostic()?;
-                            }
-                        }
-                        Ok(Err(e)) => {
-                            println!("\nError reading from server: {}", e);
-                            break 'connection;
-                        }
-                        Err(_) => {
-                            // Short timeout reached, notify but keep waiting
-                            let spinner = opts.terminal.spinner();
-                            if let Some(spinner) = &spinner {
-                                spinner.set_message("Waiting for server response...");
-                            }
-                            // Continue with longer timeout
-                            let res =
-                                timeout(Duration::from_secs(5 * 60), reader.read(&mut byte_buffer))
-                                    .await;
-                            if let Some(spinner) = &spinner {
-                                spinner.finish_and_clear();
-                            }
-                            match res {
-                                Ok(Ok(0)) => {
-                                    println!("\nServer connection closed. Reconnecting...");
-                                    break 'connection;
-                                }
-                                Ok(Ok(n)) => {
-                                    if let Ok(s) = std::str::from_utf8(&byte_buffer[..n]) {
-                                        print!("{}", s);
-                                        io::stdout().flush().into_diagnostic()?;
-                                    }
-                                }
-                                Ok(Err(e)) => {
-                                    println!("\nError reading from server: {}", e);
-                                    break 'connection;
-                                }
-                                Err(_) => {
-                                    println!("\nServer response timeout. Reconnecting...");
-                                    break 'connection;
-                                }
-                            }
-                        }
+                    // Process response with streaming output
+                    if Self::process_server_response(&mut reader, &mut read_buffer, &opts)
+                        .await
+                        .is_err()
+                    {
+                        break 'connection;
                     }
                 }
 
@@ -373,7 +335,7 @@ impl BaseCommand {
 
         // Wait for exit signals
         tokio::select! {
-            _ = &mut quit_rx => {},
+            _ = stdin_quit => {},
             _result = inlet_rx => {},
         }
 
@@ -382,4 +344,260 @@ impl BaseCommand {
 
         Ok(())
     }
+
+    async fn process_server_response(
+        reader: &mut tokio::net::tcp::OwnedReadHalf,
+        read_buffer: &mut [u8],
+        opts: &CommandGlobalOpts,
+    ) -> miette::Result<()> {
+        match Self::print_server_response(reader, read_buffer, Duration::from_secs(30)).await? {
+            ReadStatus::ConnectionClosed => {
+                println!("\nServer connection closed. Reconnecting...");
+                Err(miette!("Server connection closed"))
+            }
+            ReadStatus::Success => Ok(()),
+            ReadStatus::IoError(e) => {
+                println!("\nError reading from server: {}", e);
+                Err(miette!("Error reading from server: {}", e))
+            }
+            ReadStatus::Timeout => {
+                // Short timeout reached, notify but keep waiting
+                let spinner = opts.terminal.spinner();
+                if let Some(spinner) = &spinner {
+                    spinner.set_message("Waiting for server response...");
+                }
+
+                // Continue with longer timeout
+                let res =
+                    Self::print_server_response(reader, read_buffer, Duration::from_secs(5 * 60))
+                        .await;
+
+                if let Some(spinner) = &spinner {
+                    spinner.finish_and_clear();
+                }
+
+                match res? {
+                    ReadStatus::ConnectionClosed => {
+                        println!("\nServer connection closed. Reconnecting...");
+                        Err(miette!("Server connection closed"))
+                    }
+                    ReadStatus::Success => Ok(()),
+                    ReadStatus::IoError(e) => {
+                        println!("\nError reading from server: {}", e);
+                        Err(miette!("Error reading from server: {}", e))
+                    }
+                    ReadStatus::Timeout => {
+                        println!("\nServer response timeout. Reconnecting...");
+                        Err(miette!("Server response timeout"))
+                    }
+                }
+            }
+        }
+    }
+
+    async fn print_server_response(
+        reader: &mut tokio::net::tcp::OwnedReadHalf,
+        read_buffer: &mut [u8],
+        timeout_duration: Duration,
+    ) -> Result<ReadStatus> {
+        // Use timeout only for the initial read
+        Ok(
+            match timeout(timeout_duration, reader.read(read_buffer)).await {
+                Ok(Ok(0)) => ReadStatus::ConnectionClosed,
+                Ok(Ok(n)) => {
+                    // Process the first chunk
+                    let chunk = String::from_utf8_lossy(&read_buffer[0..n]).into_owned();
+                    print!("{}", chunk);
+                    io::stdout().flush().into_diagnostic()?;
+
+                    if !is_server_end_sequence(&chunk) {
+                        // Read more data
+                        loop {
+                            match reader.read(read_buffer).await {
+                                Ok(0) => return Ok(ReadStatus::ConnectionClosed),
+                                Ok(n) => {
+                                    let chunk =
+                                        String::from_utf8_lossy(&read_buffer[0..n]).into_owned();
+                                    print!("{}", chunk);
+                                    io::stdout().flush().into_diagnostic()?;
+                                    // Check for end sequence
+                                    if is_server_end_sequence(&chunk) {
+                                        break;
+                                    }
+                                }
+                                Err(e) => return Ok(ReadStatus::IoError(e)),
+                            }
+                        }
+                    }
+
+                    ReadStatus::Success
+                }
+                Ok(Err(e)) => ReadStatus::IoError(e),
+                Err(_) => ReadStatus::Timeout,
+            },
+        )
+    }
+
+    #[allow(dead_code)]
+    async fn dummy_inlet(
+        &self,
+        opts: &CommandGlobalOpts,
+    ) -> miette::Result<JoinHandle<Result<()>>> {
+        use tokio::net::TcpListener;
+
+        let spinner = opts.terminal.spinner();
+        if let Some(spinner) = &spinner {
+            spinner.set_message(format!(
+                "Starting dummy echo inlet on {}...",
+                color_primary(&self.inlet_address)
+            ));
+        }
+
+        // Start a TCP server that echoes back any input
+        let addr = self.inlet_address.hostname_port().to_string();
+        let inlet_handle = tokio::spawn(async move {
+            // Create TCP listener
+            let listener = TcpListener::bind(&addr)
+                .await
+                .into_diagnostic()
+                .wrap_err(format!("Failed to bind to {}", addr))?;
+
+            loop {
+                // Accept connections
+                let (socket, _) = listener
+                    .accept()
+                    .await
+                    .into_diagnostic()
+                    .wrap_err("Failed to accept connection")?;
+
+                // Handle each connection in a separate task
+                tokio::spawn(async move {
+                    if let Err(err) = Self::handle_connection(socket).await {
+                        eprintln!("Connection error: {:?}", err);
+                    }
+                });
+            }
+        });
+
+        if let Some(spinner) = &spinner {
+            spinner.finish_and_clear();
+        }
+        opts.terminal.write_line(fmt_ok!(
+            "Dummy echo inlet started on {}",
+            color_primary(&self.inlet_address)
+        ))?;
+
+        Ok(inlet_handle)
+    }
+
+    // Helper function to handle individual connections
+    #[allow(dead_code)]
+    async fn handle_connection(mut socket: tokio::net::TcpStream) -> miette::Result<()> {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        // Send welcome message
+        let welcome =
+            "Welcome to the dummy echo inlet. Type anything and it will be echoed back.\n";
+        socket
+            .write_all(welcome.as_bytes())
+            .await
+            .into_diagnostic()?;
+
+        let mut buffer = [0; 8192];
+
+        // Read from socket in a loop
+        loop {
+            // Read data from socket
+            let n = match socket.read(&mut buffer).await {
+                Ok(0) => return Ok(()), // Connection closed
+                Ok(n) => n,
+                Err(e) => return Err(miette!("Failed to read from socket: {}", e)),
+            };
+
+            // Echo data back prefixed with "Echo: "
+            let received = String::from_utf8_lossy(&buffer[..n]);
+            let response = format!("Echo: {}\n", received.trim_end());
+
+            // Write response back to client
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .into_diagnostic()
+                .wrap_err("Failed to write to socket")?;
+        }
+    }
+}
+
+/// Models the possible outcomes when reading server responses
+#[derive(Debug)]
+enum ReadStatus {
+    /// Successfully read data
+    Success,
+
+    /// Server connection was closed
+    ConnectionClosed,
+
+    /// Error occurred during reading
+    IoError(io::Error),
+
+    /// Initial read operation timed out
+    Timeout,
+}
+
+struct StdinHandler {}
+
+struct StdinHandle {
+    tx: tokio::sync::broadcast::Sender<String>,
+}
+
+impl StdinHandler {
+    fn start() -> StdinHandle {
+        let (tx, _) = tokio::sync::broadcast::channel(64);
+        let returned_tx = tx.clone();
+
+        // Spawn a task to read from stdin
+        tokio::spawn(async move {
+            let mut stdin = tokio::io::stdin();
+            let mut read_buffer = [0u8; 1024];
+            let mut accumulated_input = Vec::new();
+
+            loop {
+                match stdin.read(&mut read_buffer).await {
+                    Ok(0) => break, // EOF (0 bytes read)
+                    Ok(n) => {
+                        // Append the new input to our accumulated buffer
+                        accumulated_input.extend_from_slice(&read_buffer[..n]);
+
+                        // Send the data if the input ends with a newline - TODO: doesn't support multiline input
+                        if accumulated_input.ends_with(b"\n") {
+                            let input = String::from_utf8_lossy(&accumulated_input).into_owned();
+                            if is_quit_sequence(&input) {
+                                let _ = tx.send(input);
+                                drop(tx);
+                                break;
+                            }
+                            let _ = tx.send(input);
+                            // Clear the accumulated input after processing
+                            accumulated_input.clear();
+                        }
+                        // If the message length is greater or equal than the buffer sie, continue accumulating
+                    }
+                    Err(e) => {
+                        eprintln!("Error reading from stdin: {}", e);
+                        break;
+                    }
+                }
+            }
+        });
+
+        StdinHandle { tx: returned_tx }
+    }
+}
+
+fn is_quit_sequence(input: &str) -> bool {
+    input.trim() == ":quit" || input.trim() == ":q"
+}
+
+fn is_server_end_sequence(input: &str) -> bool {
+    input.ends_with("\n\n> ")
 }

--- a/implementations/rust/ockam/ockam_command/src/base_command.rs
+++ b/implementations/rust/ockam/ockam_command/src/base_command.rs
@@ -15,7 +15,7 @@ use ockam_node::Context;
 use std::io::{self, Write};
 use std::str::FromStr;
 use std::time::Duration;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
 
@@ -179,7 +179,7 @@ impl BaseCommand {
         inlet_handle: JoinHandle<Result<()>>,
     ) -> miette::Result<()> {
         use tokio::net::TcpStream;
-        use tokio::time::{sleep, timeout};
+        use tokio::time::sleep;
 
         // Inlet monitor future
         let (inlet_tx, inlet_rx) = tokio::sync::oneshot::channel::<()>();
@@ -193,10 +193,8 @@ impl BaseCommand {
             }
         });
 
-        // Buffers
-        let stdin = StdinHandler::start();
-
         // stdin quit handler
+        let stdin = StdinHandler::start();
         let mut stdin_rx = stdin.tx.subscribe();
         let stdin_quit = async {
             loop {
@@ -229,40 +227,8 @@ impl BaseCommand {
                 Err(miette!("Failed to connect to the TCP Inlet"))
             }
 
-            async fn read_initial_message(
-                reader: &mut tokio::net::tcp::OwnedReadHalf,
-                read_buffer: &mut [u8],
-            ) -> miette::Result<bool> {
-                match timeout(Duration::from_secs(5), async {
-                    loop {
-                        match reader.read(read_buffer).await {
-                            Ok(0) => break,
-                            Ok(n) => {
-                                let chunk = String::from_utf8_lossy(&read_buffer[..n]).into_owned();
-                                print!("{}", chunk);
-                                io::stdout().flush().into_diagnostic()?;
-
-                                // Exit if we received a partial buffer (n < buffer size)
-                                if n < read_buffer.len() {
-                                    break;
-                                }
-                            }
-                            Err(e) => {
-                                return Err(miette!("Error reading from server: {}", e));
-                            }
-                        }
-                    }
-                    Ok::<(), miette::Error>(())
-                })
-                .await
-                {
-                    Ok(Ok(())) => Ok(true),
-                    Ok(Err(e)) => Err(e),
-                    Err(_) => Ok(false), // Timeout occurred
-                }
-            }
-
-            let mut read_buffer = [0u8; 1024];
+            let mut read_header_buffer = String::new();
+            let mut read_body_buffer = Vec::new();
 
             'repl: loop {
                 // 1: Try to connect to the inlet
@@ -274,14 +240,22 @@ impl BaseCommand {
                     }
                 };
 
-                let (mut reader, mut writer) = stream.into_split();
+                let (reader, mut writer) = stream.into_split();
+                let mut reader = BufReader::new(reader);
 
                 // 2: Try to read initial message
-                match read_initial_message(&mut reader, &mut read_buffer).await {
-                    Ok(true) => {
+                match Self::process_server_response(
+                    &mut reader,
+                    &mut read_header_buffer,
+                    &mut read_body_buffer,
+                    &opts,
+                )
+                .await
+                {
+                    Ok(()) => {
                         // Successfully got initial message, continue to REPL
                     }
-                    _ => {
+                    Err(_) => {
                         sleep(Duration::from_secs(1)).await;
                         continue 'repl;
                     }
@@ -316,12 +290,18 @@ impl BaseCommand {
                         println!("Failed to write to server. Reconnecting...");
                         break 'connection;
                     }
+                    let _ = writer.flush().await;
 
-                    // Process response with streaming output
-                    if Self::process_server_response(&mut reader, &mut read_buffer, &opts)
-                        .await
-                        .is_err()
+                    // Wait for server response and print it
+                    if let Err(err) = Self::process_server_response(
+                        &mut reader,
+                        &mut read_header_buffer,
+                        &mut read_body_buffer,
+                        &opts,
+                    )
+                    .await
                     {
+                        println!("Failed to read from server: {}", err);
                         break 'connection;
                     }
                 }
@@ -346,11 +326,19 @@ impl BaseCommand {
     }
 
     async fn process_server_response(
-        reader: &mut tokio::net::tcp::OwnedReadHalf,
-        read_buffer: &mut [u8],
+        reader: &mut BufReader<tokio::net::tcp::OwnedReadHalf>,
+        read_header_buffer: &mut String,
+        read_body_buffer: &mut Vec<u8>,
         opts: &CommandGlobalOpts,
     ) -> miette::Result<()> {
-        match Self::print_server_response(reader, read_buffer, Duration::from_secs(30)).await? {
+        match Self::print_server_response(
+            reader,
+            read_header_buffer,
+            read_body_buffer,
+            Duration::from_secs(30),
+        )
+        .await?
+        {
             ReadStatus::ConnectionClosed => {
                 println!("\nServer connection closed. Reconnecting...");
                 Err(miette!("Server connection closed"))
@@ -368,9 +356,13 @@ impl BaseCommand {
                 }
 
                 // Continue with longer timeout
-                let res =
-                    Self::print_server_response(reader, read_buffer, Duration::from_secs(5 * 60))
-                        .await;
+                let res = Self::print_server_response(
+                    reader,
+                    read_header_buffer,
+                    read_body_buffer,
+                    Duration::from_secs(5 * 60),
+                )
+                .await;
 
                 if let Some(spinner) = &spinner {
                     spinner.finish_and_clear();
@@ -396,134 +388,38 @@ impl BaseCommand {
     }
 
     async fn print_server_response(
-        reader: &mut tokio::net::tcp::OwnedReadHalf,
-        read_buffer: &mut [u8],
+        reader: &mut BufReader<tokio::net::tcp::OwnedReadHalf>,
+        read_header_buffer: &mut String,
+        read_body_buffer: &mut Vec<u8>,
         timeout_duration: Duration,
     ) -> Result<ReadStatus> {
-        // Use timeout only for the initial read
-        Ok(
-            match timeout(timeout_duration, reader.read(read_buffer)).await {
-                Ok(Ok(0)) => ReadStatus::ConnectionClosed,
-                Ok(Ok(n)) => {
-                    // Process the first chunk
-                    let chunk = String::from_utf8_lossy(&read_buffer[0..n]).into_owned();
-                    print!("{}", chunk);
-                    io::stdout().flush().into_diagnostic()?;
-
-                    if !is_server_end_sequence(&chunk) {
-                        // Read more data
-                        loop {
-                            match reader.read(read_buffer).await {
-                                Ok(0) => return Ok(ReadStatus::ConnectionClosed),
-                                Ok(n) => {
-                                    let chunk =
-                                        String::from_utf8_lossy(&read_buffer[0..n]).into_owned();
-                                    print!("{}", chunk);
-                                    io::stdout().flush().into_diagnostic()?;
-                                    // Check for end sequence
-                                    if is_server_end_sequence(&chunk) {
-                                        break;
-                                    }
-                                }
-                                Err(e) => return Ok(ReadStatus::IoError(e)),
-                            }
-                        }
-                    }
-
-                    ReadStatus::Success
-                }
-                Ok(Err(e)) => ReadStatus::IoError(e),
-                Err(_) => ReadStatus::Timeout,
-            },
-        )
-    }
-
-    #[allow(dead_code)]
-    async fn dummy_inlet(
-        &self,
-        opts: &CommandGlobalOpts,
-    ) -> miette::Result<JoinHandle<Result<()>>> {
-        use tokio::net::TcpListener;
-
-        let spinner = opts.terminal.spinner();
-        if let Some(spinner) = &spinner {
-            spinner.set_message(format!(
-                "Starting dummy echo inlet on {}...",
-                color_primary(&self.inlet_address)
-            ));
-        }
-
-        // Start a TCP server that echoes back any input
-        let addr = self.inlet_address.hostname_port().to_string();
-        let inlet_handle = tokio::spawn(async move {
-            // Create TCP listener
-            let listener = TcpListener::bind(&addr)
-                .await
-                .into_diagnostic()
-                .wrap_err(format!("Failed to bind to {}", addr))?;
-
-            loop {
-                // Accept connections
-                let (socket, _) = listener
-                    .accept()
-                    .await
+        // Use timeout only for the header read
+        read_header_buffer.clear();
+        match timeout(timeout_duration, reader.read_line(read_header_buffer)).await {
+            Ok(Ok(0)) => Ok(ReadStatus::ConnectionClosed),
+            Ok(Ok(_n)) => {
+                // Process the header as a line containing the body length
+                let body_len: usize = read_header_buffer
+                    .trim()
+                    .parse()
                     .into_diagnostic()
-                    .wrap_err("Failed to accept connection")?;
+                    .wrap_err(format!(
+                        "Failed to parse header line as an integer: {read_header_buffer}"
+                    ))?;
 
-                // Handle each connection in a separate task
-                tokio::spawn(async move {
-                    if let Err(err) = Self::handle_connection(socket).await {
-                        eprintln!("Connection error: {:?}", err);
-                    }
-                });
+                // Process the body
+                read_body_buffer.resize(body_len, 0);
+                reader
+                    .read_exact(read_body_buffer)
+                    .await
+                    .into_diagnostic()?;
+                let body = String::from_utf8_lossy(read_body_buffer).into_owned();
+                print!("{}", body);
+                io::stdout().flush().into_diagnostic()?;
+                Ok(ReadStatus::Success)
             }
-        });
-
-        if let Some(spinner) = &spinner {
-            spinner.finish_and_clear();
-        }
-        opts.terminal.write_line(fmt_ok!(
-            "Dummy echo inlet started on {}",
-            color_primary(&self.inlet_address)
-        ))?;
-
-        Ok(inlet_handle)
-    }
-
-    // Helper function to handle individual connections
-    #[allow(dead_code)]
-    async fn handle_connection(mut socket: tokio::net::TcpStream) -> miette::Result<()> {
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
-        // Send welcome message
-        let welcome =
-            "Welcome to the dummy echo inlet. Type anything and it will be echoed back.\n";
-        socket
-            .write_all(welcome.as_bytes())
-            .await
-            .into_diagnostic()?;
-
-        let mut buffer = [0; 8192];
-
-        // Read from socket in a loop
-        loop {
-            // Read data from socket
-            let n = match socket.read(&mut buffer).await {
-                Ok(0) => return Ok(()), // Connection closed
-                Ok(n) => n,
-                Err(e) => return Err(miette!("Failed to read from socket: {}", e)),
-            };
-
-            // Echo data back prefixed with "Echo: "
-            let received = String::from_utf8_lossy(&buffer[..n]);
-            let response = format!("Echo: {}\n", received.trim_end());
-
-            // Write response back to client
-            socket
-                .write_all(response.as_bytes())
-                .await
-                .into_diagnostic()
-                .wrap_err("Failed to write to socket")?;
+            Ok(Err(e)) => Ok(ReadStatus::IoError(e)),
+            Err(_) => Ok(ReadStatus::Timeout),
         }
     }
 }
@@ -557,30 +453,20 @@ impl StdinHandler {
 
         // Spawn a task to read from stdin
         tokio::spawn(async move {
-            let mut stdin = tokio::io::stdin();
-            let mut read_buffer = [0u8; 1024];
-            let mut accumulated_input = Vec::new();
+            let mut stdin = BufReader::new(tokio::io::stdin());
+            let mut read_buffer = String::new();
 
             loop {
-                match stdin.read(&mut read_buffer).await {
+                match stdin.read_line(&mut read_buffer).await {
                     Ok(0) => break, // EOF (0 bytes read)
-                    Ok(n) => {
-                        // Append the new input to our accumulated buffer
-                        accumulated_input.extend_from_slice(&read_buffer[..n]);
-
-                        // Send the data if the input ends with a newline - TODO: doesn't support multiline input
-                        if accumulated_input.ends_with(b"\n") {
-                            let input = String::from_utf8_lossy(&accumulated_input).into_owned();
-                            if is_quit_sequence(&input) {
-                                let _ = tx.send(input);
-                                drop(tx);
-                                break;
-                            }
-                            let _ = tx.send(input);
-                            // Clear the accumulated input after processing
-                            accumulated_input.clear();
+                    Ok(_n) => {
+                        if is_quit_sequence(&read_buffer) {
+                            let _ = tx.send(read_buffer.clone());
+                            drop(tx);
+                            break;
                         }
-                        // If the message length is greater or equal than the buffer sie, continue accumulating
+                        let _ = tx.send(read_buffer.clone());
+                        read_buffer.clear();
                     }
                     Err(e) => {
                         eprintln!("Error reading from stdin: {}", e);
@@ -598,6 +484,101 @@ fn is_quit_sequence(input: &str) -> bool {
     input.trim() == ":quit" || input.trim() == ":q"
 }
 
-fn is_server_end_sequence(input: &str) -> bool {
-    input.ends_with("\n\n> ")
+#[allow(dead_code)]
+pub(super) mod dummy_server {
+    use super::*;
+
+    impl BaseCommand {
+        /// Start a TCP server that echoes back any input
+        pub(super) async fn dummy_inlet(
+            &self,
+            opts: &CommandGlobalOpts,
+        ) -> miette::Result<JoinHandle<Result<()>>> {
+            use tokio::net::TcpListener;
+
+            let addr = self.inlet_address.hostname_port().to_string();
+            let inlet_handle = tokio::spawn(async move {
+                let listener = TcpListener::bind(&addr)
+                    .await
+                    .into_diagnostic()
+                    .wrap_err(format!("Failed to bind to {}", addr))?;
+                loop {
+                    let (socket, _) = listener
+                        .accept()
+                        .await
+                        .into_diagnostic()
+                        .wrap_err("Failed to accept connection")?;
+                    tokio::spawn(async move {
+                        if let Err(err) = Self::handle_connection(socket).await {
+                            eprintln!("Connection error: {:?}", err);
+                        }
+                    });
+                }
+            });
+
+            opts.terminal.write_line(fmt_ok!(
+                "Dummy echo inlet started on {}",
+                color_primary(&self.inlet_address)
+            ))?;
+
+            Ok(inlet_handle)
+        }
+
+        async fn handle_connection(socket: tokio::net::TcpStream) -> miette::Result<()> {
+            let (reader, mut writer) = socket.into_split();
+            let mut reader = BufReader::new(reader);
+
+            // Initial message
+            let welcome =
+                "Welcome to the dummy echo inlet. Type anything and it will be echoed back.\n";
+            Self::send_formatted_response(&mut writer, welcome).await?;
+
+            let mut buffer = String::new();
+
+            loop {
+                buffer.clear();
+                match reader.read_line(&mut buffer).await {
+                    Ok(0) => {
+                        return Ok(());
+                    }
+                    Ok(_n) => {}
+                    Err(e) => {
+                        return Err(miette!("Failed to read from socket: {}", e));
+                    }
+                };
+
+                if buffer.trim().is_empty() {
+                    continue;
+                }
+
+                // Echo data back
+                let message = format!("Echo: {}", buffer);
+                Self::send_formatted_response(&mut writer, &message).await?;
+            }
+        }
+
+        async fn send_formatted_response(
+            writer: &mut tokio::net::tcp::OwnedWriteHalf,
+            message: &str,
+        ) -> miette::Result<()> {
+            // First line contains just the length
+            let header = format!("{}\n", message.len());
+            writer
+                .write_all(header.as_bytes())
+                .await
+                .into_diagnostic()
+                .wrap_err("Failed to write header to socket")?;
+            writer
+                .write_all(message.as_bytes())
+                .await
+                .into_diagnostic()
+                .wrap_err("Failed to write message to socket")?;
+            writer
+                .flush()
+                .await
+                .into_diagnostic()
+                .wrap_err("Failed to flush message")?;
+            Ok(())
+        }
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/cluster/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/create.rs
@@ -12,6 +12,7 @@ use ockam_api::orchestrator::ai_platform::api::AiPlatformApi;
 use ockam_api::orchestrator::ai_platform::node_service_client::AI_API_BASE_URL_ENV;
 use ockam_api::orchestrator::ai_platform::responses::EcrCredentials;
 use ockam_api::{fmt_log, fmt_ok};
+use ockam_core::env::get_env_ignore_error;
 use ockam_node::Context;
 use std::process::Stdio;
 use std::sync::Arc;
@@ -38,6 +39,11 @@ pub struct CreateCommand {
     /// Whether to use a public AWS ECR
     #[arg(long)]
     pub use_public_ecr: bool,
+
+    /// Whether to use the Docker cache when building the image.
+    /// It can be set using the `OCKAM_USE_DOCKER_CACHE` environment variable.
+    #[arg(long)]
+    pub use_docker_cache: bool,
 
     // === Specific args for the HTTP API endpoint
     /// The Cluster that will be used to set up the Zone.
@@ -97,7 +103,10 @@ impl InMemoryNodeCommand<ZoneConfig> for CreateNodeCommand {
 impl Command<ZoneConfig> for CreateCommand {
     const NAME: &'static str = "cluster create";
 
-    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<ZoneConfig> {
+    async fn run(mut self, ctx: &Context, opts: CommandGlobalOpts) -> Result<ZoneConfig> {
+        if let Some(v) = get_env_ignore_error::<bool>("OCKAM_USE_DOCKER_CACHE") {
+            self.use_docker_cache = v;
+        }
         let command = CreateNodeCommand {
             opts: opts.clone(),
             command: self.clone(),
@@ -254,7 +263,6 @@ impl CreateCommand {
             (
                 vec![
                     "build",
-                    "--no-cache",
                     "--load",
                     "--platform",
                     "linux/amd64",
@@ -268,7 +276,6 @@ impl CreateCommand {
             (
                 vec![
                     "build",
-                    "--no-cache",
                     "--platform",
                     "linux/amd64",
                     "-t",
@@ -286,6 +293,9 @@ impl CreateCommand {
             let mut command = tokio::process::Command::new("docker");
             for arg in cmd_args {
                 command.arg(arg);
+            }
+            if !self.use_docker_cache {
+                command.arg("--no-cache");
             }
             for (env_name, env_value) in env_vars {
                 command.env(env_name, env_value);

--- a/implementations/rust/ockam/ockam_command/src/cluster/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/create.rs
@@ -248,59 +248,129 @@ impl CreateCommand {
                 color_primary(&repository_uri_tag)
             ));
         }
-        let output = tokio::process::Command::new("docker")
-            .arg("build")
-            .arg("--platform")
-            .arg("linux/amd64")
-            .arg("-t")
-            .arg(&repository_uri_tag)
-            .arg(".")
-            .current_dir(dockerfile_dir)
-            .env("DOCKER_BUILDKIT", "0")
-            .output()
-            .await
-            .into_diagnostic()?;
-        if let Some(spinner) = spinner.as_ref() {
-            spinner.finish_and_clear();
-        }
-        opts.terminal.write_line(fmt_ok!(
-            "Built local image {} with tag {}",
-            color_primary(image_name),
-            color_primary(&repository_uri_tag)
-        ))?;
-        if !output.status.success() {
-            return Err(miette::Error::msg(format!(
-                "Failed to build image {}: {}",
+
+        let build_attempts = [
+            // With buildkit enabled
+            (
+                vec![
+                    "build",
+                    "--no-cache",
+                    "--load",
+                    "--platform",
+                    "linux/amd64",
+                    "-t",
+                    &repository_uri_tag,
+                    ".",
+                ],
+                vec![("DOCKER_BUILDKIT", "1")],
+            ),
+            // With buildkit disabled
+            (
+                vec![
+                    "build",
+                    "--no-cache",
+                    "--platform",
+                    "linux/amd64",
+                    "-t",
+                    &repository_uri_tag,
+                    ".",
+                ],
+                vec![("DOCKER_BUILDKIT", "0")],
+            ),
+        ];
+
+        let mut last_error = None;
+
+        // Try each command until one succeeds
+        for (cmd_args, env_vars) in &build_attempts {
+            let mut command = tokio::process::Command::new("docker");
+            for arg in cmd_args {
+                command.arg(arg);
+            }
+            for (env_name, env_value) in env_vars {
+                command.env(env_name, env_value);
+            }
+
+            info!(
+                "Attempting docker build for {} with command: docker {} and env: {:?}",
                 image_name,
-                String::from_utf8_lossy(&output.stderr)
-            )));
+                cmd_args.join(" "),
+                env_vars
+            );
+
+            let output = command
+                .current_dir(&dockerfile_dir)
+                .output()
+                .await
+                .into_diagnostic()?;
+
+            if output.status.success() {
+                // Command succeeded
+                if let Some(spinner) = spinner.as_ref() {
+                    spinner.finish_and_clear();
+                }
+                opts.terminal.write_line(fmt_ok!(
+                    "Built local image {} with tag {}",
+                    color_primary(image_name),
+                    color_primary(&repository_uri_tag)
+                ))?;
+
+                // Push image
+                let push_spinner = opts.terminal.spinner();
+                if let Some(spinner) = push_spinner.as_ref() {
+                    spinner.set_message(format!("Pushing image {}...", color_primary(image_name)));
+                }
+                let push_output = tokio::process::Command::new("docker")
+                    .arg("push")
+                    .arg(&repository_uri_tag)
+                    .output()
+                    .await
+                    .into_diagnostic()?;
+
+                if !push_output.status.success() {
+                    return Err(miette::Error::msg(format!(
+                        "Failed to push image {}: {}",
+                        image_name,
+                        String::from_utf8_lossy(&push_output.stderr)
+                    )));
+                }
+
+                if let Some(spinner) = push_spinner {
+                    spinner.finish_and_clear();
+                }
+
+                opts.terminal
+                    .write_line(fmt_ok!("Pushed image {}\n", color_primary(image_name)))?;
+
+                return Ok(repository_uri_tag);
+            } else {
+                // Store the error for reporting if all commands fail
+                last_error = Some(format!(
+                    "Docker build failed with command 'docker {}' and env vars {:?}: {}",
+                    cmd_args.join(" "),
+                    env_vars,
+                    String::from_utf8_lossy(&output.stderr)
+                ));
+
+                // Log the failed attempt and continue to the next command
+                info!(
+                    "Docker build attempt failed for {}: {}",
+                    image_name,
+                    last_error.as_ref().unwrap()
+                );
+            }
         }
 
-        // Push image
-        let spinner = opts.terminal.spinner();
-        if let Some(spinner) = spinner.as_ref() {
-            spinner.set_message(format!("Pushing image {}...", color_primary(image_name)));
-        }
-        let output = tokio::process::Command::new("docker")
-            .arg("push")
-            .arg(&repository_uri_tag)
-            .output()
-            .await
-            .into_diagnostic()?;
-        if !output.status.success() {
-            return Err(miette::Error::msg(format!(
-                "Failed to push image {}: {}",
-                image_name,
-                String::from_utf8_lossy(&output.stderr)
-            )));
-        }
+        // If we get here, all commands failed
         if let Some(spinner) = spinner {
             spinner.finish_and_clear();
         }
-        opts.terminal
-            .write_line(fmt_ok!("Pushed image {}\n", color_primary(image_name)))?;
 
-        Ok(repository_uri_tag)
+        Err(miette::Error::msg(format!(
+            "Failed to build image {}: {}",
+            image_name,
+            last_error.unwrap_or_else(|| "Unknown error".to_string())
+        )))
     }
 
     async fn deploy_zone(


### PR DESCRIPTION
- Use random port for the inlet
- React to ctrlc, `:quit`, and `:q` at any point
- Add fallback `docker build` command
- Add env var `OCKAM_USE_DOCKER_CACHE`
- Support big payloads. Now the server responses follow a format where the first line indicates the body length