### PR TITLE
feat(elixir): terminate relays after idle timeout

### DIFF
--- a/implementations/elixir/ockam/ockam_services/lib/services/relay/static_forwarding.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/relay/static_forwarding.ex
@@ -28,6 +28,14 @@ defmodule Ockam.Services.Relay.StaticForwarding do
 
   require Logger
 
+  # Shutdown the relay if no messages are received for this time
+  # This works because the rust side, when a node creates a relay,
+  # there is something that ping itself _through_ the relay each
+  # 10 seconds.  So no activity through the relay
+  # means (likely) the other side is dead.  A cleaner apprach would
+  # be welcomed here.
+  @idle_timeout 20_000
+
   @spec list_running_relays() :: [{Ockam.Address.t(), map()}]
   def list_running_relays() do
     Ockam.Node.Registry.select_by_attribute(:service, :relay)
@@ -118,6 +126,7 @@ defmodule Ockam.Services.Relay.StaticForwarding do
         Forwarder.create(
           Keyword.merge(forwarder_options,
             address: forwarder_address,
+            idle_timeout: @idle_timeout,
             relay_options: [
               alias: alias_str,
               route: route,


### PR DESCRIPTION
the nodes keep pinging through the relay periodically, use inactivity there as a way to terminate dangling relays.
