### PR TITLE
feat: push secrets on `cluster create` command

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/enroll/enrollment.rs
+++ b/implementations/rust/ockam/ockam_api/src/enroll/enrollment.rs
@@ -23,7 +23,7 @@ pub enum EnrollStatus {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AiEnrollStatus {
-    EnrolledSuccessfully(String),
+    EnrolledSuccessfully,
     AlreadyEnrolled,
     UnexpectedStatus(String, Status),
     FailedNoStatus(String),
@@ -32,7 +32,7 @@ pub enum AiEnrollStatus {
 impl From<AiEnrollStatus> for EnrollStatus {
     fn from(val: AiEnrollStatus) -> Self {
         match val {
-            AiEnrollStatus::EnrolledSuccessfully(_) => EnrollStatus::EnrolledSuccessfully,
+            AiEnrollStatus::EnrolledSuccessfully => EnrollStatus::EnrolledSuccessfully,
             AiEnrollStatus::AlreadyEnrolled => EnrollStatus::AlreadyEnrolled,
             AiEnrollStatus::UnexpectedStatus(e, s) => EnrollStatus::UnexpectedStatus(e, s),
             AiEnrollStatus::FailedNoStatus(e) => EnrollStatus::FailedNoStatus(e),
@@ -167,7 +167,7 @@ impl Enrollment for SecureClient {
             .await
             .into_diagnostic()?;
         match reply {
-            Reply::Successful(_) => Ok(AiEnrollStatus::EnrolledSuccessfully("TODO".to_string())),
+            Reply::Successful(_) => Ok(AiEnrollStatus::EnrolledSuccessfully),
             Reply::Failed(e, Some(s)) => {
                 error!("enrolling with a token returned an error: {e:?}");
                 Ok(AiEnrollStatus::UnexpectedStatus(e.to_string(), s))

--- a/implementations/rust/ockam/ockam_command/src/base_command.rs
+++ b/implementations/rust/ockam/ockam_command/src/base_command.rs
@@ -1,4 +1,5 @@
 use crate::branding::BrandingCompileEnvVars;
+use crate::cluster::common_args::HttpApiArgs;
 use crate::cluster::zone_config::ZoneConfig;
 use crate::{Command, CommandGlobalOpts, Result};
 use clap::Args;
@@ -109,7 +110,10 @@ impl BaseCommand {
         use crate::cluster::create::CreateCommand;
         let create_command = CreateCommand {
             use_public_ecr: true,
-            api_endpoint: Some(AI_API_BASE_URL.to_string()),
+            http_api: HttpApiArgs {
+                api_endpoint: Some(AI_API_BASE_URL.to_string()),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let zone_config = create_command.run(ctx, opts.clone()).await?;

--- a/implementations/rust/ockam/ockam_command/src/base_command.rs
+++ b/implementations/rust/ockam/ockam_command/src/base_command.rs
@@ -1,5 +1,5 @@
 use crate::branding::BrandingCompileEnvVars;
-use crate::cluster::common_args::HttpApiArgs;
+use crate::cluster::common_args::{HttpApiArgs, ZoneNameOrConfigArg};
 use crate::cluster::zone_config::ZoneConfig;
 use crate::{Command, CommandGlobalOpts, Result};
 use clap::Args;
@@ -110,10 +110,7 @@ impl BaseCommand {
         use crate::cluster::create::CreateCommand;
         let create_command = CreateCommand {
             use_public_ecr: true,
-            http_api: HttpApiArgs {
-                api_endpoint: Some(AI_API_BASE_URL.to_string()),
-                ..Default::default()
-            },
+            http_api: HttpApiArgs::from_api_endpoint(AI_API_BASE_URL.to_string()),
             ..Default::default()
         };
         let zone_config = create_command.run(ctx, opts.clone()).await?;
@@ -149,15 +146,15 @@ impl BaseCommand {
 
         use crate::cluster::ticket::TicketCommand;
         let ticket_command = TicketCommand {
-            zone_name: zone_name.clone(),
-            api_endpoint: Some(AI_API_BASE_URL.to_string()),
+            zone: ZoneNameOrConfigArg::from_zone_name(zone_name.clone()),
+            http_api: HttpApiArgs::from_api_endpoint(AI_API_BASE_URL.to_string()),
             ..Default::default()
         };
         let ticket = ticket_command.run(ctx, no_output_opts.clone()).await?;
 
         use crate::cluster::inlet::InletCommand;
         let inlet_command = InletCommand {
-            zone_name: zone_name.clone(),
+            zone: ZoneNameOrConfigArg::from_zone_name(zone_name.clone()),
             pod: pod_name.clone(),
             enrollment_ticket: ticket,
             from: self.inlet_address.clone(),

--- a/implementations/rust/ockam/ockam_command/src/cluster/common_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/common_args.rs
@@ -1,8 +1,27 @@
+use crate::cluster::utils::get_cluster;
 use crate::cluster::zone_config::ZoneConfig;
 use clap::Args;
 use miette::{miette, IntoDiagnostic};
+use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::ai_platform::node_service_client::AI_API_BASE_URL_ENV;
 use ockam_core::env::get_env_ignore_error;
+use ockam_node::Context;
+
+#[derive(Clone, Debug, Args, Default)]
+pub struct ClusterArg {
+    /// The Cluster that hosts the Zone.
+    #[arg(long)]
+    pub cluster: Option<String>,
+}
+
+impl ClusterArg {
+    pub async fn get_cluster(&self, ctx: &Context, node: &InMemoryNode) -> miette::Result<String> {
+        if let Some(cluster) = &self.cluster {
+            return Ok(cluster.clone());
+        }
+        get_cluster(ctx, node).await
+    }
+}
 
 #[derive(Clone, Debug, Args, Default)]
 pub struct ZoneConfigArg {

--- a/implementations/rust/ockam/ockam_command/src/cluster/common_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/common_args.rs
@@ -33,6 +33,13 @@ impl From<ZoneConfigArg> for ZoneNameOrConfigArg {
 }
 
 impl ZoneNameOrConfigArg {
+    pub fn from_zone_name(zone_name: String) -> Self {
+        Self {
+            zone_name: Some(zone_name),
+            zone_config: ZoneConfigArg::default(),
+        }
+    }
+
     pub fn zone_name(&self) -> crate::Result<String> {
         if let Some(zone_name) = &self.zone_name {
             return Ok(zone_name.clone());
@@ -75,6 +82,13 @@ pub struct HttpApiArgs {
 }
 
 impl HttpApiArgs {
+    pub fn from_api_endpoint(api_endpoint: String) -> Self {
+        Self {
+            use_http_api: true,
+            api_endpoint: Some(api_endpoint),
+        }
+    }
+
     pub fn use_http_api(&self) -> bool {
         if let Some(api_endpoint) = &self.api_endpoint {
             std::env::set_var(AI_API_BASE_URL_ENV, api_endpoint);

--- a/implementations/rust/ockam/ockam_command/src/cluster/common_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/common_args.rs
@@ -5,24 +5,39 @@ use ockam_api::orchestrator::ai_platform::node_service_client::AI_API_BASE_URL_E
 use ockam_core::env::get_env_ignore_error;
 
 #[derive(Clone, Debug, Args, Default)]
-#[group(multiple = false)]
-pub struct ZoneArg {
-    /// The name of the Zone
-    #[arg(long)]
-    pub zone_name: Option<String>,
-
+pub struct ZoneConfigArg {
     /// The path to the Zone configuration file, in yaml or json format.
     /// If not set, the `./ockam.yaml` file from the current directory will be used.
     #[arg(long, visible_alias = "config")]
     pub zone_config: Option<String>,
 }
 
-impl ZoneArg {
+#[derive(Clone, Debug, Args, Default)]
+#[group(multiple = false)]
+pub struct ZoneNameOrConfigArg {
+    /// The name of the Zone
+    #[arg(long)]
+    pub zone_name: Option<String>,
+
+    #[command(flatten)]
+    pub zone_config: ZoneConfigArg,
+}
+
+impl From<ZoneConfigArg> for ZoneNameOrConfigArg {
+    fn from(zone_config: ZoneConfigArg) -> Self {
+        Self {
+            zone_name: None,
+            zone_config,
+        }
+    }
+}
+
+impl ZoneNameOrConfigArg {
     pub fn zone_name(&self) -> crate::Result<String> {
         if let Some(zone_name) = &self.zone_name {
             return Ok(zone_name.clone());
         }
-        let zone_config_path = match &self.zone_config {
+        let zone_config_path = match &self.zone_config.zone_config {
             Some(path) => path,
             None => {
                 if std::path::Path::new("./ockam.yaml")
@@ -68,4 +83,13 @@ impl HttpApiArgs {
             || self.api_endpoint.is_some()
             || get_env_ignore_error::<String>(AI_API_BASE_URL_ENV).is_some()
     }
+}
+
+#[derive(Clone, Debug, Args, Default)]
+pub struct SecretsConfigArg {
+    /// The path to the secrets file, in yaml or json format.
+    /// If not set, the `./secrets.yaml` file from the current directory will be used.
+    /// If no file is found, the command will just list the existing secrets.
+    #[arg(long, visible_alias = "secrets")]
+    pub secrets_config: Option<String>,
 }

--- a/implementations/rust/ockam/ockam_command/src/cluster/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/create.rs
@@ -1,4 +1,6 @@
-use crate::cluster::utils::get_api_client;
+use crate::cluster::common_args::{HttpApiArgs, SecretsConfigArg, ZoneConfigArg};
+use crate::cluster::secret::SecretCommand;
+use crate::cluster::utils::{get_api_client, get_cluster};
 use crate::cluster::zone_config::ZoneConfig;
 use crate::node_command::InMemoryNodeCommand;
 use crate::{docs, Command, CommandGlobalOpts, Result};
@@ -9,7 +11,6 @@ use miette::IntoDiagnostic;
 use ockam_api::colors::color_primary;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::ai_platform::api::AiPlatformApi;
-use ockam_api::orchestrator::ai_platform::node_service_client::AI_API_BASE_URL_ENV;
 use ockam_api::orchestrator::ai_platform::responses::EcrCredentials;
 use ockam_api::{fmt_log, fmt_ok};
 use ockam_core::env::get_env_ignore_error;
@@ -30,11 +31,11 @@ before_help = docs::before_help(PREVIEW_TAG),
 after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct CreateCommand {
-    /// The path to the Zone configuration file, in yaml or json format.
-    ///
-    /// If not set, the `./ockam.yaml` file from the current directory will be used.
-    #[arg(long, visible_alias = "config")]
-    pub zone_config: Option<String>,
+    #[command(flatten)]
+    pub zone_config: ZoneConfigArg,
+
+    #[command(flatten)]
+    pub secrets_config: SecretsConfigArg,
 
     /// Whether to use a public AWS ECR
     #[arg(long)]
@@ -45,21 +46,8 @@ pub struct CreateCommand {
     #[arg(long)]
     pub use_docker_cache: bool,
 
-    // === Specific args for the HTTP API endpoint
-    /// The Cluster that will be used to set up the Zone.
-    /// If not set, it will be retrieved from the enrolled user data.
-    #[arg(long)]
-    pub cluster: Option<String>,
-
-    /// Force the command to use the HTTP API.
-    /// By default, the command will use the Orchestrator API.
-    #[arg(long)]
-    pub use_http_api: bool,
-
-    /// The API endpoint of the Ockam AI Platform.
-    /// Defaults to `http://localhost:30080`.
-    #[arg(long)]
-    pub api_endpoint: Option<String>,
+    #[command(flatten)]
+    pub http_api: HttpApiArgs,
 }
 
 #[derive(Clone)]
@@ -70,24 +58,11 @@ struct CreateNodeCommand {
 
 #[async_trait]
 impl InMemoryNodeCommand<ZoneConfig> for CreateNodeCommand {
-    async fn init(&self) -> miette::Result<()> {
-        if let Some(api_endpoint) = &self.command.api_endpoint {
-            std::env::set_var(AI_API_BASE_URL_ENV, api_endpoint);
-        }
-        Ok(())
-    }
-
     async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<ZoneConfig> {
         let ctx = node.ctx();
-        let use_http_api = self.command.use_http_api || self.command.api_endpoint.is_some();
+        let use_http_api = self.command.http_api.use_http_api();
         let api_client = get_api_client(&node, use_http_api).await?;
-        let cluster = match &self.command.cluster {
-            None => {
-                let controller_client = node.create_controller().await?;
-                controller_client.get_cluster(ctx).await?.into_inner()
-            }
-            Some(cluster) => cluster.to_string(),
-        };
+        let cluster = get_cluster(ctx, &node).await?;
         let zone_config = self
             .command
             .process_images(ctx, &self.opts, &*api_client, &cluster)
@@ -124,7 +99,11 @@ impl CreateCommand {
         api_client: &(dyn AiPlatformApi + Send + Sync + 'static),
         cluster: &str,
     ) -> Result<ZoneConfig> {
-        let zone_config_path = self.zone_config.as_deref().unwrap_or("./ockam.yaml");
+        let zone_config_path = self
+            .zone_config
+            .zone_config
+            .as_deref()
+            .unwrap_or("./ockam.yaml");
         let mut zone_config = ZoneConfig::from_file(zone_config_path)?;
 
         let config_images = zone_config.get_local_images_names();
@@ -399,16 +378,23 @@ impl CreateCommand {
             ));
         }
 
-        // TODO: do we want to recreate the zone every time?
-        //  Is there another way of reapplying the configuration for an existing zone?
         let _ = api_client
             .delete_zone(ctx, cluster, &zone_config.name)
             .await;
         api_client
             .create_zone(ctx, cluster, &zone_config.name)
             .await?;
-        // TODO: how do we pass the secrets to the command?
-        // api_client.create_secret(ctx, cluster, &self.zone_name, secret_name, secret_fields).await?;
+        {
+            let mut opts = opts.clone();
+            opts.terminal = opts.terminal.disable();
+            SecretCommand {
+                secrets_config: self.secrets_config.clone(),
+                zone: self.zone_config.clone().into(),
+                http_api: self.http_api.clone(),
+            }
+            .push_secrets(ctx, &opts, api_client, cluster, &zone_config.name)
+            .await?;
+        }
 
         let zone_config_json = serde_json::to_value(zone_config).into_diagnostic()?;
         api_client

--- a/implementations/rust/ockam/ockam_command/src/cluster/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/delete.rs
@@ -1,4 +1,5 @@
-use crate::cluster::utils::get_api_client;
+use crate::cluster::common_args::{HttpApiArgs, ZoneNameOrConfigArg};
+use crate::cluster::utils::{get_api_client, get_cluster};
 use crate::node_command::InMemoryNodeCommand;
 use crate::{docs, Command, CommandGlobalOpts, Result};
 use async_trait::async_trait;
@@ -6,8 +7,6 @@ use clap::Args;
 use colorful::Colorful;
 use ockam_api::fmt_ok;
 use ockam_api::nodes::InMemoryNode;
-use ockam_api::orchestrator::ai_platform::api::AiPlatformApi;
-use ockam_api::orchestrator::ai_platform::node_service_client::AI_API_BASE_URL_ENV;
 use ockam_node::Context;
 use std::sync::Arc;
 
@@ -23,25 +22,11 @@ before_help = docs::before_help(PREVIEW_TAG),
 after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct DeleteCommand {
-    /// The name of the Zone to deploy in the Ockam AI Platform
-    #[arg(long)]
-    pub zone_name: String,
+    #[command(flatten)]
+    pub zone: ZoneNameOrConfigArg,
 
-    // === Specific args for the HTTP API endpoint
-    /// The Cluster that will be used to set up the Zone.
-    /// If not set, it will be retrieved from the enrolled user data.
-    #[arg(long)]
-    pub cluster: Option<String>,
-
-    /// Force the command to use the HTTP API.
-    /// By default, the command will use the Orchestrator API.
-    #[arg(long)]
-    pub use_http_api: bool,
-
-    /// The API endpoint of the Ockam AI Platform.
-    /// Defaults to `http://localhost:30080`.
-    #[arg(long)]
-    pub api_endpoint: Option<String>,
+    #[command(flatten)]
+    pub http_api: HttpApiArgs,
 }
 
 #[derive(Clone)]
@@ -52,35 +37,18 @@ struct DeployNodeCommand {
 
 #[async_trait]
 impl InMemoryNodeCommand for DeployNodeCommand {
-    async fn init(&self) -> miette::Result<()> {
-        if let Some(api_endpoint) = &self.command.api_endpoint {
-            std::env::set_var(AI_API_BASE_URL_ENV, api_endpoint);
-        }
-        Ok(())
-    }
-
     async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
         let ctx = node.ctx();
-        let use_http_api = self.command.use_http_api || self.command.api_endpoint.is_some();
+        let use_http_api = self.command.http_api.use_http_api();
         let api_client = get_api_client(&node, use_http_api).await?;
-        let cluster = match &self.command.cluster {
-            None => {
-                let controller_client = node.create_controller().await?;
-                controller_client.get_cluster(ctx).await?.into_inner()
-            }
-            Some(cluster) => cluster.to_string(),
-        };
-        api_client
-            .delete_zone(ctx, &cluster, &self.command.zone_name)
-            .await?;
+        let cluster = get_cluster(ctx, &node).await?;
+        let zone_name = self.command.zone.zone_name()?;
+        api_client.delete_zone(ctx, &cluster, &zone_name).await?;
         self.opts
             .terminal
             .clone()
             .to_stdout()
-            .plain(fmt_ok!(
-                "Zone {} deleted successfully",
-                self.command.zone_name
-            ))
+            .plain(fmt_ok!("Zone {} deleted successfully", &zone_name))
             .write_line()?;
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/cluster/inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/inlet.rs
@@ -91,6 +91,7 @@ impl InMemoryNodeCommand for InletNodeCommand {
         if let Some(allow) = &self.command.allow {
             node_config["tcp-inlet"]["allow"] = allow.to_string().into();
         }
+        let in_memory = false;
         let node_cmd = crate::node::create::CreateCommand {
             name: node_config.to_string(),
             config_args: ConfigArgs {
@@ -101,12 +102,13 @@ impl InMemoryNodeCommand for InletNodeCommand {
                 foreground: true,
                 ..Default::default()
             },
+            in_memory,
             ..Default::default()
         };
         let tmp_dir = tempfile::tempdir().into_diagnostic()?;
         std::env::set_var(OCKAM_HOME, tmp_dir.path());
         let mut opts = self.opts.clone();
-        opts.state = Arc::new(CliState::new(false).await?);
+        opts.state = Arc::new(CliState::new(in_memory).await?);
         node_cmd.run(node.ctx(), opts).await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/cluster/inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/inlet.rs
@@ -1,5 +1,4 @@
-use crate::cluster::common_args::ZoneNameOrConfigArg;
-use crate::cluster::utils::get_cluster;
+use crate::cluster::common_args::{ClusterArg, ZoneNameOrConfigArg};
 use crate::node::config::ConfigArgs;
 use crate::node_command::InMemoryNodeCommand;
 use crate::tcp::inlet::create::tcp_inlet_default_from_addr;
@@ -29,6 +28,9 @@ before_help = docs::before_help(PREVIEW_TAG),
 after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct InletCommand {
+    #[command(flatten)]
+    pub cluster: ClusterArg,
+
     #[command(flatten)]
     pub zone: ZoneNameOrConfigArg,
 
@@ -76,7 +78,7 @@ struct InletNodeCommand {
 impl InMemoryNodeCommand for InletNodeCommand {
     async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
         let ctx = node.ctx();
-        let cluster = get_cluster(ctx, &node).await?;
+        let cluster = self.command.cluster.get_cluster(ctx, &node).await?;
         let zone_name = self.command.zone.zone_name()?;
         let relay_name = format!("{}-{}-{}", cluster, zone_name, self.command.pod);
         let mut node_config = serde_json::json!({

--- a/implementations/rust/ockam/ockam_command/src/cluster/inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/inlet.rs
@@ -1,3 +1,5 @@
+use crate::cluster::common_args::ZoneNameOrConfigArg;
+use crate::cluster::utils::get_cluster;
 use crate::node::config::ConfigArgs;
 use crate::node_command::InMemoryNodeCommand;
 use crate::tcp::inlet::create::tcp_inlet_default_from_addr;
@@ -11,7 +13,6 @@ use ockam::transport::SchemeHostnamePort;
 use ockam_abac::PolicyExpression;
 use ockam_api::cli_state::OCKAM_HOME;
 use ockam_api::nodes::InMemoryNode;
-use ockam_api::orchestrator::ai_platform::api::AiPlatformApi;
 use ockam_api::CliState;
 use ockam_node::Context;
 use std::sync::Arc;
@@ -28,13 +29,8 @@ before_help = docs::before_help(PREVIEW_TAG),
 after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct InletCommand {
-    /// The Cluster that hosts the Zone.
-    #[arg(long)]
-    pub cluster: Option<String>,
-
-    /// The name of the Zone to connect to
-    #[arg(long)]
-    pub zone_name: String,
+    #[command(flatten)]
+    pub zone: ZoneNameOrConfigArg,
 
     /// References the name of TCP Outlet created in the Zone and the Relay name.
     #[arg(long)]
@@ -79,20 +75,10 @@ struct InletNodeCommand {
 #[async_trait]
 impl InMemoryNodeCommand for InletNodeCommand {
     async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
-        let cluster = match &self.command.cluster {
-            None => {
-                let controller_client = node.create_controller().await?;
-                controller_client
-                    .get_cluster(node.ctx())
-                    .await?
-                    .into_inner()
-            }
-            Some(cluster) => cluster.to_string(),
-        };
-        let relay_name = format!(
-            "{}-{}-{}",
-            cluster, self.command.zone_name, self.command.pod
-        );
+        let ctx = node.ctx();
+        let cluster = get_cluster(ctx, &node).await?;
+        let zone_name = self.command.zone.zone_name()?;
+        let relay_name = format!("{}-{}-{}", cluster, zone_name, self.command.pod);
         let mut node_config = serde_json::json!({
             "tcp-inlet": {
                 "from": self.command.from.to_string(),

--- a/implementations/rust/ockam/ockam_command/src/cluster/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/mod.rs
@@ -1,11 +1,11 @@
-mod common_args;
+pub mod common_args;
 pub(crate) mod create;
 mod delete;
 pub(crate) mod enroll;
 pub(crate) mod init;
 pub(crate) mod inlet;
 mod outlet;
-mod secret;
+pub(crate) mod secret;
 pub(crate) mod ticket;
 pub mod utils;
 pub mod zone_config;

--- a/implementations/rust/ockam/ockam_command/src/cluster/outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/outlet.rs
@@ -88,6 +88,7 @@ impl InMemoryNodeCommand for OutletNodeCommand {
         if let Some(allow) = &self.command.allow {
             node_config["tcp-outlet"]["allow"] = allow.to_string().into();
         }
+        let in_memory = false;
         let node_cmd = crate::node::create::CreateCommand {
             name: node_config.to_string(),
             config_args: ConfigArgs {
@@ -98,12 +99,13 @@ impl InMemoryNodeCommand for OutletNodeCommand {
                 foreground: true,
                 ..Default::default()
             },
+            in_memory,
             ..Default::default()
         };
         let tmp_dir = tempfile::tempdir().into_diagnostic()?;
         std::env::set_var(OCKAM_HOME, tmp_dir.path());
         let mut opts = self.opts.clone();
-        opts.state = Arc::new(CliState::new(false).await?);
+        opts.state = Arc::new(CliState::new(in_memory).await?);
         node_cmd.run(node.ctx(), opts).await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/cluster/secret.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/secret.rs
@@ -1,7 +1,5 @@
-use std::sync::Arc;
-
 use super::utils::{get_api_client, get_cluster};
-use crate::cluster::common_args::{HttpApiArgs, ZoneArg};
+use crate::cluster::common_args::{HttpApiArgs, SecretsConfigArg, ZoneNameOrConfigArg};
 use crate::{docs, node_command::InMemoryNodeCommand, Command, CommandGlobalOpts, Result};
 use async_trait::async_trait;
 use clap::Args;
@@ -9,10 +7,12 @@ use colorful::Colorful;
 use miette::{IntoDiagnostic, WrapErr};
 use ockam_api::colors::color_primary;
 use ockam_api::nodes::InMemoryNode;
+use ockam_api::orchestrator::ai_platform::api::AiPlatformApi;
 use ockam_api::{fmt_log, fmt_ok, fmt_warn};
 use ockam_core::compat::collections::HashMap;
 use ockam_node::Context;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 const LONG_ABOUT: &str = include_str!("./static/secret/long_about.txt");
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
@@ -26,13 +26,11 @@ before_help = docs::before_help(PREVIEW_TAG),
 after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct SecretCommand {
-    /// The path to the secrets file, in yaml or json format.
-    /// If not set, the `./secrets.yaml` file from the current directory will be used.
-    /// If no file is found, the command will just list the existing secrets.
-    pub secrets_path: Option<String>,
+    #[command(flatten)]
+    pub secrets_config: SecretsConfigArg,
 
     #[command(flatten)]
-    pub zone: ZoneArg,
+    pub zone: ZoneNameOrConfigArg,
 
     #[command(flatten)]
     pub http_api: HttpApiArgs,
@@ -54,46 +52,9 @@ impl InMemoryNodeCommand for SecretNodeCommand {
         let zone_name = self.command.zone.zone_name()?;
 
         // Push secrets
-        if let Some(secrets) = self.command.parse_secrets_file()? {
-            // Delete existing secrets
-            let spinner = self.opts.terminal.spinner();
-            if let Some(spinner) = &spinner {
-                spinner.set_message("Listing secrets...");
-            }
-            let secrets_to_remove = api_client.list_secrets(ctx, &cluster, &zone_name).await?;
-            if !secrets_to_remove.is_empty() {
-                if let Some(spinner) = &spinner {
-                    spinner.set_message("Deleting existing secrets...");
-                }
-            }
-            for secret in &secrets_to_remove {
-                api_client
-                    .delete_secret(ctx, &cluster, &zone_name, &secret.name)
-                    .await?;
-            }
-
-            // Push secrets from file
-            for secret in &secrets.0 {
-                if let Some(spinner) = &spinner {
-                    spinner.set_message(format!(
-                        "Creating secret {} to zone {} in cluster {}...",
-                        color_primary(&secret.name),
-                        color_primary(&zone_name),
-                        color_primary(&cluster)
-                    ));
-                }
-                api_client
-                    .create_secret(ctx, &cluster, &zone_name, &secret.name, &secret.fields)
-                    .await?;
-            }
-
-            if let Some(spinner) = &spinner {
-                spinner.finish_and_clear();
-            }
-            self.opts
-                .terminal
-                .write_line(fmt_ok!("Secrets created successfully!"))?;
-        }
+        self.command
+            .push_secrets(ctx, &self.opts, &*api_client, &cluster, &zone_name)
+            .await?;
 
         // List secrets
         let spinner = self.opts.terminal.spinner();
@@ -106,7 +67,7 @@ impl InMemoryNodeCommand for SecretNodeCommand {
         }
         if secrets.is_empty() {
             self.opts.terminal.write_line(fmt_warn!(
-                "No secrets found for zone {} in cluster {}",
+                "No secrets defined for zone {} in cluster {}",
                 color_primary(&zone_name),
                 color_primary(&cluster)
             ))?;
@@ -142,8 +103,64 @@ impl Command for SecretCommand {
 }
 
 impl SecretCommand {
+    pub async fn push_secrets(
+        &self,
+        ctx: &Context,
+        opts: &CommandGlobalOpts,
+        api_client: &(dyn AiPlatformApi + Send + Sync + 'static),
+        cluster: &str,
+        zone_name: &str,
+    ) -> Result<()> {
+        let secrets = match self.parse_secrets_file()? {
+            Some(secrets) => secrets,
+            None => {
+                return Ok(());
+            }
+        };
+
+        // Delete existing secrets
+        let spinner = opts.terminal.spinner();
+        if let Some(spinner) = &spinner {
+            spinner.set_message("Listing secrets...");
+        }
+        let secrets_to_remove = api_client.list_secrets(ctx, cluster, zone_name).await?;
+        if !secrets_to_remove.is_empty() {
+            if let Some(spinner) = &spinner {
+                spinner.set_message("Deleting existing secrets...");
+            }
+        }
+        for secret in &secrets_to_remove {
+            api_client
+                .delete_secret(ctx, cluster, zone_name, &secret.name)
+                .await?;
+        }
+
+        // Push secrets from file
+        for secret in &secrets.0 {
+            if let Some(spinner) = &spinner {
+                spinner.set_message(format!(
+                    "Creating secret {} to zone {} in cluster {}...",
+                    color_primary(&secret.name),
+                    color_primary(zone_name),
+                    color_primary(cluster)
+                ));
+            }
+            api_client
+                .create_secret(ctx, cluster, zone_name, &secret.name, &secret.fields)
+                .await?;
+        }
+
+        if let Some(spinner) = &spinner {
+            spinner.finish_and_clear();
+        }
+        opts.terminal
+            .write_line(fmt_ok!("Secrets created successfully!"))?;
+
+        Ok(())
+    }
+
     fn parse_secrets_file(&self) -> Result<Option<Secrets>> {
-        let path = match &self.secrets_path {
+        let path = match &self.secrets_config.secrets_config {
             Some(path) => path,
             None => {
                 if std::path::Path::new("./secrets.yaml")

--- a/implementations/rust/ockam/ockam_command/src/cluster/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/ticket.rs
@@ -4,15 +4,12 @@ use async_trait::async_trait;
 
 use clap::Args;
 use miette::{miette, IntoDiagnostic};
-use ockam_api::orchestrator::ai_platform::api::AiPlatformApi;
-use ockam_api::{
-    nodes::InMemoryNode, orchestrator::ai_platform::node_service_client::AI_API_BASE_URL_ENV,
-};
+use ockam_api::nodes::InMemoryNode;
 use ockam_node::Context;
 
+use super::utils::{get_api_client, get_cluster};
+use crate::cluster::common_args::{HttpApiArgs, ZoneNameOrConfigArg};
 use crate::{docs, node_command::InMemoryNodeCommand, Command, CommandGlobalOpts, Result};
-
-use super::utils::get_api_client;
 
 const LONG_ABOUT: &str = include_str!("./static/ticket/long_about.txt");
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
@@ -26,25 +23,11 @@ before_help = docs::before_help(PREVIEW_TAG),
 after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct TicketCommand {
-    // === Specific args for the HTTP API endpoint
-    /// The Cluster that will be used
-    /// If not set, it will be retrieved from the enrolled user data.
-    #[arg(long)]
-    pub cluster: Option<String>,
+    #[command(flatten)]
+    pub zone: ZoneNameOrConfigArg,
 
-    /// The name of the Zone
-    #[arg(long)]
-    pub zone_name: String,
-
-    /// Force the command to use the HTTP API.
-    /// By default, the command will use the Orchestrator API.
-    #[arg(long)]
-    pub use_http_api: bool,
-
-    /// The API endpoint of the Ockam AI Platform.
-    /// Defaults to `http://localhost:30080`.
-    #[arg(long)]
-    pub api_endpoint: Option<String>,
+    #[command(flatten)]
+    pub http_api: HttpApiArgs,
 
     /// Attributes in `key=value` format to be attached to the member. You can specify this option multiple times for multiple attributes
     #[arg(short, long = "attribute", value_name = "ATTRIBUTE")]
@@ -63,32 +46,14 @@ struct TicketNodeCommand {
 
 #[async_trait]
 impl InMemoryNodeCommand<String> for TicketNodeCommand {
-    async fn init(&self) -> miette::Result<()> {
-        if let Some(api_endpoint) = &self.command.api_endpoint {
-            std::env::set_var(AI_API_BASE_URL_ENV, api_endpoint);
-        }
-        Ok(())
-    }
-
     async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<String> {
         let ctx = node.ctx();
-        let use_http_api = self.command.use_http_api || self.command.api_endpoint.is_some();
+        let use_http_api = self.command.http_api.use_http_api();
         let api_client = get_api_client(&node, use_http_api).await?;
-        let cluster = match &self.command.cluster {
-            None => {
-                let controller_client = node.create_controller().await?;
-                controller_client.get_cluster(ctx).await?.into_inner()
-            }
-            Some(cluster) => cluster.to_string(),
-        };
+        let cluster = get_cluster(ctx, &node).await?;
+        let zone_name = self.command.zone.zone_name()?;
         let ticket = api_client
-            .create_enrollment_token(
-                ctx,
-                &cluster,
-                &self.command.zone_name,
-                self.command.attributes()?,
-                None,
-            )
+            .create_enrollment_token(ctx, &cluster, &zone_name, self.command.attributes()?, None)
             .await?;
 
         self.opts

--- a/implementations/rust/ockam/ockam_command/src/cluster/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/ticket.rs
@@ -53,7 +53,13 @@ impl InMemoryNodeCommand<String> for TicketNodeCommand {
         let cluster = get_cluster(ctx, &node).await?;
         let zone_name = self.command.zone.zone_name()?;
         let ticket = api_client
-            .create_enrollment_token(ctx, &cluster, &zone_name, self.command.attributes()?, None)
+            .create_enrollment_token(
+                ctx,
+                &cluster,
+                &zone_name,
+                self.command.attributes()?,
+                self.command.allowed_relay_name.clone(),
+            )
             .await?;
 
         self.opts

--- a/implementations/rust/ockam/ockam_command/src/cluster/zone_config.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/zone_config.rs
@@ -73,6 +73,26 @@ impl ZoneConfig {
             }
         }
 
+        // Check for duplicate pod names or container names
+        let mut pod_names = HashMap::new();
+        for pod in &self.pods {
+            if let Some(existing) = pod_names.insert(&pod.name, pod) {
+                return Err(miette::miette!(format!(
+                    "Duplicate pod name '{}' found in zone configuration",
+                    existing.name
+                )));
+            }
+            let mut container_names = HashMap::new();
+            for container in &pod.containers {
+                if let Some(existing) = container_names.insert(&container.name, container) {
+                    return Err(miette::miette!(format!(
+                        "Duplicate container name '{}' found in pod '{}'",
+                        existing.name, pod.name
+                    )));
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -358,6 +378,69 @@ pods:
             .unwrap_err()
             .to_string()
             .contains("Container name 'container-name-is-too-long' exceeds 10 characters"));
+    }
+
+    #[test]
+    fn test_validate_duplicate_names() {
+        // Test duplicate pod names
+        let config_duplicate_pods = ZoneConfig {
+            name: "zone".to_string(),
+            pods: vec![
+                Pod {
+                    name: "pod1".to_string(),
+                    containers: vec![Container {
+                        name: "container1".to_string(),
+                        image: "image1".to_string(),
+                        other_fields: HashMap::new(),
+                    }],
+                    other_fields: HashMap::new(),
+                },
+                Pod {
+                    name: "pod1".to_string(), // Duplicate pod name
+                    containers: vec![Container {
+                        name: "container2".to_string(),
+                        image: "image2".to_string(),
+                        other_fields: HashMap::new(),
+                    }],
+                    other_fields: HashMap::new(),
+                },
+            ],
+        };
+
+        let result = config_duplicate_pods.validate();
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Duplicate pod name 'pod1' found"));
+
+        // Test duplicate container names within a pod
+        let config_duplicate_containers = ZoneConfig {
+            name: "zone".to_string(),
+            pods: vec![Pod {
+                name: "pod1".to_string(),
+                containers: vec![
+                    Container {
+                        name: "container1".to_string(),
+                        image: "image1".to_string(),
+                        other_fields: HashMap::new(),
+                    },
+                    Container {
+                        name: "container1".to_string(), // Duplicate container name
+                        image: "image2".to_string(),
+                        other_fields: HashMap::new(),
+                    },
+                ],
+                other_fields: HashMap::new(),
+            }],
+        };
+
+        let result = config_duplicate_containers.validate();
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Duplicate container name 'container1' found in pod 'pod1'"));
     }
 
     #[test]

--- a/implementations/rust/ockam/ockam_command/src/enroll/handler.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/handler.rs
@@ -67,7 +67,7 @@ impl InMemoryNodeCommand for EnrollHandler {
     }
 
     async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
-        let (user_info, cluster) = self.enroll_identity(&node).await?;
+        let user_info = self.enroll_identity(&node).await?;
 
         if !self.is_ai_cloud_account {
             if let Err(error) = self.retrieve_user_space_and_project(&node).await {
@@ -125,11 +125,6 @@ impl InMemoryNodeCommand for EnrollHandler {
             color_primary(identity.name()),
             color_primary(identity.identifier().to_string())
         ))?;
-        if let Some(cluster) = cluster {
-            self.opts.terminal.write_line(fmt_log!(
-                "Your Cluster associated to the Ockam AI Platform is {cluster}"
-            ))?;
-        }
 
         if !self.is_ai_cloud_account {
             self.opts.terminal
@@ -226,10 +221,7 @@ impl EnrollHandler {
         Ok(is_already_enrolled)
     }
 
-    pub(crate) async fn enroll_identity(
-        &self,
-        node: &InMemoryNode,
-    ) -> miette::Result<(UserInfo, Option<String>)> {
+    pub(crate) async fn enroll_identity(&self, node: &InMemoryNode) -> miette::Result<UserInfo> {
         if !self
             .opts
             .state
@@ -237,7 +229,7 @@ impl EnrollHandler {
             .await?
         {
             if let Ok(user_info) = self.opts.state.get_default_user().await {
-                return Ok((user_info, None));
+                return Ok(user_info);
             }
         }
 
@@ -261,8 +253,7 @@ impl EnrollHandler {
 
         // Enroll the identity with the Orchestrator
         let controller = node.create_controller().await?;
-        let cluster = self
-            .enroll_with_node(node.ctx(), &controller, token)
+        self.enroll_with_node(node.ctx(), &controller, token)
             .await
             .wrap_err("Failed to enroll your local Identity with Ockam Orchestrator")?;
         self.opts
@@ -271,7 +262,7 @@ impl EnrollHandler {
             .await
             .wrap_err("Unable to set your local Identity as enrolled")?;
 
-        Ok((user_info, cluster))
+        Ok(user_info)
     }
 
     fn display_header(&self) {
@@ -356,14 +347,9 @@ impl EnrollHandler {
         ctx: &Context,
         controller: &ControllerClient,
         token: OidcToken,
-    ) -> miette::Result<Option<String>> {
-        let cluster: Option<String> = None;
+    ) -> miette::Result<()> {
         let reply = if self.is_ai_cloud_account {
             let reply = controller.enroll_ai_with_oidc_token(ctx, token).await?;
-            // if let AiEnrollStatus::EnrolledSuccessfully(c) = &reply {
-            //     cluster = Some(c.to_string());
-            // }
-            // cluster = Some(controller.get_cluster(ctx).await?.into_inner()); // TODO: remove once enroll_ai_with_oidc_token is fixed
             reply.into()
         } else {
             controller.enroll_with_oidc_token(ctx, token).await?
@@ -371,11 +357,11 @@ impl EnrollHandler {
         match reply {
             EnrollStatus::EnrolledSuccessfully => {
                 info!("Enrolled successfully");
-                Ok(cluster)
+                Ok(())
             }
             EnrollStatus::AlreadyEnrolled => {
                 info!("Already enrolled");
-                Ok(cluster)
+                Ok(())
             }
             EnrollStatus::UnexpectedStatus(error, status) => {
                 warn!(%error, %status, "Unexpected status while enrolling");


### PR DESCRIPTION
It will also be run as part of the `ockam` command if the `./secrets.yaml` file exists.

Other fixes included:
- pass relay name in cluster ticket command
- zone config return error if has duplicated pods or containers