### PR TITLE
fix(elixir): fix replacement and termination of relays

### DIFF
--- a/implementations/elixir/ockam/ockam_services/lib/services/relay/worker.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/relay/worker.ex
@@ -21,32 +21,26 @@ defmodule Ockam.Services.Relay.Worker do
     notify = Keyword.get(relay_options, :notify, false)
     route = Keyword.get(relay_options, :route)
 
-    case monitor(route) do
-      {:ok, ref} ->
-        {:ok, ts} = DateTime.now("Etc/UTC")
+    ref = monitor(route)
+    {:ok, ts} = DateTime.now("Etc/UTC")
 
-        regitry_metadata = %{
-          service: :relay,
-          tags: user_defined_tags,
-          target_identifier: target_identifier,
-          created_at: ts,
-          updated_at: ts
-        }
+    regitry_metadata = %{
+      service: :relay,
+      tags: user_defined_tags,
+      target_identifier: target_identifier,
+      created_at: ts,
+      updated_at: ts
+    }
 
-        maybe_notify_target(notify, route, alias_str, state.address)
+    maybe_notify_target(notify, route, alias_str, state.address)
 
-        {:ok, regitry_metadata,
-         Map.merge(state, %{
-           alias: alias_str,
-           route: route,
-           target_identifier: target_identifier,
-           monitor_ref: ref
-         })}
-
-      :error ->
-        Logger.warning("monitoring #{inspect(route)} failed, addr not found")
-        {:error, :monitoring_failed}
-    end
+    {:ok, regitry_metadata,
+     Map.merge(state, %{
+       alias: alias_str,
+       route: route,
+       target_identifier: target_identifier,
+       monitor_ref: ref
+     })}
   end
 
   @impl true
@@ -111,7 +105,7 @@ defmodule Ockam.Services.Relay.Worker do
       )
       when ref == current_ref do
     Logger.warning("Terminating relay worker,  route terminated with reason: #{inspect(reason)}")
-    {:stop, reason, state}
+    {:stop, :normal, state}
   end
 
   def handle_monitor_down(
@@ -126,12 +120,6 @@ defmodule Ockam.Services.Relay.Worker do
   end
 
   defp monitor([addr | _route]) do
-    case Ockam.Node.whereis(addr) do
-      nil ->
-        :error
-
-      pid ->
-        {:ok, Process.monitor(pid)}
-    end
+    Process.monitor(Ockam.Node.whereis(addr))
   end
 end

--- a/implementations/elixir/ockam/ockam_services/test/services/static_forwarding_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/services/static_forwarding_test.exs
@@ -268,4 +268,84 @@ defmodule Test.Services.StaticForwardingTest do
 
     assert_eventually([] = StaticForwardingService.list_running_relays())
   end
+
+  test "relay can be updated multiple times", %{
+    authority: authority,
+    alice: alice,
+    bob: bob,
+    carol: carol,
+    listener: listener,
+    service_addr: service_address
+  } do
+    {:ok, test_address_alice} = Node.register_random_address()
+    {:ok, test_address_bob} = Node.register_random_address()
+    {:ok, test_address_carol} = Node.register_random_address()
+
+    alias_str = "test_static_forwarding_alias"
+    forwarder_address = "forward_to_" <> alias_str
+
+    on_exit(fn ->
+      Node.stop(forwarder_address)
+      Node.unregister_address(test_address_alice)
+      Node.unregister_address(test_address_bob)
+      Node.unregister_address(test_address_carol)
+    end)
+
+    {:ok, channel_alice} =
+      create_channel_with_credential(authority, alice, listener, %{
+        "ockam-relay" => alias_str
+      })
+
+    {:ok, channel_bob} =
+      create_channel_with_credential(authority, bob, listener, %{
+        "ockam-relay" => alias_str
+      })
+
+    {:ok, channel_carol} =
+      create_channel_with_credential(authority, carol, listener, %{
+        "ockam-relay" => alias_str
+      })
+
+    {:ok, ^forwarder_address} =
+      assert_register_relay(channel_alice, service_address, alias_str, [test_address_alice])
+
+    {:ok, ^forwarder_address} =
+      assert_register_relay(channel_bob, service_address, alias_str, [test_address_bob])
+
+    # Termination of replaced route don't affect the relay
+    Ockam.Node.stop(channel_alice)
+
+    {:ok, ^forwarder_address} =
+      assert_register_relay(channel_carol, service_address, alias_str, [test_address_carol])
+
+    # Termination of replaced route don't affect the relay
+    Ockam.Node.stop(channel_bob)
+
+    assert_message_pass_through_relay(forwarder_address, [test_address_carol])
+
+    # Metadata on the relay point to alice
+    carol_id = Identity.get_identifier(carol)
+
+    assert_eventually(
+      [%Relay{addr: ^forwarder_address, target_identifier: ^carol_id}] =
+        StaticForwardingService.list_running_relays()
+    )
+
+    ref = Process.monitor(Ockam.Node.whereis(forwarder_address))
+
+    # Terminate alice' channel.  This "client" side of the secure channel.
+    # The "server" side will be terminated due to inactivity because of the idle_timeout on the
+    # listener defined on the test setup. The relay must be terminated in reaction to that.
+    Ockam.Node.stop(channel_carol)
+
+    receive do
+      {:DOWN, ^ref, :process, _pid, _reason} ->
+        :ok
+    after
+      5000 ->
+        raise "Timeout waiting for relay termination"
+    end
+
+    assert_eventually([] = StaticForwardingService.list_running_relays())
+  end
 end


### PR DESCRIPTION
replacing the relay a couple of times without it being terminated was leading to issues due to a bug on how we stored the updated monitor reference.
This in turn caused cascading failure at different place, due to the way `Ockam.Worker` behaviour is defined (basically, we _can't_  fail at the `setup()` call,  so always setup monitor even if the address doesn't exists,  that anyway result in a DOWN message be sent immediately, so the relay is terminated when receiving that).

Added test case for replacement and secure channel termination interleaving -and checked that new test was indeed failing before this fix-