### PR TITLE
feat: in `cluster init`, support downloading templates from zip urls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arboard"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
@@ -1335,6 +1344,25 @@ checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
  "bytes 1.9.0",
  "either",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1662,6 +1690,12 @@ name = "const_fn"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "copypasta"
@@ -2092,6 +2126,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
+
+[[package]]
 name = "delegate"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,6 +2160,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2543,11 +2594,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -2856,8 +2908,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -3730,9 +3784,9 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3861,6 +3915,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-rs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3890,9 +3953,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 dependencies = [
  "value-bag",
 ]
@@ -3914,6 +3977,27 @@ checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -4055,9 +4139,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -4784,6 +4868,7 @@ dependencies = [
  "tracing",
  "url",
  "which 7.0.2",
+ "zip-extract",
 ]
 
 [[package]]
@@ -5359,6 +5444,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "pem"
@@ -8361,20 +8456,21 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -8386,9 +8482,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -8399,9 +8495,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8409,9 +8505,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8422,9 +8518,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-encoder"
@@ -8523,9 +8622,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8976,6 +9075,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9099,6 +9207,62 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "aes 0.8.4",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "deflate64",
+ "flate2",
+ "getrandom 0.3.1",
+ "hmac",
+ "indexmap 2.7.0",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zip-extract"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6d94e397dd6d0273e6747e46e7aa0289bfd9736ba8772f2fe948bc4adc3f73"
+dependencies = [
+ "log",
+ "thiserror 2.0.9",
+ "zip",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8"
+
+[[package]]
+name = "zopfli"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]
 
 [[package]]

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -20,6 +20,7 @@ This file contains attributions for any 3rd-party open source code used in this 
 | anstyle-query | MIT, Apache-2.0 | https://crates.io/crates/anstyle-query |
 | anstyle-wincon | MIT, Apache-2.0 | https://crates.io/crates/anstyle-wincon |
 | anyhow | MIT, Apache-2.0 | https://crates.io/crates/anyhow |
+| arbitrary | MIT, Apache-2.0 | https://crates.io/crates/arbitrary |
 | arboard | MIT, Apache-2.0 | https://crates.io/crates/arboard |
 | arrayref | BSD-2-Clause | https://crates.io/crates/arrayref |
 | as-slice | MIT, Apache-2.0 | https://crates.io/crates/as-slice |
@@ -97,6 +98,7 @@ This file contains attributions for any 3rd-party open source code used in this 
 | byteorder-lite | Unlicense, MIT | https://crates.io/crates/byteorder-lite |
 | bytes | MIT | https://crates.io/crates/bytes |
 | bytes-utils | Apache-2.0, MIT | https://crates.io/crates/bytes-utils |
+| bzip2 | MIT, Apache-2.0 | https://crates.io/crates/bzip2 |
 | caps | MIT, Apache-2.0 | https://crates.io/crates/caps |
 | cast | MIT, Apache-2.0 | https://crates.io/crates/cast |
 | cbindgen | MPL-2.0 | https://crates.io/crates/cbindgen |
@@ -127,6 +129,7 @@ This file contains attributions for any 3rd-party open source code used in this 
 | console | MIT | https://crates.io/crates/console |
 | const-oid | Apache-2.0, MIT | https://crates.io/crates/const-oid |
 | const_fn | Apache-2.0, MIT | https://crates.io/crates/const_fn |
+| constant_time_eq | CC0-1.0, MIT-0, Apache-2.0 | https://crates.io/crates/constant_time_eq |
 | copypasta | MIT, Apache-2.0 | https://crates.io/crates/copypasta |
 | copypasta-ext | MIT, Apache-2.0 | https://crates.io/crates/copypasta-ext |
 | core-error | MIT, Apache-2.0 | https://crates.io/crates/core-error |
@@ -162,9 +165,11 @@ This file contains attributions for any 3rd-party open source code used in this 
 | data-encoding | MIT | https://crates.io/crates/data-encoding |
 | dbus | Apache-2.0, MIT | https://crates.io/crates/dbus |
 | dbus-tokio | Apache-2.0, MIT | https://crates.io/crates/dbus-tokio |
+| deflate64 | MIT | https://crates.io/crates/deflate64 |
 | delegate | MIT, Apache-2.0 | https://crates.io/crates/delegate |
 | der | Apache-2.0, MIT | https://crates.io/crates/der |
 | deranged | MIT, Apache-2.0 | https://crates.io/crates/deranged |
