### PR TITLE
feat: add `background` argument to `cluster inlet/outlet`

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/base_command.rs
+++ b/implementations/rust/ockam/ockam_command/src/base_command.rs
@@ -224,6 +224,7 @@ impl BaseCommand {
             enrollment_ticket: Some(ticket),
             from: from.clone(),
             to: Some(to.to_string()),
+            background: true,
             no_ctrlc_handler: true,
             ..Default::default()
         };

--- a/implementations/rust/ockam/ockam_command/src/cluster/inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/inlet.rs
@@ -52,6 +52,9 @@ pub struct InletCommand {
     "))]
     pub enrollment_ticket: Option<String>,
 
+    #[arg(long)]
+    pub background: bool,
+
     /// Disable the Ctrl-C handler.
     #[arg(long)]
     pub no_ctrlc_handler: bool,
@@ -114,7 +117,11 @@ impl InMemoryNodeCommand for InletNodeCommand {
             node_config["tcp-inlet"]["allow"] = allow.to_string().into();
         }
         let in_memory = true;
-        let node_callback = NodeCallback::create().await?;
+        let node_callback = if self.command.background {
+            Some(NodeCallback::create().await?)
+        } else {
+            None
+        };
         let node_cmd = crate::node::create::CreateCommand {
             name: node_config.to_string(),
             config_args: ConfigArgs {
@@ -127,7 +134,7 @@ impl InMemoryNodeCommand for InletNodeCommand {
                 ..Default::default()
             },
             in_memory,
-            tcp_callback_port: Some(node_callback.callback_port()),
+            tcp_callback_port: node_callback.as_ref().map(|n| n.callback_port()),
             ..Default::default()
         };
         let mut opts = self.opts.clone();
@@ -138,7 +145,11 @@ impl InMemoryNodeCommand for InletNodeCommand {
             node_cmd.run(node.ctx(), opts).await?;
             Ok(())
         });
-        wait_for_node_callback_future(handle, node_callback).await?;
+        if let Some(node_callback) = node_callback {
+            wait_for_node_callback_future(handle, node_callback).await?;
+        } else {
+            handle.await.into_diagnostic()??;
+        }
         Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/cluster/outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/outlet.rs
@@ -42,6 +42,9 @@ pub struct OutletCommand {
     #[arg(long)]
     pub relay: String,
 
+    #[arg(long)]
+    pub background: bool,
+
     // == TCP Outlet Options ==
     /// Service address of your TCP Outlet, which is part of a route used in other commands.
     /// This unique address identifies the TCP Outlet worker on the Node on your local machine.
@@ -91,7 +94,11 @@ impl InMemoryNodeCommand for OutletNodeCommand {
             node_config["tcp-outlet"]["allow"] = allow.to_string().into();
         }
         let in_memory = true;
-        let node_callback = NodeCallback::create().await?;
+        let node_callback = if self.command.background {
+            Some(NodeCallback::create().await?)
+        } else {
+            None
+        };
         let node_cmd = crate::node::create::CreateCommand {
             name: node_config.to_string(),
             config_args: ConfigArgs {
@@ -103,7 +110,7 @@ impl InMemoryNodeCommand for OutletNodeCommand {
                 ..Default::default()
             },
             in_memory,
-            tcp_callback_port: Some(node_callback.callback_port()),
+            tcp_callback_port: node_callback.as_ref().map(|n| n.callback_port()),
             ..Default::default()
         };
         let mut opts = self.opts.clone();
@@ -114,7 +121,11 @@ impl InMemoryNodeCommand for OutletNodeCommand {
             node_cmd.run(node.ctx(), opts).await?;
             Ok(())
         });
-        wait_for_node_callback_future(handle, node_callback).await?;
+        if let Some(node_callback) = node_callback {
+            wait_for_node_callback_future(handle, node_callback).await?;
+        } else {
+            handle.await.into_diagnostic()??;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
This argument allows us to run cluster portals in background (when run in `ockam`) and foreground (when run in `cluster inlet/outlet) modes. 