### PR TITLE
fix(elixir): terminate relay when next worker in forward path terminates

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/recoverable_client.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/recoverable_client.ex
@@ -80,7 +80,10 @@ defmodule Ockam.Transport.TCP.RecoverableClient do
     {:noreply, refresh_client(state)}
   end
 
-  def handle_monitor_down({:DOWN, ref, :process, _pid, _reason} = down, %{monitor_ref: ref} = state) do
+  def handle_monitor_down(
+        {:DOWN, ref, :process, _pid, _reason} = down,
+        %{monitor_ref: ref} = state
+      ) do
     Logger.debug("DOWN for current client: #{inspect(down)} state: #{inspect(state)}")
     {:noreply, schedule_refresh_client(state)}
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/recoverable_client.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/recoverable_client.ex
@@ -80,12 +80,12 @@ defmodule Ockam.Transport.TCP.RecoverableClient do
     {:noreply, refresh_client(state)}
   end
 
-  def handle_info({:DOWN, ref, :process, _pid, _reason} = down, %{monitor_ref: ref} = state) do
+  def handle_monitor_down({:DOWN, ref, :process, _pid, _reason} = down, %{monitor_ref: ref} = state) do
     Logger.debug("DOWN for current client: #{inspect(down)} state: #{inspect(state)}")
     {:noreply, schedule_refresh_client(state)}
   end
 
-  def handle_info({:DOWN, _ref, _type, _pid, _reason} = down, state) do
+  def handle_monitor_down({:DOWN, _ref, _type, _pid, _reason} = down, state) do
     Logger.debug("DOWN for old client: #{inspect(down)} state: #{inspect(state)}")
     {:noreply, state}
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/worker.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/worker.ex
@@ -129,6 +129,10 @@ defmodule Ockam.Worker do
         Ockam.Worker.handle_idle_timeout(state)
       end
 
+      def handle_info({:DOWN, _ref, :process, _pid, _reason} = down, state) do
+        handle_monitor_down(down, state)
+      end
+
       @doc false
       @impl true
       def handle_continue(:post_init, options) do
@@ -151,7 +155,16 @@ defmodule Ockam.Worker do
         Ockam.Worker.is_authorized(message, state)
       end
 
-      defoverridable setup: 2, address_prefix: 1, is_authorized: 2, create: 2
+      @doc false
+      def handle_monitor_down(_down, state) do
+        {:noreply, state}
+      end
+
+      defoverridable setup: 2,
+                     address_prefix: 1,
+                     is_authorized: 2,
+                     create: 2,
+                     handle_monitor_down: 2
     end
   end
 

--- a/implementations/elixir/ockam/ockam_services/lib/services/relay/static_forwarding.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/relay/static_forwarding.ex
@@ -28,14 +28,6 @@ defmodule Ockam.Services.Relay.StaticForwarding do
 
   require Logger
 
-  # Shutdown the relay if no messages are received for this time
-  # This works because the rust side, when a node creates a relay,
-  # there is something that ping itself _through_ the relay each
-  # 10 seconds.  So no activity through the relay
-  # means (likely) the other side is dead.  A cleaner apprach would
-  # be welcomed here.
-  @idle_timeout 20_000
-
   @spec list_running_relays() :: [{Ockam.Address.t(), map()}]
   def list_running_relays() do
     Ockam.Node.Registry.select_by_attribute(:service, :relay)