+| derive_arbitrary | MIT, Apache-2.0 | https://crates.io/crates/derive_arbitrary |
 | dialoguer | MIT | https://crates.io/crates/dialoguer |
 | digest | MIT, Apache-2.0 | https://crates.io/crates/digest |
 | displaydoc | MIT, Apache-2.0 | https://crates.io/crates/displaydoc |
@@ -306,12 +311,15 @@ This file contains attributions for any 3rd-party open source code used in this 
 | libm | MIT, Apache-2.0 | https://crates.io/crates/libm |
 | libmimalloc-sys | MIT | https://crates.io/crates/libmimalloc-sys |
 | libsqlite3-sys | MIT | https://crates.io/crates/libsqlite3-sys |
+| libz-rs-sys | Zlib | https://crates.io/crates/libz-rs-sys |
 | linked-hash-map | MIT, Apache-2.0 | https://crates.io/crates/linked-hash-map |
 | linux-raw-sys | Apache-2.0 WITH LLVM-exception, Apache-2.0, MIT | https://crates.io/crates/linux-raw-sys |
 | litemap | Unicode-3.0 | https://crates.io/crates/litemap |
 | lock_api | MIT, Apache-2.0 | https://crates.io/crates/lock_api |
 | log | MIT, Apache-2.0 | https://crates.io/crates/log |
 | lz4 | MIT | https://crates.io/crates/lz4 |
+| lzma-rs | MIT | https://crates.io/crates/lzma-rs |
+| lzma-sys | MIT, Apache-2.0 | https://crates.io/crates/lzma-sys |
 | malloc_buf | MIT | https://crates.io/crates/malloc_buf |
 | matchers | MIT | https://crates.io/crates/matchers |
 | matchit | MIT, BSD-3-Clause | https://crates.io/crates/matchit |
@@ -380,6 +388,7 @@ This file contains attributions for any 3rd-party open source code used in this 
 | parking_lot_core | MIT, Apache-2.0 | https://crates.io/crates/parking_lot_core |
 | paste | MIT, Apache-2.0 | https://crates.io/crates/paste |
 | pathdiff | MIT, Apache-2.0 | https://crates.io/crates/pathdiff |
+| pbkdf2 | MIT, Apache-2.0 | https://crates.io/crates/pbkdf2 |
 | pem | MIT | https://crates.io/crates/pem |
 | pem-rfc7468 | Apache-2.0, MIT | https://crates.io/crates/pem-rfc7468 |
 | percent-encoding | MIT, Apache-2.0 | https://crates.io/crates/percent-encoding |
@@ -652,6 +661,7 @@ This file contains attributions for any 3rd-party open source code used in this 
 | xcursor | MIT | https://crates.io/crates/xcursor |
 | xml-rs | MIT | https://crates.io/crates/xml-rs |
 | xmlparser | MIT, Apache-2.0 | https://crates.io/crates/xmlparser |
+| xz2 | MIT, Apache-2.0 | https://crates.io/crates/xz2 |
 | yaml-rust | MIT, Apache-2.0 | https://crates.io/crates/yaml-rust |
 | yasna | MIT, Apache-2.0 | https://crates.io/crates/yasna |
 | yoke | Unicode-3.0 | https://crates.io/crates/yoke |
@@ -664,6 +674,10 @@ This file contains attributions for any 3rd-party open source code used in this 
 | zeroize_derive | Apache-2.0, MIT | https://crates.io/crates/zeroize_derive |
 | zerovec | Unicode-3.0 | https://crates.io/crates/zerovec |
 | zerovec-derive | Unicode-3.0 | https://crates.io/crates/zerovec-derive |
+| zip | MIT | https://crates.io/crates/zip |
+| zip-extract | MIT | https://crates.io/crates/zip-extract |
+| zlib-rs | Zlib | https://crates.io/crates/zlib-rs |
+| zopfli | Apache-2.0 | https://crates.io/crates/zopfli |
 | zstd | MIT | https://crates.io/crates/zstd |
 | zstd-safe | MIT, Apache-2.0 | https://crates.io/crates/zstd-safe |
 

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -100,6 +100,7 @@ tokio-retry = "0.3"
 tracing = { version = "0.1", default-features = false }
 url = "2.5.2"
 which = "7.0.2"
