### PR TITLE
refactor: process "ockam" as a clap command, enabling passing arguments to it

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/base_command.rs
+++ b/implementations/rust/ockam/ockam_command/src/base_command.rs
@@ -13,7 +13,6 @@ use ockam_api::address::get_free_address;
 use ockam_api::colors::color_primary;
 use ockam_api::orchestrator::ai_platform::node_service_client::AI_API_BASE_URL;
 use ockam_api::{fmt_log, fmt_ok, fmt_separator};
-use ockam_core::env::get_env_ignore_error;
 use ockam_node::{Context, Executor, NodeBuilder};
 use std::fmt::{Display, Formatter};
 use std::net::SocketAddr;
@@ -26,6 +25,10 @@ use tracing::debug;
 
 #[derive(Clone, Debug, Args, Default)]
 pub struct BaseCommand {
+    #[arg(long)]
+    ignore_docker_cache: bool,
+
+    #[arg(long, default_value = "hello", env = "INIT_REPOSITORY")]
     init_repository: String,
 }
 
@@ -34,15 +37,7 @@ impl BaseCommand {
         BrandingCompileEnvVars::bin_name().to_string()
     }
 
-    async fn parse_args(mut self, _opts: &CommandGlobalOpts) -> Result<Self> {
-        // load default values
-        self.init_repository = "hello".to_string();
-
-        // load env vars
-        if let Some(v) = get_env_ignore_error("INIT_REPOSITORY") {
-            self.init_repository = v;
-        }
-
+    async fn parse_args(self, _opts: &CommandGlobalOpts) -> Result<Self> {
         Ok(self)
     }
 
@@ -125,6 +120,7 @@ impl BaseCommand {
         let create_command = CreateCommand {
             use_public_ecr: true,
             http_api: HttpApiArgs::from_api_endpoint(AI_API_BASE_URL.to_string()),
+            ignore_docker_cache: self.ignore_docker_cache,
             ..Default::default()
         };
         let zone_config = create_command.run(ctx, opts.clone()).await?;

--- a/implementations/rust/ockam/ockam_command/src/cluster/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/create.rs
@@ -13,7 +13,6 @@ use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::ai_platform::api::AiPlatformApi;
 use ockam_api::orchestrator::ai_platform::responses::EcrCredentials;
 use ockam_api::{fmt_log, fmt_ok};
-use ockam_core::env::get_env_ignore_error;
 use ockam_node::Context;
 use std::process::Stdio;
 use std::sync::Arc;
@@ -42,9 +41,9 @@ pub struct CreateCommand {
     pub use_public_ecr: bool,
 
     /// Whether to use the Docker cache when building the image.
-    /// It can be set using the `OCKAM_USE_DOCKER_CACHE` environment variable.
-    #[arg(long)]
-    pub use_docker_cache: bool,
+    /// It can be set using the `OCKAM_IGNORE_DOCKER_CACHE` environment variable.
+    #[arg(long, env = "OCKAM_IGNORE_DOCKER_CACHE")]
+    pub ignore_docker_cache: bool,
 
     #[command(flatten)]
     pub http_api: HttpApiArgs,
@@ -79,9 +78,6 @@ impl Command<ZoneConfig> for CreateCommand {
     const NAME: &'static str = "cluster create";
 
     async fn run(mut self, ctx: &Context, opts: CommandGlobalOpts) -> Result<ZoneConfig> {
-        if let Some(v) = get_env_ignore_error::<bool>("OCKAM_USE_DOCKER_CACHE") {
-            self.use_docker_cache = v;
-        }
         let command = CreateNodeCommand {
             opts: opts.clone(),
             command: self.clone(),
@@ -273,7 +269,7 @@ impl CreateCommand {
             for arg in cmd_args {
                 command.arg(arg);
             }
-            if !self.use_docker_cache {
+            if self.ignore_docker_cache {
                 command.arg("--no-cache");
             }
             for (env_name, env_value) in env_vars {

--- a/implementations/rust/ockam/ockam_command/src/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/command.rs
@@ -1,3 +1,4 @@
+use crate::base_command::BaseCommand;
 use crate::branding::{load_compile_time_vars, BrandingCompileEnvVars, OUTPUT_BRANDING};
 use crate::command_events::add_command_event;
 use crate::command_global_opts::CommandGlobalOpts;
@@ -51,11 +52,14 @@ arg_required_else_help = false,
 subcommand_required = false,
 )]
 pub struct OckamCommand {
-    #[command(subcommand)]
-    pub(crate) subcommand: OckamSubcommand,
-
     #[command(flatten)]
     pub global_args: GlobalArgs,
+
+    #[command(flatten)]
+    pub base_command_args: BaseCommand,
+
+    #[command(subcommand)]
+    pub(crate) subcommand: Option<OckamSubcommand>,
 }
 
 impl OckamCommand {
@@ -73,11 +77,8 @@ impl OckamCommand {
         // This allows us to customize how we format the error messages and their content.
         let _hook_result = miette::set_hook(Box::new(|_| Box::new(ErrorReportHandler::new())));
 
-        let command_name = self.subcommand.name();
-
         let mut in_memory = false;
-
-        if let OckamSubcommand::Node(cmd) = &self.subcommand {
+        if let Some(OckamSubcommand::Node(cmd)) = &self.subcommand {
             if let crate::node::NodeSubcommand::Create(c) = &cmd.subcommand {
                 in_memory = c.in_memory;
             }
@@ -117,9 +118,12 @@ impl OckamCommand {
         debug!("{:#?}", logging_configuration);
         debug!("{:#?}", exporting_configuration);
 
+        let command_name = self.name();
         let tracer = global::tracer(OCKAM_TRACER_NAME);
-
-        let span = if let Some(opentelemetry_context) = self.subcommand.get_opentelemetry_context()
+        let span = if let Some(opentelemetry_context) = self
+            .subcommand
+            .as_ref()
+            .and_then(|c| c.get_opentelemetry_context())
         {
             let span_builder =
                 SpanBuilder::from_name(command_name.clone()).with_links(vec![Link::new(
@@ -162,8 +166,7 @@ impl OckamCommand {
         );
 
         let options = CommandGlobalOpts::new(self.global_args.clone(), cli_state, terminal);
-
-        options.log_inputs(arguments, &self.subcommand);
+        options.log_inputs(arguments, &self.name());
 
         if let Err(err) = check_if_an_upgrade_is_available(&options).await {
             warn!("Failed to check for upgrade, error={err}");
@@ -201,7 +204,7 @@ impl OckamCommand {
             Err(err) => {
                 // If the user is trying to run `ockam reset` and the local state is corrupted,
                 // we can try to hard reset the local state.
-                if let OckamSubcommand::Reset(c) = &self.subcommand {
+                if let Some(OckamSubcommand::Reset(c)) = &self.subcommand {
                     c.hard_reset();
                     println!(
                         "{}",
@@ -250,7 +253,12 @@ impl OckamCommand {
             return None;
         };
 
-        let app_name = if self.subcommand.is_local_node() {
+        let app_name = if self
+            .subcommand
+            .as_ref()
+            .map(|c| c.is_local_node())
+            .unwrap_or_default()
+        {
             "local node"
         } else {
             "cli"
@@ -260,7 +268,7 @@ impl OckamCommand {
             logging_configuration,
             exporting_configuration,
             app_name,
-            self.subcommand.node_name(),
+            self.subcommand.as_ref().and_then(|c| c.node_name()),
             ctx,
         );
 
@@ -269,8 +277,14 @@ impl OckamCommand {
 
     /// Create the logging configuration, depending on the command to execute
     fn make_logging_configuration(&self, is_tty: bool) -> miette::Result<LoggingConfiguration> {
-        if self.subcommand.is_background_node() {
-            Ok(LoggingConfiguration::background(self.subcommand.log_path()).into_diagnostic()?)
+        let subcommand = self.subcommand.as_ref();
+
+        if subcommand
+            .map(|c| c.is_background_node())
+            .unwrap_or_default()
+        {
+            let log_path = subcommand.map(|c| c.log_path()).unwrap_or_default();
+            Ok(LoggingConfiguration::background(log_path).into_diagnostic()?)
         } else {
             let verbose = self.global_args.verbose;
             let mut level_and_crates =
@@ -278,11 +292,14 @@ impl OckamCommand {
             let mut log_path = if level_and_crates.explicit_verbose_flag {
                 None
             } else {
-                Some(CliState::command_log_path(self.subcommand.name().as_str())?)
+                Some(CliState::command_log_path(self.name().as_str())?)
             };
             let mut logging_enabled = logging_enabled()?;
             let mut default_log_format = LogFormat::Default;
-            if self.subcommand.is_foreground_node() && verbose == 0 {
+            let is_foreground_node = subcommand
+                .map(|c| c.is_foreground_node())
+                .unwrap_or_default();
+            if is_foreground_node && verbose == 0 {
                 log_path = None;
                 logging_enabled = LoggingEnabled::On;
                 level_and_crates.crates_filter =
@@ -311,7 +328,12 @@ impl OckamCommand {
         state: &CliState,
         ctx: &Context,
     ) -> miette::Result<ExportingConfiguration> {
-        if self.subcommand.is_background_node() {
+        if self
+            .subcommand
+            .as_ref()
+            .map(|c| c.is_background_node())
+            .unwrap_or_default()
+        {
             ExportingConfiguration::background(state, ctx)
                 .await
                 .into_diagnostic()
@@ -322,7 +344,7 @@ impl OckamCommand {
         }
     }
 
-    #[instrument(skip_all, fields(command = self.subcommand.name()), level = Level::TRACE)]
+    #[instrument(skip_all, fields(command = self.name()), level = Level::TRACE)]
     async fn run_command(
         self,
         ctx: &Context,
@@ -331,6 +353,18 @@ impl OckamCommand {
         arguments: &[String],
     ) -> miette::Result<()> {
         add_command_event(opts.state.clone(), command_name, arguments.join(" ")).await?;
-        self.subcommand.run(ctx, opts).await
+        if let Some(subcommand) = self.subcommand {
+            subcommand.run(ctx, opts).await
+        } else {
+            self.base_command_args.run(ctx, opts).await
+        }
+    }
+
+    fn name(&self) -> String {
+        if let Some(subcommand) = &self.subcommand {
+            subcommand.name()
+        } else {
+            self.base_command_args.name()
+        }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
+++ b/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
@@ -2,7 +2,6 @@ use console::Term;
 use std::sync::Arc;
 use tracing::debug;
 
-use crate::subcommand::OckamSubcommand;
 use crate::version::Version;
 use crate::GlobalArgs;
 use ockam_api::terminal::{Terminal, TerminalStream};
@@ -43,10 +42,10 @@ impl CommandGlobalOpts {
     }
 
     /// Log the inputs and configurations used to execute the command
-    pub(crate) fn log_inputs(&self, arguments: &[String], cmd: &OckamSubcommand) {
+    pub(crate) fn log_inputs(&self, arguments: &[String], cmd_name: &str) {
         debug!("Arguments: {}", arguments.join(" "));
         debug!("Global arguments: {:#?}", &self.global_args);
-        debug!("Command: {:#?}", &cmd);
+        debug!("Command: {:#?}", &cmd_name);
         debug!("Version: {}", Version::new().no_color());
     }
 

--- a/implementations/rust/ockam/ockam_command/src/entry_point.rs
+++ b/implementations/rust/ockam/ockam_command/src/entry_point.rs
@@ -58,13 +58,7 @@ pub fn run() -> miette::Result<()> {
         input
     };
 
-    let no_args_passed = input.len() <= 1;
-    let command_parsing_res = if no_args_passed {
-        let cmd = OckamCommand::default();
-        Ok(cmd)
-    } else {
-        OckamCommand::try_parse_from(&input)
-    };
+    let command_parsing_res = OckamCommand::try_parse_from(&input);
 
     let node_builder = NodeBuilder::new().no_logging();
 

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/utils.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/utils.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use miette::IntoDiagnostic;
+use miette::{miette, IntoDiagnostic};
 use once_cell::sync::Lazy;
 
 use crate::{OckamCommand, OckamSubcommand};
@@ -22,7 +22,8 @@ pub fn parse_cmd_from_args(cmd: &str, args: &[String]) -> miette::Result<OckamSu
         .chain(cmd.split(' '))
         .chain(args.iter().map(|s| s.as_str()))
         .collect::<Vec<_>>();
-    Ok(OckamCommand::try_parse_from(args)
+    OckamCommand::try_parse_from(args)
         .into_diagnostic()?
-        .subcommand)
+        .subcommand
+        .ok_or(miette!("Failed to parse as a subcommand"))
 }

--- a/implementations/rust/ockam/ockam_command/src/subcommand.rs
+++ b/implementations/rust/ockam/ockam_command/src/subcommand.rs
@@ -17,7 +17,6 @@ use ockam_node::Context;
 
 use crate::admin::AdminCommand;
 use crate::authority::{AuthorityCommand, AuthoritySubcommand};
-use crate::base_command::BaseCommand;
 use crate::branding::command;
 use crate::cluster::ClusterCommand;
 use crate::command_global_opts::CommandGlobalOpts;
@@ -70,8 +69,6 @@ use crate::Result;
 #[derive(Clone, Debug, Subcommand)]
 #[command(about = docs::about("List of commands which can be executed with `ockam`"))]
 pub enum OckamSubcommand {
-    BaseCommand(BaseCommand),
-
     #[command(name = command::name("enroll"), hide = command::hide("enroll"))]
     Enroll(EnrollCommand),
 
@@ -166,18 +163,10 @@ pub enum OckamSubcommand {
     Share(ShareCommand),
 }
 
-impl Default for OckamSubcommand {
-    fn default() -> Self {
-        OckamSubcommand::BaseCommand(BaseCommand::default())
-    }
-}
-
 impl OckamSubcommand {
     /// Run the subcommand
     pub async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self {
-            OckamSubcommand::BaseCommand(c) => c.run(ctx, opts).await,
-
             OckamSubcommand::Enroll(c) => c.run(ctx, opts).await,
             OckamSubcommand::Cluster(c) => c.run(ctx, opts).await,
 
@@ -337,7 +326,6 @@ impl OckamSubcommand {
     /// Return the subcommand name
     pub fn name(&self) -> String {
         match self {
-            OckamSubcommand::BaseCommand(c) => c.name(),
             OckamSubcommand::Enroll(c) => c.name(),
             OckamSubcommand::Cluster(c) => c.name(),
             OckamSubcommand::Node(c) => c.name(),


### PR DESCRIPTION
- The `ockam` command now accepts arguments: `--ignore-docker-cache` and `--init-repository`. That also means we can enable logging in the base command, for example: `ockam -vv`
- The `OCKAM_USE_DOCKER_CACHE` env var has been replaced by `OCKAM_IGNORE_DOCKER_CACHE`, so the default behavior now is to use docker cache.