@@ -126,7 +118,6 @@ defmodule Ockam.Services.Relay.StaticForwarding do
         Forwarder.create(
           Keyword.merge(forwarder_options,
             address: forwarder_address,
-            idle_timeout: @idle_timeout,
             relay_options: [
               alias: alias_str,
               route: route,

--- a/implementations/elixir/ockam/ockam_services/lib/services/relay/worker.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/relay/worker.ex
@@ -20,29 +20,45 @@ defmodule Ockam.Services.Relay.Worker do
     target_identifier = Keyword.get(relay_options, :target_identifier)
     notify = Keyword.get(relay_options, :notify, false)
     route = Keyword.get(relay_options, :route)
-    {:ok, ts} = DateTime.now("Etc/UTC")
 
-    regitry_metadata = %{
-      service: :relay,
-      tags: user_defined_tags,
-      target_identifier: target_identifier,
-      created_at: ts,
-      updated_at: ts
-    }
+    case monitor(route) do
+      {:ok, ref} ->
+        {:ok, ts} = DateTime.now("Etc/UTC")
 
-    maybe_notify_target(notify, route, alias_str, state.address)
+        regitry_metadata = %{
+          service: :relay,
+          tags: user_defined_tags,
+          target_identifier: target_identifier,
+          created_at: ts,
+          updated_at: ts
+        }
 
-    {:ok, regitry_metadata,
-     Map.merge(state, %{alias: alias_str, route: route, target_identifier: target_identifier})}
+        maybe_notify_target(notify, route, alias_str, state.address)
+
+        {:ok, regitry_metadata,
+         Map.merge(state, %{
+           alias: alias_str,
+           route: route,
+           target_identifier: target_identifier,
+           monitor_ref: ref
+         })}
+
+      :error ->
+        Logger.warning("monitoring #{inspect(route)} failed, addr not found")
+        {:error, :monitoring_failed}
+    end
   end
 
   @impl true
   def handle_call(
         {:update_route, route, target_identifier, user_defined_tags, notify},
         _from,
-        %{alias: alias_str} = state
+        %{alias: alias_str, monitor_ref: ref} = state
       ) do
+    true = Process.demonitor(ref, [:flush])
+    ref = monitor(route)
     state = Map.put(state, :route, route)
+    state = Map.put(state, :monitor_ref, ref)
     {:ok, ts} = DateTime.now("Etc/UTC")
     # Update metadata attributes
     :ok =
@@ -87,5 +103,35 @@ defmodule Ockam.Services.Relay.Worker do
   def handle_message(msg, state) do
     Logger.warning("message #{inspect(msg)} received without target route setup, discarded")
     {:ok, state}
+  end
+
+  def handle_monitor_down(
+        {:DOWN, ref, :process, _pid, reason},
+        %{monitor_ref: current_ref} = state
+      )
+      when ref == current_ref do
+    Logger.warning("Terminating relay worker,  route terminated with reason: #{inspect(reason)}")
+    {:stop, reason, state}
+  end
+
+  def handle_monitor_down(
+        {:DOWN, ref, :process, pid, reason},
+        %{monitor_ref: current_ref} = state
+      ) do
+    Logger.info(
+      "Ignoring outdated monitor notification. Reason: #{inspect(reason)} Pid: #{inspect(pid)} Ref: #{inspect(ref)}.  Current ref: #{inspect(current_ref)}"
+    )
+
+    {:noreply, state}
+  end
+
+  defp monitor([addr | _route]) do
+    case Ockam.Node.whereis(addr) do
+      nil ->
+        :error
+
+      pid ->
+        {:ok, Process.monitor(pid)}
+    end
   end
 end

--- a/implementations/elixir/ockam/ockam_services/test/services/static_forwarding_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/services/static_forwarding_test.exs
@@ -34,7 +34,9 @@ defmodule Test.Services.StaticForwardingTest do
           static_keypair: listener_keypair,
           static_key_attestation: attestation
         ],
-        authorities: [authority]
+        authorities: [authority],
+        # Needed to test the relay termination
+        idle_timeout: 2000
       )
 
     # TODO: rework the relationship on credential exchange API, attribute storage and secure channel
@@ -211,6 +213,59 @@ defmodule Test.Services.StaticForwardingTest do
       refute_register_relay(channel_carol_2, service_address, "anyalias", [test_address_carol])
 
     Ockam.Node.stop(forwarder_address)
+    assert_eventually([] = StaticForwardingService.list_running_relays())
+  end
+
+  test "relay terminated if forwarder route stops", %{
+    authority: authority,
+    alice: alice,
+    listener: listener,
+    service_addr: service_address
+  } do
+    {:ok, test_address_alice} = Node.register_random_address()
+
+    alias_str = "test_static_forwarding_alias"
+
+    forwarder_address = "forward_to_" <> alias_str
+
+    on_exit(fn ->
+      Node.stop(forwarder_address)
+      Node.unregister_address(test_address_alice)
+    end)
+
+    {:ok, channel_alice} =
+      create_channel_with_credential(authority, alice, listener, %{
+        "ockam-relay" => alias_str
+      })
+
+    {:ok, ^forwarder_address} =
+      assert_register_relay(channel_alice, service_address, alias_str, [test_address_alice])
+
+    assert_message_pass_through_relay(forwarder_address, [test_address_alice])
+
+    # Metadata on the relay point to alice
+    alice_id = Identity.get_identifier(alice)
+
+    assert_eventually(
+      [%Relay{addr: ^forwarder_address, target_identifier: ^alice_id}] =
+        StaticForwardingService.list_running_relays()
+    )
+
+    ref = Process.monitor(Ockam.Node.whereis(forwarder_address))
+
+    # Terminate alice' channel.  This "client" side of the secure channel.
+    # The "server" side will be terminated due to inactivity because of the idle_timeout on the
+    # listener defined on the test setup. The relay must be terminated in reaction to that.
+    Ockam.Node.stop(channel_alice)
+
+    receive do
+      {:DOWN, ^ref, :process, _pid, _reason} ->
+        :ok
+    after
+      5000 ->
+        raise "Timeout waiting for relay termination"
+    end
+
     assert_eventually([] = StaticForwardingService.list_running_relays())
   end
 end


### PR DESCRIPTION
previous attempt at detecting inactivity at relay was faulty because the nodes don't ping through the relay. They only monitor the secure channel itself. 

The node that setup a relay will try to ping the echo worker on the other side, that tests the route till the other node is up,  but that doesn't pass through the relay at any time,  making detecting inactivity at the relay worker irrelevant.  (this is further complicated when there are portals through the relay, as they have their own ping mechanism and those do pass through the relay).

This takes a different approach.  Detect if the immediate next addr that the message would be forwarder to is still running. If it isn't,  terminate the relay.