+zip-extract = "0.2.3"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/implementations/rust/ockam/ockam_command/src/cluster/init.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/init.rs
@@ -7,9 +7,10 @@ use ockam_api::colors::color_primary;
 use ockam_api::fmt_ok;
 use ockam_node::Context;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Stdio;
 use tempfile::TempDir;
+use tracing::{debug, info};
 use url::Url;
 
 const LONG_ABOUT: &str = include_str!("./static/init/long_about.txt");
@@ -44,35 +45,28 @@ impl Command for InitCommand {
 
         // Check if the current directory can be used
         let target_path = self.create_target_path()?;
+        let target_path_str = target_path.display().to_string();
 
         // Clone repository in a temporary directory
-        let repository_url = self.get_repository_url();
-        let temp_dir = tempfile::tempdir()
-            .into_diagnostic()
-            .wrap_err("Failed to create temporary directory")?;
+        let repository_downloader = RepositoryDownloader::new(&self.repository, target_path)?;
+        let repository_url = &repository_downloader.repository_url;
         if let Some(spinner) = &spinner {
             spinner.set_message(format!(
                 "Downloading template from {}...",
-                color_primary(&repository_url)
+                color_primary(repository_url)
             ));
         }
-        self.clone_repository(&repository_url, &temp_dir).await?;
-
-        // Get the repository directory name (last part of the URL before .git)
-        let repo_dir_name = repository_url
-            .trim_end_matches(".git")
-            .split('/')
-            .last()
-            .ok_or_else(|| miette!("Failed to parse repository name from URL"))?;
+        repository_downloader.clone_repository().await?;
 
         // Copy all files except .git directory to the target path
         if let Some(spinner) = &spinner {
             spinner.set_message(format!(
                 "Copying template at {}...",
-                color_primary(target_path.display())
+                color_primary(&target_path_str)
             ));
         }
-        self.copy_repository_files_to_target_path(&temp_dir, repo_dir_name, &target_path)
+        repository_downloader
+            .copy_repository_files_to_target_path()
             .await?;
 
         if let Some(spinner) = &spinner {
@@ -83,7 +77,7 @@ impl Command for InitCommand {
             .to_stdout()
             .plain(fmt_ok!(
                 "Initialized template at {}",
-                color_primary(target_path.display())
+                color_primary(&target_path_str)
             ))
             .write_line()?;
 
@@ -92,27 +86,6 @@ impl Command for InitCommand {
 }
 
 impl InitCommand {
-    fn get_repository_url(&self) -> String {
-        let repository = self.repository.trim().trim_end_matches(".git");
-
-        if Url::parse(repository).is_ok() {
-            // An arbitrary URL
-            format!("{}.git", repository)
-        } else if repository.starts_with("git@") {
-            // SSH URL for an arbitrary GitHub repository
-            repository.to_string()
-        } else if repository.contains('/') {
-            // URL for an arbitrary GitHub repository
-            format!("https://github.com/{}.git", repository)
-        } else {
-            // URL for an ockam template
-            format!(
-                "https://github.com/build-trust/ockam-cluster-template-{}.git",
-                repository
-            )
-        }
-    }
-
     fn create_target_path(&self) -> Result<PathBuf> {
         let target_path = match &self.target_path {
             None => std::env::current_dir()
@@ -134,63 +107,6 @@ impl InitCommand {
         }
         Ok(target_path)
     }
-
-    async fn clone_repository(&self, repository_url: &str, temp_dir: &TempDir) -> Result<()> {
-        let clone_status = tokio::process::Command::new("git")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .stdin(Stdio::null())
-            .args(["clone", repository_url, "--depth", "1"])
-            .current_dir(temp_dir.path())
-            .status()
-            .await
-            .into_diagnostic()
-            .wrap_err("Failed to execute git clone command")?;
-
-        if !clone_status.success() {
-            return Err(miette!("Failed to clone repository. Please check if the repository exists and you have internet access."));
-        }
-        Ok(())
-    }
-
-    async fn copy_repository_files_to_target_path(
-        &self,
-        temp_dir: &TempDir,
-        repo_dir_name: &str,
-        target_path: &Path,
-    ) -> Result<()> {
-        let source_dir = temp_dir.path().join(repo_dir_name);
-        for entry in fs::read_dir(&source_dir)
-            .into_diagnostic()
-            .wrap_err("Failed to read template directory")?
-        {
-            let entry = entry.into_diagnostic()?;
-            let path = entry.path();
-            let file_name = path.file_name().unwrap();
-
-            // Skip .git directory
-            if file_name == ".git" {
-                continue;
-            }
-
-            let target = target_path.join(file_name);
-
-            if path.is_dir() {
-                copy_dir_all(&path, &target)
-                    .into_diagnostic()
-                    .wrap_err_with(|| {
-                        format!("Failed to copy directory from {:?} to {:?}", path, target)
-                    })?;
-            } else {
-                fs::copy(&path, &target)
-                    .into_diagnostic()
-                    .wrap_err_with(|| {
-                        format!("Failed to copy file from {:?} to {:?}", path, target)
-                    })?;
-            }
-        }
-        Ok(())
-    }
 }
 
 /// Recursively copy directories
@@ -211,4 +127,222 @@ fn copy_dir_all(src: &PathBuf, dst: &PathBuf) -> std::io::Result<()> {
         }
     }
     Ok(())
+}
+
+struct RepositoryDownloader {
+    repository_url: String,
+    repository_type: RepositoryType,
+    temp_dir: TempDir,
+    target_path: PathBuf,
+}
+
+impl RepositoryDownloader {
+    fn new(repository_hint: &str, target_path: PathBuf) -> Result<Self> {
+        let repository_type = if repository_hint.ends_with(".git") {
+            RepositoryType::Git
+        } else {
+            // Defaults to ZIP when a repository name or a template name is passed
+            RepositoryType::Zip
+        };
+        let temp_dir = tempfile::tempdir()
+            .into_diagnostic()
+            .wrap_err("Failed to create temporary directory")?;
+        Ok(Self {
+            repository_url: Self::_build_repository_url_from_hint(
+                repository_hint,
+                &repository_type,
+            ),
+            repository_type,
+            temp_dir,
+            target_path,
+        })
+    }
+
+    fn _build_repository_url_from_hint(hint: &str, repository_type: &RepositoryType) -> String {
+        match repository_type {
+            RepositoryType::Git => {
+                let hint = hint.trim_end_matches(".git");
+                if Url::parse(hint).is_ok() {
+                    // An arbitrary URL
+                    format!("{}.git", hint)
+                } else if hint.starts_with("git@") {
+                    // SSH URL for a git repository
+                    format!("{}.git", hint)
+                } else if hint.contains('/') {
+                    // A "<user>/<repo>" string
+                    format!("https://github.com/{}.git", hint)
+                } else {
+                    // An Ockam template name
+                    format!(
+                        "https://github.com/build-trust/ockam-cluster-template-{}.git",
+                        hint
+                    )
+                }
+            }
+            RepositoryType::Zip => {
+                if Url::parse(hint).is_ok() {
+                    // An arbitrary URL
+                    hint.to_string()
+                } else if hint.contains('/') {
+                    // A "<user>/<repo>" string
+                    format!("https://github.com/{}/archive/refs/heads/main.zip", hint)
+                } else {
+                    // An Ockam template name
+                    format!(
+                        "https://github.com/build-trust/ockam-cluster-template-{}/archive/refs/heads/main.zip",
+                        hint
+                    )
+                }
+            }
+        }
+    }
+
+    async fn clone_repository(&self) -> Result<()> {
+        match self.repository_type {
+            RepositoryType::Git => self._clone_git_repository().await,
+            RepositoryType::Zip => self._download_zip_repository().await,
+        }
+    }
+
+    async fn _clone_git_repository(&self) -> Result<()> {
+        debug!("Cloning git repository from {}", self.repository_url);
+        let clone_status = tokio::process::Command::new("git")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .stdin(Stdio::null())
+            .args(["clone", &self.repository_url, "--depth", "1"])
+            .current_dir(self.temp_dir.path())
+            .status()
+            .await
+            .into_diagnostic()
+            .wrap_err("Failed to execute git clone command")?;
+        if !clone_status.success() {
+            Err(miette!("Failed to clone repository. Please check if the repository exists and you have internet access."))
+        } else {
+            info!("Cloned git repository from {}", self.repository_url);
+            Ok(())
+        }
+    }
+
+    async fn _download_zip_repository(&self) -> Result<()> {
+        // Download zip
+        debug!("Downloading zip repository from {}", self.repository_url);
+        let archive_path = self.temp_dir.path().join("repo.zip");
+        let response = reqwest::get(&self.repository_url)
+            .await
+            .into_diagnostic()
+            .wrap_err("Failed to download repository")?;
+        if !response.status().is_success() {
+            return Err(miette!(
+                "Failed to download repository. Server returned status: {}",
+                response.status()
+            ));
+        }
+        let bytes = response
+            .bytes()
+            .await
+            .into_diagnostic()
+            .wrap_err("Failed to read response body")?;
+        let mut file = tokio::fs::File::create(&archive_path)
+            .await
+            .into_diagnostic()
+            .wrap_err("Failed to create archive file")?;
+        tokio::io::copy(&mut bytes.as_ref(), &mut file)
+            .await
+            .into_diagnostic()
+            .wrap_err("Failed to write archive file")?;
+        info!("Downloaded zip repository to {}", archive_path.display());
+
+        // Unzip
+        debug!(
+            "Extracting zip repository to {}",
+            self.temp_dir.path().display()
+        );
+        let _temp_dir = self.temp_dir.path().to_path_buf();
+        let _archive_path = archive_path.clone();
+        tokio::task::spawn_blocking(move || {
+            zip_extract::extract(
+                fs::File::open(&_archive_path)
+                    .into_diagnostic()
+                    .wrap_err("Failed to open downloaded archive")?,
+                &_temp_dir,
+                true,
+            )
+            .into_diagnostic()
+            .wrap_err("Failed to extract ZIP archive")?;
+            Ok::<_, miette::Error>(())
+        })
+        .await
+        .into_diagnostic()
+        .wrap_err("Failed to complete ZIP extraction")??;
+
+        // Remove the archive after extraction
+        tokio::fs::remove_file(&archive_path)
+            .await
+            .into_diagnostic()?;
+        info!(
+            "Extracted zip repository to {}",
+            self.temp_dir.path().display()
+        );
+
+        Ok(())
+    }
+
+    async fn copy_repository_files_to_target_path(&self) -> Result<()> {
+        let source_dir = match self.repository_type {
+            RepositoryType::Git => {
+                let repo_name = self
+                    .repository_url
+                    .trim_end_matches(".git")
+                    .split('/')
+                    .last()
+                    .ok_or_else(|| miette!("Failed to parse repository name from URL"))?;
+                self.temp_dir.path().join(repo_name)
+            }
+            RepositoryType::Zip => self.temp_dir.path().to_path_buf(),
+        };
+        debug!(
+            "Copying repository files to target path {:?} from {:?}",
+            self.target_path, source_dir
+        );
+        for entry in fs::read_dir(&source_dir)
+            .into_diagnostic()
+            .wrap_err("Failed to read template directory")?
+        {
+            let entry = entry.into_diagnostic()?;
+            let path = entry.path();
+            let file_name = path.file_name().unwrap();
+
+            // Skip .git directory
+            if file_name == ".git" {
+                continue;
+            }
+
+            let target = self.target_path.join(file_name);
+
+            if path.is_dir() {
+                copy_dir_all(&path, &target)
+                    .into_diagnostic()
+                    .wrap_err_with(|| {
+                        format!("Failed to copy directory from {:?} to {:?}", path, target)
+                    })?;
+            } else {
+                fs::copy(&path, &target)
+                    .into_diagnostic()
+                    .wrap_err_with(|| {
+                        format!("Failed to copy file from {:?} to {:?}", path, target)
+                    })?;
+            }
+        }
+        info!(
+            "Copied repository files to target path {:?} from {:?}",
+            self.target_path, source_dir
+        );
+        Ok(())
+    }
+}
+
+enum RepositoryType {
+    Git,
+    Zip,
 }


### PR DESCRIPTION
- Add a new way to download zip repositories using rust libraries (reqwest + zip-extract)
- When passing a template name or a repository name (like "hello" to download the default template), it will treat it as a zip URL to remove the git dependency
- To download a template using git, you have to pass the template name with the git suffix (e.g. `hello.git`) or pass a full uri (e.g. `git@github.com:build-trust/ockam-cluster-template-hello.git` or `https://github.com/build-trust/ockam-cluster-template-hello.git`)