### PR TITLE
feat(rust): improvements to cluster outlet command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/base_command.rs
+++ b/implementations/rust/ockam/ockam_command/src/base_command.rs
@@ -1,5 +1,5 @@
 use crate::branding::BrandingCompileEnvVars;
-use crate::cluster::common_args::{HttpApiArgs, ZoneNameOrConfigArg};
+use crate::cluster::common_args::{EnrollmentTicketConfigArg, HttpApiArgs, ZoneNameOrConfigArg};
 use crate::cluster::zone_config::{Outlet, ZoneConfig};
 use crate::entry_point::RUNTIME;
 use crate::util::port_is_free_guard;
@@ -189,7 +189,7 @@ impl BaseCommand {
     #[allow(clippy::too_many_arguments)]
     async fn cluster_inlet(
         &self,
-        ctx: &Context,
+        _ctx: &Context,
         opts: &CommandGlobalOpts,
         zone_name: &str,
         pod_name: &str,
@@ -209,19 +209,14 @@ impl BaseCommand {
         let mut no_output_opts = opts.clone();
         no_output_opts.terminal = opts.terminal.disable();
 
-        use crate::cluster::ticket::TicketCommand;
-        let ticket_command = TicketCommand {
-            zone: ZoneNameOrConfigArg::from_zone_name(zone_name.to_string()),
-            http_api: HttpApiArgs::from_api_endpoint(AI_API_BASE_URL.to_string()),
-            ..Default::default()
-        };
-        let ticket = ticket_command.run(ctx, no_output_opts.clone()).await?;
-
         use crate::cluster::inlet::InletCommand;
         let inlet_command = InletCommand {
             zone: ZoneNameOrConfigArg::from_zone_name(zone_name.to_string()),
+            http_api: HttpApiArgs::from_api_endpoint(AI_API_BASE_URL.to_string()),
             pod: pod_name.to_string(),
-            enrollment_ticket: Some(ticket),
+            enrollment_ticket: EnrollmentTicketConfigArg {
+                enrollment_ticket: None,
+            },
             from: from.clone(),
             to: Some(to.to_string()),
             background: true,

--- a/implementations/rust/ockam/ockam_command/src/cluster/common_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/common_args.rs
@@ -133,8 +133,6 @@ pub struct SecretsConfigArg {
 
 #[derive(Clone, Debug, Args, Default)]
 pub struct EnrollmentTicketConfigArg {
-    /// Enrollment ticket
-    /// If not set, one will be created
     #[arg(long, env = "ENROLLMENT_TICKET", value_name = "ENROLLMENT TICKET")]
     #[arg(help = docs::about("\
     A path, URL or inlined hex-encoded enrollment ticket to use for the Ockam Identity associated to this node. \

--- a/implementations/rust/ockam/ockam_command/src/cluster/common_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/common_args.rs
@@ -1,8 +1,12 @@
+use std::collections::BTreeMap;
+
 use crate::cluster::utils::get_cluster;
 use crate::cluster::zone_config::ZoneConfig;
+use crate::docs;
 use clap::Args;
-use miette::{miette, IntoDiagnostic};
+use miette::{miette, Context as _, IntoDiagnostic};
 use ockam_api::nodes::InMemoryNode;
+use ockam_api::orchestrator::ai_platform::api::AiPlatformApi;
 use ockam_api::orchestrator::ai_platform::node_service_client::AI_API_BASE_URL_ENV;
 use ockam_core::env::get_env_ignore_error;
 use ockam_node::Context;
@@ -125,4 +129,34 @@ pub struct SecretsConfigArg {
     /// If no file is found, the command will just list the existing secrets.
     #[arg(long, visible_alias = "secrets")]
     pub secrets_config: Option<String>,
+}
+
+#[derive(Clone, Debug, Args, Default)]
+pub struct EnrollmentTicketConfigArg {
+    /// Enrollment ticket
+    /// If not set, one will be created
+    #[arg(long, env = "ENROLLMENT_TICKET", value_name = "ENROLLMENT TICKET")]
+    #[arg(help = docs::about("\
+    A path, URL or inlined hex-encoded enrollment ticket to use for the Ockam Identity associated to this node. \
+    If ommited one will be created automatically with default attributes
+    "))]
+    pub enrollment_ticket: Option<String>,
+}
+
+impl EnrollmentTicketConfigArg {
+    pub async fn get(
+        &self,
+        ctx: &Context,
+        api_client: &(dyn AiPlatformApi + Send + Sync + 'static),
+        cluster: &str,
+        zone_name: &str,
+        relay: Option<String>,
+    ) -> crate::Result<String> {
+        if let Some(t) = &self.enrollment_ticket {
+            return Ok(t.clone());
+        }
+        api_client
+            .create_enrollment_token(ctx, cluster, zone_name, BTreeMap::default(), relay)
+            .await.wrap_err("Failed to generate an enrollment ticket for the inlet. Please provide one with the --enrollment-ticket argument")
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/cluster/inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/inlet.rs
@@ -1,4 +1,6 @@
-use crate::cluster::common_args::{ClusterArg, HttpApiArgs, ZoneNameOrConfigArg};
+use crate::cluster::common_args::{
+    ClusterArg, EnrollmentTicketConfigArg, HttpApiArgs, ZoneNameOrConfigArg,
+};
 use crate::cluster::utils::get_api_client;
 use crate::node::config::ConfigArgs;
 use crate::node::node_callback::NodeCallback;
@@ -10,15 +12,13 @@ use crate::util::parsers::hostname_parser;
 use crate::{docs, Command, CommandGlobalOpts, Result};
 use async_trait::async_trait;
 use clap::Args;
-use miette::{IntoDiagnostic, WrapErr};
+use miette::IntoDiagnostic;
 use ockam::transport::SchemeHostnamePort;
 use ockam_abac::PolicyExpression;
 use ockam_api::cli_state::OCKAM_HOME;
 use ockam_api::nodes::InMemoryNode;
-use ockam_api::orchestrator::ai_platform::api::AiPlatformApi;
 use ockam_api::CliState;
 use ockam_node::Context;
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 const LONG_ABOUT: &str = include_str!("./static/inlet/long_about.txt");
@@ -44,13 +44,8 @@ pub struct InletCommand {
     pub pod: String,
 
     // == Node Options ==
-    #[arg(long, env = "ENROLLMENT_TICKET", value_name = "ENROLLMENT TICKET")]
-    #[arg(help = docs::about("\
-    A path, URL or inlined hex-encoded enrollment ticket to use for the Ockam Identity associated to this node. \
-    When passed, the identity will be given a project membership credential. \
-    Check the `project ticket` command for more information about enrollment tickets.
-    "))]
-    pub enrollment_ticket: Option<String>,
+    #[command(flatten)]
+    pub enrollment_ticket: EnrollmentTicketConfigArg,
 
     #[arg(long)]
     pub background: bool,
@@ -102,7 +97,9 @@ impl InMemoryNodeCommand for InletNodeCommand {
         let cluster = self.command.cluster.get_cluster(ctx, &node).await?;
         let zone_name = self.command.zone.zone_name()?;
         let enrollment_ticket = self
-            .get_enrollment_ticket(ctx, &*api_client, &cluster, &zone_name)
+            .command
+            .enrollment_ticket
+            .get(ctx, &*api_client, &cluster, &zone_name, None)
             .await?;
         let relay_name = format!("{}-{}-{}", cluster, zone_name, self.command.pod);
         let outlet_name = self.command.to.as_ref().unwrap_or(&self.command.pod);
@@ -165,22 +162,5 @@ impl Command for InletCommand {
         };
         command.execute(ctx, opts.state.clone()).await?;
         Ok(())
-    }
-}
-
-impl InletNodeCommand {
-    async fn get_enrollment_ticket(
-        &self,
-        ctx: &Context,
-        api_client: &(dyn AiPlatformApi + Send + Sync + 'static),
-        cluster: &str,
-        zone_name: &str,
-    ) -> Result<String> {
-        if let Some(t) = &self.command.enrollment_ticket {
-            return Ok(t.clone());
-        }
-        api_client
-            .create_enrollment_token(ctx, cluster, zone_name, BTreeMap::default(), None)
-            .await.wrap_err("Failed to generate an enrollment ticket for the inlet. Please provide one with the --enrollment-ticket argument")
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/cluster/outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/outlet.rs
@@ -1,3 +1,7 @@
+use crate::cluster::common_args::{
+    ClusterArg, EnrollmentTicketConfigArg, HttpApiArgs, ZoneNameOrConfigArg,
+};
+use crate::cluster::utils::get_api_client;
 use async_trait::async_trait;
 use std::sync::Arc;
 
@@ -30,27 +34,31 @@ before_help = docs::before_help(PREVIEW_TAG),
 after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct OutletCommand {
-    // == Node Options ==
-    #[arg(long, env = "ENROLLMENT_TICKET", value_name = "ENROLLMENT TICKET")]
-    #[arg(help = docs::about("\
-    A path, URL or inlined hex-encoded enrollment ticket to use for the Ockam Identity associated to this node. \
-    When passed, the identity will be given a project membership credential. \
-    Check the `project ticket` command for more information about enrollment tickets.
-    "))]
-    pub enrollment_ticket: String,
+    #[command(flatten)]
+    pub cluster: ClusterArg,
 
+    #[command(flatten)]
+    pub zone: ZoneNameOrConfigArg,
+
+    // == Node Options ==
+    #[command(flatten)]
+    pub enrollment_ticket: EnrollmentTicketConfigArg,
+
+    /// Relay to register at.
     #[arg(long)]
     pub relay: String,
 
     #[arg(long)]
     pub background: bool,
 
+    #[command(flatten)]
+    pub http_api: HttpApiArgs,
+
     // == TCP Outlet Options ==
     /// Service address of your TCP Outlet, which is part of a route used in other commands.
     /// This unique address identifies the TCP Outlet worker on the Node on your local machine.
     /// Examples are `/service/my-outlet` or `my-outlet`.
-    /// If not provided, `outlet` will be used, or a random address will be generated if `outlet` is taken.
-    /// You will need this address when creating a TCP Inlet using `ockam tcp-inlet create`.
+    /// If not provided, the name of the relay will be used.
     #[arg(long, display_order = 902, id = "OUTLET_ADDRESS", value_parser = extract_address_value)]
     pub from: Option<String>,
 
@@ -81,15 +89,35 @@ struct OutletNodeCommand {
 #[async_trait]
 impl InMemoryNodeCommand for OutletNodeCommand {
     async fn run(&self, node: Arc<InMemoryNode>) -> miette::Result<()> {
+        let ctx = node.ctx();
+        let use_http_api = self.command.http_api.use_http_api();
+        let api_client = get_api_client(&node, use_http_api).await?;
+
+        // TODO: the cluster and zone are only needed here if the enrollment ticket is not provided
+        // *but* at some point we will need them to set the default policy on the outlet
+        let cluster = self.command.cluster.get_cluster(ctx, &node).await?;
+        let zone_name = self.command.zone.zone_name()?;
+        let relay_name = format!("{}-{}-{}", cluster, zone_name, self.command.relay);
+        let enrollment_ticket = self
+            .command
+            .enrollment_ticket
+            .get(
+                ctx,
+                &*api_client,
+                &cluster,
+                &zone_name,
+                Some(self.command.relay.clone()),
+            )
+            .await?;
         let mut node_config = serde_json::json!({
-            "relay": self.command.relay.clone(),
+            "relay": relay_name,
             "tcp-outlet": {
                 "to": self.command.to.to_string(),
                 }
         });
-        if let Some(from) = &self.command.from {
-            node_config["tcp-outlet"]["from"] = from.to_string().into();
-        }
+        let from = &self.command.from.as_ref().unwrap_or(&self.command.relay);
+        node_config["tcp-outlet"]["from"] = from.to_string().into();
+
         if let Some(allow) = &self.command.allow {
             node_config["tcp-outlet"]["allow"] = allow.to_string().into();
         }
@@ -102,7 +130,7 @@ impl InMemoryNodeCommand for OutletNodeCommand {
         let node_cmd = crate::node::create::CreateCommand {
             name: node_config.to_string(),
             config_args: ConfigArgs {
-                enrollment_ticket: Some(self.command.enrollment_ticket.clone()),
+                enrollment_ticket: Some(enrollment_ticket),
                 ..Default::default()
             },
             foreground_args: ForegroundArgs {


### PR DESCRIPTION
allow for automatically create ticket. Infer outlet name, build long relay names based on cluster and zone (so user don't need to know about our prefix  naming schema).

If `--enrollment-ticket` is not given,  one will be created (assuming the user is the owner of the cluster/zone) and give relay rights for the appropriate relay name.   `from`  is optional,  but instead of defaulting to `"outlet"` its default to the relay name, that is what is expected in this scenario. 