### PR TITLE
feat(rust): list relays on project nodes

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/orchestrator/project/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/orchestrator/project/mod.rs
@@ -4,6 +4,7 @@ mod controller_client;
 mod operations;
 #[allow(clippy::module_inception)]
 mod project;
+mod project_client;
 mod projects_orchestrator_api;
 
 pub use project::*;

--- a/implementations/rust/ockam/ockam_api/src/orchestrator/project/project_client.rs
+++ b/implementations/rust/ockam/ockam_api/src/orchestrator/project/project_client.rs
@@ -1,0 +1,88 @@
+use minicbor::{CborLen, Decode, Encode};
+use ockam::{identity::Identifier, Context, Decodable, Encodable, Encoded, Message};
+use ockam_core::api::Request;
+use ockam_core::cbor_encode_preallocate;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeMap,
+    fmt::{Display, Formatter},
+};
+
+use crate::{
+    colors::color_primary,
+    orchestrator::{HasSecureClient, ProjectNodeClient},
+    output::Output,
+};
+
+#[derive(Encode, Decode, CborLen, Serialize, Deserialize, Debug, Clone, Message)]
+#[cbor(map)]
+pub struct ProjectRelay {
+    #[cbor(n(1))]
+    pub addr: String,
+
+    #[cbor(n(2))]
+    pub tags: BTreeMap<String, String>,
+
+    #[cbor(n(3))]
+    pub target_identifier: Identifier,
+
+    #[cbor(n(4))]
+    pub created_at: i64,
+
+    #[cbor(n(5))]
+    pub updated_at: i64,
+}
+
+impl Encodable for ProjectRelay {
+    fn encode(self) -> ockam_core::Result<Encoded> {
+        cbor_encode_preallocate(self)
+    }
+}
+
+impl Decodable for ProjectRelay {
+    fn decode(e: &[u8]) -> ockam_core::Result<Self> {
+        Ok(minicbor::decode(e)?)
+    }
+}
+
+impl Display for ProjectRelay {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{}", color_primary(&self.addr))?;
+        Ok(())
+    }
+}
+
+impl Output for ProjectRelay {
+    fn item(&self) -> crate::Result<String> {
+        Ok(self.padded_display())
+    }
+}
+
+#[derive(Encode, Decode, CborLen, Serialize, Deserialize, Debug, Clone, Message)]
+#[cbor(transparent)]
+pub struct ProjectRelayList(#[n(0)] pub Vec<ProjectRelay>);
+
+impl Encodable for ProjectRelayList {
+    fn encode(self) -> ockam_core::Result<Encoded> {
+        cbor_encode_preallocate(self)
+    }
+}
+
+impl Decodable for ProjectRelayList {
+    fn decode(e: &[u8]) -> ockam_core::Result<Self> {
+        Ok(ProjectRelayList(minicbor::decode(e)?))
+    }
+}
+
+impl ProjectNodeClient {
+    pub async fn list_relays(&self, ctx: &Context) -> crate::Result<Vec<ProjectRelay>> {
+        trace!("listing project relays");
+        let req = Request::get("/");
+        let res: ProjectRelayList = self
+            .get_secure_client()
+            .ask(ctx, "static_forwarding_api", req)
+            .await?
+            .miette_success("project relay list")?;
+        Ok(res.0)
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod enroll;
 mod import;
 mod info;
 mod list;
+mod relays;
 mod show;
 mod ticket;
 #[allow(unused)]
@@ -25,6 +26,7 @@ mod version;
 pub use addon::AddonCommand;
 pub use create::CreateCommand;
 pub use delete::DeleteCommand;
+pub use relays::ListRelaysCommand;
 pub use ticket::TicketCommand;
 
 use ockam_node::Context;
@@ -55,6 +57,7 @@ pub enum ProjectSubcommand {
     Create(CreateCommand),
     Delete(DeleteCommand),
     Addon(AddonCommand),
+    Relays(ListRelaysCommand),
 }
 
 impl ProjectCommand {
@@ -70,6 +73,7 @@ impl ProjectCommand {
             ProjectSubcommand::Create(c) => c.run(ctx, opts).await,
             ProjectSubcommand::Delete(c) => c.run(ctx, opts).await,
             ProjectSubcommand::Addon(c) => c.run(ctx, opts).await,
+            ProjectSubcommand::Relays(c) => c.run(ctx, opts).await,
         }
     }
 
@@ -85,6 +89,7 @@ impl ProjectCommand {
             ProjectSubcommand::Create(c) => c.name(),
             ProjectSubcommand::Delete(c) => c.name(),
             ProjectSubcommand::Addon(c) => c.name(),
+            ProjectSubcommand::Relays(c) => c.name(),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/relays.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/relays.rs
@@ -1,0 +1,94 @@
+use crate::node_command::InMemoryNodeCommand;
+use crate::shared_args::{IdentityOpts, TimeoutArg, TrustOpts};
+use crate::{docs, Command, CommandGlobalOpts};
+use async_trait::async_trait;
+use clap::Args;
+use ockam::Context;
+use ockam_api::fmt_log;
+use ockam_api::nodes::InMemoryNode;
+use ockam_api::orchestrator::project::ProjectsOrchestratorApi;
+use std::sync::Arc;
+use std::time::Duration;
+
+const HELP_DETAIL: &str = "";
+
+/// List relays on the project node
+#[derive(Clone, Debug, Args)]
+#[command(help_template = docs::after_help(HELP_DETAIL))]
+pub struct ListRelaysCommand {
+    #[command(flatten)]
+    pub timeout: TimeoutArg,
+
+    #[command(flatten)]
+    identity_opts: IdentityOpts,
+
+    #[command(flatten)]
+    trust_opts: TrustOpts,
+}
+
+#[derive(Clone)]
+struct ListRelayNodeCommand {
+    opts: CommandGlobalOpts,
+    command: ListRelaysCommand,
+}
+
+impl ListRelayNodeCommand {
+    pub fn new(opts: CommandGlobalOpts, command: ListRelaysCommand) -> Self {
+        Self { opts, command }
+    }
+}
+
+#[async_trait]
+impl InMemoryNodeCommand for ListRelayNodeCommand {
+    fn project_name(&self) -> Option<String> {
+        self.command.trust_opts.project_name.clone()
+    }
+
+    fn identity_name(&self) -> Option<String> {
+        self.command.identity_opts.identity_name.clone()
+    }
+
+    fn timeout(&self) -> Option<Duration> {
+        Some(self.command.timeout.timeout)
+    }
+
+    async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let ctx = node.ctx();
+        self.opts
+            .terminal
+            .write_line(fmt_log!("Listing relays at project node ...\n"))?;
+        let project = node.get_project_by_name_or_default(&None).await?;
+        let client = node
+            .create_project_client(
+                &project.project_identifier().unwrap(),
+                project.project_multiaddr().unwrap(),
+                None,
+                ockam_api::orchestrator::CredentialsEnabled::On,
+            )
+            .await?;
+        let relays = client.list_relays(ctx).await?;
+
+        let plain = &self.opts.terminal.build_list(&relays, "No relays found")?;
+
+        self.opts
+            .terminal
+            .clone()
+            .to_stdout()
+            .plain(plain)
+            .json_obj(relays)?
+            .write_line()?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Command for ListRelaysCommand {
+    const NAME: &'static str = "project relays";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        ListRelayNodeCommand::new(opts.clone(), self.clone())
+            .execute(ctx, opts.state)
+            .await
+    }
+}


### PR DESCRIPTION
list existing relays on project nodes.  

Adds a new function to the `ProjectNodeClient`   :  ` pub async fn list_relays(&self, ctx: &Context) -> crate::Result<Vec<ProjectRelay>>`

And a simple cli to access it:
```
./ockam project relays 
    Listing relays at project node ...

  │ forward_to_ae5e3ce40e0404a45ecacaaf05e5f735-xyz-app

  │ forward_to_ae5e3ce40e0404a45ecacaaf05e5f735-xyz-main

```

```
pablo@pablo-gti14:~/src/ockam/target/debug$ ./ockam project relays --output json
    Listing relays at project node ...

[
  {
    "addr": "forward_to_ae5e3ce40e0404a45ecacaaf05e5f735-xyz-app",
    "created_at": 1746053071,
    "tags": {},
    "target_identifier": "I68dcee8ec059d7f1814917bd422d76c82b5d80ca04636dcd7ea8e4ed0f40e48d",
    "updated_at": 1746123035
  },
  {
    "addr": "forward_to_ae5e3ce40e0404a45ecacaaf05e5f735-xyz-main",
    "created_at": 1745968547,
    "tags": {},
    "target_identifier": "I8618fdbfe98b99908e53c41fb114c34ff91cefb14a95ccc909664a99adae47a9",
    "updated_at": 1746123041
  }
]
```
