### PR TITLE
fix: cluster inlets improvements

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/base_command.rs
+++ b/implementations/rust/ockam/ockam_command/src/base_command.rs
@@ -206,7 +206,7 @@ impl BaseCommand {
         if let Some(spinner) = &spinner {
             spinner.set_message(format!(
                 "Opening a Portal to the outlet {} from {}...",
-                color_primary(pod_name),
+                color_primary(to),
                 color_primary(from.to_string())
             ));
         }
@@ -241,7 +241,7 @@ impl BaseCommand {
         }
         opts.terminal.write_line(fmt_ok!(
             "Portal connected to the outlet {} in {}",
-            color_primary(pod_name),
+            color_primary(to),
             color_primary(from.to_string())
         ))?;
 

--- a/implementations/rust/ockam/ockam_command/src/cluster/secret.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/secret.rs
@@ -153,8 +153,11 @@ impl SecretCommand {
         if let Some(spinner) = &spinner {
             spinner.finish_and_clear();
         }
-        opts.terminal
-            .write_line(fmt_ok!("Secrets created successfully!"))?;
+        opts.terminal.write_line(fmt_ok!(
+            "Pushed secrets to zone {} in cluster {}",
+            color_primary(zone_name),
+            color_primary(cluster)
+        ))?;
 
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/cluster/zone_config.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/zone_config.rs
@@ -231,7 +231,7 @@ impl Pod {
         }
 
         // If there is only one outlet, return it as the repl
-        if rest.len() == 1 {
+        if repl.is_none() && rest.len() == 1 {
             repl = Some(rest.remove(0));
         }
 
@@ -905,6 +905,37 @@ pods:
             .rest
             .iter()
             .any(|o| o.name == Some("cache".to_string())));
+    }
+
+    #[test]
+    fn test_pod_get_outlets_multiple_yaml() {
+        let config = r"
+name: example05
+pods:
+  - name: main-pod
+    containers:
+      - name: main
+        image: main
+        args: [localhost:9000, localhost:9001]
+    portals:
+      outlets:
+        - name: repl
+          to: localhost:9000
+        - name: http
+          to: localhost:9001
+          ";
+
+        let parsed = serde_yaml::from_str::<ZoneConfig>(config).unwrap();
+        let pod = &parsed.pods[0];
+        let outlets = pod.get_outlets();
+        assert_eq!(
+            outlets.repl.as_ref().unwrap().name,
+            Some("repl".to_string())
+        );
+        assert_eq!(outlets.repl.as_ref().unwrap().to, "localhost:9000");
+        assert_eq!(outlets.rest.len(), 1);
+        assert_eq!(outlets.rest[0].name, Some("http".to_string()));
+        assert_eq!(outlets.rest[0].to, "localhost:9001");
     }
 
     #[test]

--- a/implementations/rust/ockam/ockam_command/src/cluster/zone_config.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/zone_config.rs
@@ -799,7 +799,7 @@ pods:
         let main_pod = config.get_main_pod().unwrap();
         assert_eq!(main_pod.name, "single-pod");
 
-        // Test case: multiple pods, one named "main"
+        // Test case: multiple pods, one named "main-pod"
         let yaml_with_main = r#"
         name: test-zone
         pods:
@@ -807,7 +807,7 @@ pods:
           containers:
           - name: app1
             image: app1-image
-        - name: main
+        - name: main-pod
           containers:
           - name: app2
             image: app2-image
@@ -819,7 +819,7 @@ pods:
 
         let config = serde_yaml::from_str::<ZoneConfig>(yaml_with_main).unwrap();
         let main_pod = config.get_main_pod().unwrap();
-        assert_eq!(main_pod.name, "main");
+        assert_eq!(main_pod.name, "main-pod");
 
         // Test case: multiple pods, none named "main"
         let yaml_without_main = r#"

--- a/implementations/rust/ockam/ockam_command/src/cluster/zone_config.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/zone_config.rs
@@ -211,7 +211,7 @@ impl ZoneConfig {
             // Try to find a pod named "main"
             self.pods
                 .iter()
-                .find(|pod| pod.name == "main")
+                .find(|pod| pod.name == "main-pod")
                 .ok_or_else(|| miette::miette!("Multiple pods defined, but none is named 'main'"))
         }
     }


### PR DESCRIPTION
- use "main-pod" as the main pod name instead of "main"
- parse outlets from zone config properly
- fix copy when creating an inlet in "ockam" command
- improve `cluster secret` copy