### PR TITLE
feat(rust): extract a cluster repl command for local development

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/cluster/attach.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/attach.rs
@@ -1,6 +1,7 @@
 use crate::cluster::common_args::{
     EnrollmentTicketConfigArg, HttpApiArgs, ZoneConfigArg, ZoneNameOrConfigArg,
 };
+use crate::cluster::repl::ReplCommand;
 use crate::cluster::zone_config::{Outlet, ZoneConfig};
 use crate::entry_point::RUNTIME;
 use crate::util::port_is_free_guard;
@@ -8,7 +9,6 @@ use crate::{docs, Command, CommandGlobalOpts, Result};
 use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
-use indicatif::ProgressBar;
 use miette::{miette, IntoDiagnostic, WrapErr};
 use ockam::transport::SchemeHostnamePort;
 use ockam_api::address::get_free_address;
@@ -16,19 +16,10 @@ use ockam_api::colors::color_primary;
 use ockam_api::orchestrator::ai_platform::node_service_client::AI_API_BASE_URL;
 use ockam_api::{fmt_log, fmt_ok, fmt_separator};
 use ockam_node::{Context, Executor, NodeBuilder};
-use rustyline::config::Configurer;
-use rustyline::error::ReadlineError;
-use rustyline::validate::{ValidationContext, ValidationResult, Validator};
-use rustyline::{Completer, Editor, Helper, Highlighter, Hinter};
-use std::fmt::{Display, Formatter};
 use std::net::SocketAddr;
-use std::path::PathBuf;
 use std::str::FromStr;
-use std::time::Duration;
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::task::JoinHandle;
-use tokio::time::timeout;
-use tracing::debug;
 
 const LONG_ABOUT: &str = include_str!("./static/attach/long_about.txt");
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
@@ -59,7 +50,10 @@ impl Command for AttachCommand {
         // let (repl_data, rest_inlet_handles) = cmd.dummy_inlet(&opts).await?;
         opts.terminal.write_line(fmt_separator!())?;
         if let Some(address) = repl_address {
-            self.open_repl(ctx, &opts, address).await?;
+            let repl_command = ReplCommand {
+                to: address.clone(),
+            };
+            repl_command.open_repl(ctx, &opts, address).await?;
         } else {
             // No repl outlet. Create a ctrlc handler and wait for it to be triggered before exiting the command
             let (tx, rx) = tokio::sync::oneshot::channel();
@@ -201,441 +195,6 @@ impl AttachCommand {
 
         Ok(executor)
     }
-
-    async fn open_repl(
-        &self,
-        _ctx: &Context,
-        opts: &CommandGlobalOpts,
-        inlet_address: SchemeHostnamePort,
-    ) -> miette::Result<()> {
-        use tokio::net::TcpStream;
-        use tokio::time::sleep;
-
-        let (quit_tx, quit_rx) = tokio::sync::oneshot::channel();
-        let mut quit_tx = Some(quit_tx);
-        ctrlc::set_handler(move || {
-            if let Some(quit_tx) = quit_tx.take() {
-                let _ = quit_tx.send(());
-            }
-        })
-        .expect("Error setting exit signal handler");
-
-        let (next_tx, next_rx) = tokio::sync::mpsc::channel(16);
-        let (lines_tx, lines_rx) = tokio::sync::mpsc::channel(16);
-        let mut stdin = RustylineHandle { lines_rx, next_tx };
-        let stdin_handle: JoinHandle<Result<()>> = tokio::task::spawn(async move {
-            if let Err(e) = RustylineHandler::run_repl(next_rx, lines_tx, None).await {
-                eprintln!("{:?}", e);
-            }
-            Ok(())
-        });
-
-        // Start the interactive repl
-        let opts = opts.clone();
-        let repl_handle = tokio::spawn(async move {
-            async fn connect_to_inlet(addr: &SchemeHostnamePort) -> miette::Result<TcpStream> {
-                const MAX_RETRIES: u32 = 120; // Try for about 60 seconds (120 * 500ms)
-                let duration = Duration::from_millis(500);
-                let mut retries = 0;
-
-                while retries < MAX_RETRIES {
-                    match TcpStream::connect(addr.hostname_port().to_string()).await {
-                        Ok(s) => return Ok(s),
-                        Err(_) => {
-                            retries += 1;
-                            sleep(duration).await;
-                        }
-                    }
-                }
-                Err(miette!("Failed to connect to the TCP Inlet"))
-            }
-
-            let mut read_header_buffer = String::new();
-            let mut read_body_buffer = Vec::new();
-            let mut initial_message_spinner: Option<ProgressBar> = None;
-            'repl: loop {
-                // 1: Try to connect to the inlet
-                let stream = match connect_to_inlet(&inlet_address).await {
-                    Ok(s) => s,
-                    Err(_e) => {
-                        sleep(Duration::from_secs(1)).await;
-                        continue 'repl;
-                    }
-                };
-
-                let (reader, mut writer) = stream.into_split();
-                let mut reader = BufReader::new(reader);
-
-                // 2: Try to read initial message
-                match Self::wait_until_server_is_ready(
-                    &mut reader,
-                    &mut read_header_buffer,
-                    &mut read_body_buffer,
-                )
-                .await
-                {
-                    Ok(res) => {
-                        // Successfully got initial message, continue to repl
-                        if let Some(spinner) = initial_message_spinner.take() {
-                            spinner.finish_and_clear();
-                        }
-                        opts.terminal.write(res)?;
-                    }
-                    Err(_e) => {
-                        if initial_message_spinner.is_none() {
-                            initial_message_spinner = opts.terminal.spinner();
-                        }
-                        if let Some(spinner) = &initial_message_spinner {
-                            spinner.set_message("Waiting for repl to be ready...");
-                        }
-                        sleep(Duration::from_secs(1)).await;
-                        continue 'repl;
-                    }
-                }
-
-                // 3: Start the repl loop for this connection
-                'connection: loop {
-                    // Get user input
-                    let user_input = match stdin.read_line().await {
-                        Some(i) => i,
-                        None => {
-                            // stdin channel closed, exit repl
-                            break 'repl;
-                        }
-                    };
-
-                    if user_input.trim().is_empty() {
-                        continue 'connection;
-                    }
-
-                    if is_reconnect_sequence(&user_input) {
-                        break 'connection;
-                    }
-
-                    if is_quit_sequence(&user_input) {
-                        let _ = writer.write_all(user_input.as_bytes()).await;
-                        let _ = writer.flush().await;
-                        break 'repl;
-                    }
-
-                    // Send input to server
-                    if let Err(e) = writer.write_all(user_input.as_bytes()).await {
-                        debug!("failed to write to server: {:?}", e);
-                        opts.terminal
-                            .write_line("Failed to write to server. Reconnecting...")?;
-                        break 'connection;
-                    }
-                    let _ = writer.flush().await;
-
-                    // Wait for server response and print it
-                    if let Err(e) = Self::process_server_response(
-                        &opts,
-                        &mut reader,
-                        &mut read_header_buffer,
-                        &mut read_body_buffer,
-                    )
-                    .await
-                    {
-                        opts.terminal.write_line(format!(
-                            "Failed to read from server ({e}). Reconnecting...",
-                        ))?;
-                        break 'connection;
-                    }
-                }
-
-                // If we break from the connection loop, we'll go back to connecting
-                sleep(Duration::from_secs(1)).await;
-            }
-
-            Ok::<(), miette::Error>(())
-        });
-
-        tokio::select! {
-            _ = stdin_handle => {}
-            _ = quit_rx => {},
-            _ = repl_handle => {},
-        }
-
-        Ok(())
-    }
-    async fn wait_until_server_is_ready(
-        reader: &mut BufReader<tokio::net::tcp::OwnedReadHalf>,
-        read_header_buffer: &mut String,
-        read_body_buffer: &mut Vec<u8>,
-    ) -> std::result::Result<String, String> {
-        match Self::read_server_response(
-            reader,
-            read_header_buffer,
-            read_body_buffer,
-            Duration::from_secs(5),
-        )
-        .await
-        {
-            ReadStatus::Success(res) => Ok(res),
-            status => Err(status.to_string()),
-        }
-    }
-
-    async fn process_server_response(
-        opts: &CommandGlobalOpts,
-        reader: &mut BufReader<tokio::net::tcp::OwnedReadHalf>,
-        read_header_buffer: &mut String,
-        read_body_buffer: &mut Vec<u8>,
-    ) -> std::result::Result<(), String> {
-        let res = match Self::read_server_response(
-            reader,
-            read_header_buffer,
-            read_body_buffer,
-            Duration::from_secs(30),
-        )
-        .await
-        {
-            ReadStatus::Success(res) => Ok(res),
-            ReadStatus::Timeout => {
-                // Short timeout reached, notify but keep waiting
-                let spinner = opts.terminal.spinner();
-                if let Some(spinner) = &spinner {
-                    spinner.set_message("Waiting for repl response...");
-                }
-
-                // Continue with longer timeout
-                let status = Self::read_server_response(
-                    reader,
-                    read_header_buffer,
-                    read_body_buffer,
-                    Duration::from_secs(5 * 60),
-                )
-                .await;
-
-                if let Some(spinner) = &spinner {
-                    spinner.finish_and_clear();
-                }
-
-                match status {
-                    ReadStatus::Success(res) => Ok(res),
-                    status => Err(status.to_string()),
-                }
-            }
-            status => Err(status.to_string()),
-        }?;
-        opts.terminal.write(&res).map_err(|e| e.to_string())?;
-        Ok(())
-    }
-
-    async fn read_server_response(
-        reader: &mut BufReader<tokio::net::tcp::OwnedReadHalf>,
-        read_header_buffer: &mut String,
-        read_body_buffer: &mut Vec<u8>,
-        timeout_duration: Duration,
-    ) -> ReadStatus {
-        // Use timeout only for the header read
-        read_header_buffer.clear();
-        match timeout(timeout_duration, reader.read_line(read_header_buffer)).await {
-            Ok(Ok(0)) => ReadStatus::ConnectionClosed,
-            Ok(Ok(_n)) => {
-                // Process the header as a line containing the body length
-                let body_len: usize = match read_header_buffer.trim().parse() {
-                    Ok(v) => v,
-                    Err(e) => {
-                        debug!("failed to read header length: {e}");
-                        return ReadStatus::Error("header parsing".to_string());
-                    }
-                };
-
-                // Process the body
-                read_body_buffer.resize(body_len, 0);
-                if let Err(e) = reader.read_exact(read_body_buffer).await {
-                    debug!("failed to read body: {e}");
-                    return ReadStatus::Error("body parsing".to_string());
-                };
-                let body = String::from_utf8_lossy(read_body_buffer).into_owned();
-                ReadStatus::Success(body)
-            }
-            Ok(Err(e)) => {
-                debug!("failed to read from server: {e}");
-                ReadStatus::Error("server".to_string())
-            }
-            Err(_) => ReadStatus::Timeout,
-        }
-    }
-}
-
-/// Models the possible outcomes when reading server responses
-#[derive(Debug)]
-enum ReadStatus {
-    /// Successfully read data
-    Success(String),
-
-    /// Server connection was closed
-    ConnectionClosed,
-
-    /// Error occurred during reading
-    Error(String),
-
-    /// Initial read operation timed out
-    Timeout,
-}
-
-impl Display for ReadStatus {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ReadStatus::Success(_) => write!(f, "success"),
-            ReadStatus::ConnectionClosed => write!(f, "connection closed"),
-            ReadStatus::Error(e) => write!(f, "{e}"),
-            ReadStatus::Timeout => write!(f, "timeout"),
-        }
-    }
-}
-
-struct RustylineHandler {}
-
-struct RustylineHandle {
-    lines_rx: tokio::sync::mpsc::Receiver<String>,
-    next_tx: tokio::sync::mpsc::Sender<()>,
-}
-
-impl RustylineHandle {
-    async fn read_line(&mut self) -> Option<String> {
-        match self.next_tx.send(()).await {
-            Ok(_) => self.lines_rx.recv().await.map(|line| line + "\n"),
-            Err(_) => {
-                // Channel closed, exit repl
-                None
-            }
-        }
-    }
-}
-
-#[derive(Hinter, Completer, Highlighter)]
-struct MultiLineValidatorHelper {}
-impl Validator for MultiLineValidatorHelper {
-    fn validate(
-        &self,
-        ctx: &mut ValidationContext,
-    ) -> std::result::Result<ValidationResult, ReadlineError> {
-        let input = ctx.input();
-        // We don't get the final \n here, so the first time will be just the marker,
-        // then on later calls inside this multiline input, it does have the newline between the
-        // marker and whatever the next line is.
-        if input.starts_with("\"\"\"\n") || input.eq("\"\"\"") {
-            return if input.ends_with("\n\"\"\"") || is_quit_sequence(input) {
-                Ok(ValidationResult::Valid(None))
-            } else {
-                Ok(ValidationResult::Incomplete)
-            };
-        }
-        Ok(ValidationResult::Valid(None))
-    }
-
-    fn validate_while_typing(&self) -> bool {
-        false
-    }
-}
-impl Helper for MultiLineValidatorHelper {}
-
-impl RustylineHandler {
-    async fn run_repl(
-        mut next_rx: tokio::sync::mpsc::Receiver<()>,
-        lines_tx: tokio::sync::mpsc::Sender<String>,
-        history_file_path: Option<PathBuf>,
-    ) -> Result<()> {
-        let history_file_path = Self::get_history_file_path(history_file_path)?;
-        let mut rl = Editor::new()
-            .into_diagnostic()
-            .wrap_err("Failed to initialize repl")?;
-        rl.set_max_history_size(50).into_diagnostic()?;
-        let helper = MultiLineValidatorHelper {};
-        rl.set_helper(Some(helper));
-        rl.load_history(&history_file_path).into_diagnostic()?;
-
-        loop {
-            // If we can't read from the channel, exit
-            if next_rx.recv().await.is_none() {
-                break;
-            };
-
-            // We run rustyline on their own blocking thread. The thread waits for an input line to be requested,
-            // then reads it, and delivers it. While waiting for agent response, there is no line requested,
-            // so readline is not active. If the thread terminates, the entire repl exits.
-            let readline = tokio::task::block_in_place(|| rl.readline("> "));
-            match readline {
-                Ok(line) => {
-                    if is_quit_sequence(&line) {
-                        break;
-                    }
-                    rl.add_history_entry(line.as_str()).into_diagnostic()?;
-                    if lines_tx.send(line).await.is_err() {
-                        break;
-                    }
-                    let _ = rl.append_history(&history_file_path);
-                }
-                Err(err) => {
-                    debug!("Failed to read line: {:?}", err);
-                    break;
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn get_history_file_path(history_file_path: Option<PathBuf>) -> Result<PathBuf> {
-        let create_history_file = |path: &PathBuf| -> Result<()> {
-            if !path.exists() {
-                if let Some(parent) = path.parent() {
-                    if !parent.exists() {
-                        std::fs::create_dir_all(parent)
-                            .into_diagnostic()
-                            .wrap_err("Failed to create history directory for repl")?;
-                    }
-                }
-                std::fs::File::create(path)
-                    .into_diagnostic()
-                    .wrap_err("Failed to create history file for repl")?;
-
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    let permissions = std::fs::Permissions::from_mode(0o600);
-                    std::fs::set_permissions(path, permissions)
-                        .into_diagnostic()
-                        .wrap_err("Failed to set permissions on history file")?;
-                }
-            }
-            Ok(())
-        };
-        match history_file_path {
-            Some(path) => {
-                if !path.exists() {
-                    create_history_file(&path)?;
-                }
-                Ok(path)
-            }
-            None => {
-                let default_path = std::env::current_dir()
-                    .into_diagnostic()
-                    .wrap_err("Failed to get current directory")?
-                    .join(".repl/history.txt");
-                create_history_file(&default_path)?;
-                Ok(default_path)
-            }
-        }
-    }
-}
-
-fn is_reconnect_sequence(input: &str) -> bool {
-    let i = input.trim();
-    let seq = [":reconnect", ":r"];
-    seq.contains(&i)
-}
-
-fn is_quit_sequence(input: &str) -> bool {
-    let i = input.trim();
-    let seq = [":quit", ":q"];
-    if seq.contains(&i) {
-        return true;
-    }
-    let last_line = i.lines().last().unwrap_or("").trim();
-    seq.contains(&last_line)
 }
 
 #[allow(dead_code)]
@@ -744,6 +303,7 @@ mod tests {
     use super::*;
     use crate::cluster::zone_config::Outlet;
     use std::net::TcpListener;
+    use tokio::time::Duration;
 
     #[test]
     fn test_get_address_for_outlet_with_port() -> miette::Result<()> {

--- a/implementations/rust/ockam/ockam_command/src/cluster/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod enroll;
 pub(crate) mod init;
 pub(crate) mod inlet;
 mod outlet;
+pub mod repl;
 pub(crate) mod secret;
 mod show;
 pub(crate) mod ticket;
@@ -24,6 +25,7 @@ use crate::cluster::delete::DeleteCommand;
 use crate::cluster::init::InitCommand;
 use crate::cluster::inlet::InletCommand;
 use crate::cluster::outlet::OutletCommand;
+use crate::cluster::repl::ReplCommand;
 use crate::cluster::secret::SecretCommand;
 use crate::cluster::show::ShowCommand;
 use crate::{docs, Command, CommandGlobalOpts};
@@ -61,6 +63,7 @@ impl ClusterCommand {
             ClusterSubcommand::Delete(c) => c.run(ctx, opts).await,
             ClusterSubcommand::Inlet(c) => c.run(ctx, opts).await,
             ClusterSubcommand::Outlet(c) => c.run(ctx, opts).await,
+            ClusterSubcommand::Repl(c) => c.run(ctx, opts).await,
         }
     }
 }
@@ -78,6 +81,7 @@ pub enum ClusterSubcommand {
     Delete(DeleteCommand),
     Inlet(InletCommand),
     Outlet(OutletCommand),
+    Repl(ReplCommand),
 }
 
 impl ClusterSubcommand {
@@ -93,6 +97,7 @@ impl ClusterSubcommand {
             ClusterSubcommand::Delete(c) => c.name(),
             ClusterSubcommand::Inlet(c) => c.name(),
             ClusterSubcommand::Outlet(c) => c.name(),
+            ClusterSubcommand::Repl(c) => c.name(),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/cluster/repl.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/repl.rs
@@ -1,0 +1,493 @@
+use crate::util::parsers::hostname_parser;
+use crate::{docs, Command, CommandGlobalOpts, Result};
+use async_trait::async_trait;
+use clap::Args;
+use colorful::Colorful;
+use indicatif::ProgressBar;
+use miette::{miette, IntoDiagnostic, WrapErr};
+use ockam::transport::SchemeHostnamePort;
+use ockam_api::fmt_separator;
+use ockam_node::Context;
+use rustyline::config::Configurer;
+use rustyline::error::ReadlineError;
+use rustyline::validate::{ValidationContext, ValidationResult, Validator};
+use rustyline::{Completer, Editor, Helper, Highlighter, Hinter};
+use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+use tracing::debug;
+
+const LONG_ABOUT: &str = include_str!("./static/repl/long_about.txt");
+const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/repl/after_long_help.txt");
+
+/// Open a repl client to a locally running Ockam AI Agent
+#[derive(Clone, Debug, Args, Default)]
+#[command(
+long_about = docs::about(LONG_ABOUT),
+before_help = docs::before_help(PREVIEW_TAG),
+after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
+pub struct ReplCommand {
+    /// Network address where your application is listening to.
+    /// Your TCP Outlet will forward raw TCP traffic to this destination.
+    #[arg(long, id = "SOCKET_ADDRESS", display_order = 900, value_parser = hostname_parser)]
+    pub to: SchemeHostnamePort,
+}
+
+#[async_trait]
+impl Command for ReplCommand {
+    const NAME: &'static str = "repl";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
+        opts.terminal.write_line(fmt_separator!())?;
+        let to = self.to.clone();
+        self.open_repl(ctx, &opts, to).await?;
+        Ok(())
+    }
+}
+
+impl ReplCommand {
+    pub async fn open_repl(
+        &self,
+        _ctx: &Context,
+        opts: &CommandGlobalOpts,
+        inlet_address: SchemeHostnamePort,
+    ) -> miette::Result<()> {
+        use tokio::net::TcpStream;
+        use tokio::time::sleep;
+
+        let (quit_tx, quit_rx) = tokio::sync::oneshot::channel();
+        let mut quit_tx = Some(quit_tx);
+        ctrlc::set_handler(move || {
+            if let Some(quit_tx) = quit_tx.take() {
+                let _ = quit_tx.send(());
+            }
+        })
+        .expect("Error setting exit signal handler");
+
+        let (next_tx, next_rx) = tokio::sync::mpsc::channel(16);
+        let (lines_tx, lines_rx) = tokio::sync::mpsc::channel(16);
+        let mut stdin = RustylineHandle { lines_rx, next_tx };
+        let stdin_handle: JoinHandle<Result<()>> = tokio::task::spawn(async move {
+            if let Err(e) = RustylineHandler::run_repl(next_rx, lines_tx, None).await {
+                eprintln!("{:?}", e);
+            }
+            Ok(())
+        });
+
+        // Start the interactive repl
+        let opts = opts.clone();
+        let repl_handle = tokio::spawn(async move {
+            async fn connect_to_inlet(addr: &SchemeHostnamePort) -> miette::Result<TcpStream> {
+                const MAX_RETRIES: u32 = 120; // Try for about 60 seconds (120 * 500ms)
+                let duration = Duration::from_millis(500);
+                let mut retries = 0;
+
+                while retries < MAX_RETRIES {
+                    match TcpStream::connect(addr.hostname_port().to_string()).await {
+                        Ok(s) => return Ok(s),
+                        Err(_) => {
+                            retries += 1;
+                            sleep(duration).await;
+                        }
+                    }
+                }
+                Err(miette!("Failed to connect to the TCP Inlet"))
+            }
+
+            let mut read_header_buffer = String::new();
+            let mut read_body_buffer = Vec::new();
+            let mut initial_message_spinner: Option<ProgressBar> = None;
+            'repl: loop {
+                // 1: Try to connect to the inlet
+                let stream = match connect_to_inlet(&inlet_address).await {
+                    Ok(s) => s,
+                    Err(_e) => {
+                        sleep(Duration::from_secs(1)).await;
+                        continue 'repl;
+                    }
+                };
+
+                let (reader, mut writer) = stream.into_split();
+                let mut reader = BufReader::new(reader);
+
+                // 2: Try to read initial message
+                match Self::wait_until_server_is_ready(
+                    &mut reader,
+                    &mut read_header_buffer,
+                    &mut read_body_buffer,
+                )
+                .await
+                {
+                    Ok(res) => {
+                        // Successfully got initial message, continue to repl
+                        if let Some(spinner) = initial_message_spinner.take() {
+                            spinner.finish_and_clear();
+                        }
+                        opts.terminal.write(res)?;
+                    }
+                    Err(_e) => {
+                        if initial_message_spinner.is_none() {
+                            initial_message_spinner = opts.terminal.spinner();
+                        }
+                        if let Some(spinner) = &initial_message_spinner {
+                            spinner.set_message("Waiting for repl to be ready...");
+                        }
+                        sleep(Duration::from_secs(1)).await;
+                        continue 'repl;
+                    }
+                }
+
+                // 3: Start the repl loop for this connection
+                'connection: loop {
+                    // Get user input
+                    let user_input = match stdin.read_line().await {
+                        Some(i) => i,
+                        None => {
+                            // stdin channel closed, exit repl
+                            break 'repl;
+                        }
+                    };
+
+                    if user_input.trim().is_empty() {
+                        continue 'connection;
+                    }
+
+                    if is_reconnect_sequence(&user_input) {
+                        break 'connection;
+                    }
+
+                    if is_quit_sequence(&user_input) {
+                        let _ = writer.write_all(user_input.as_bytes()).await;
+                        let _ = writer.flush().await;
+                        break 'repl;
+                    }
+
+                    // Send input to server
+                    if let Err(e) = writer.write_all(user_input.as_bytes()).await {
+                        debug!("failed to write to server: {:?}", e);
+                        opts.terminal
+                            .write_line("Failed to write to server. Reconnecting...")?;
+                        break 'connection;
+                    }
+                    let _ = writer.flush().await;
+
+                    // Wait for server response and print it
+                    if let Err(e) = Self::process_server_response(
+                        &opts,
+                        &mut reader,
+                        &mut read_header_buffer,
+                        &mut read_body_buffer,
+                    )
+                    .await
+                    {
+                        opts.terminal.write_line(format!(
+                            "Failed to read from server ({e}). Reconnecting...",
+                        ))?;
+                        break 'connection;
+                    }
+                }
+
+                // If we break from the connection loop, we'll go back to connecting
+                sleep(Duration::from_secs(1)).await;
+            }
+
+            Ok::<(), miette::Error>(())
+        });
+
+        tokio::select! {
+            _ = stdin_handle => {}
+            _ = quit_rx => {},
+            _ = repl_handle => {},
+        }
+
+        Ok(())
+    }
+    async fn wait_until_server_is_ready(
+        reader: &mut BufReader<tokio::net::tcp::OwnedReadHalf>,
+        read_header_buffer: &mut String,
+        read_body_buffer: &mut Vec<u8>,
+    ) -> std::result::Result<String, String> {
+        match Self::read_server_response(
+            reader,
+            read_header_buffer,
+            read_body_buffer,
+            Duration::from_secs(5),
+        )
+        .await
+        {
+            ReadStatus::Success(res) => Ok(res),
+            status => Err(status.to_string()),
+        }
+    }
+
+    async fn process_server_response(
+        opts: &CommandGlobalOpts,
+        reader: &mut BufReader<tokio::net::tcp::OwnedReadHalf>,
+        read_header_buffer: &mut String,
+        read_body_buffer: &mut Vec<u8>,
+    ) -> std::result::Result<(), String> {
+        let mut finished = false;
+        let mut timeout = Duration::from_secs(30);
+        let mut spinner: Option<Option<ProgressBar>> = None;
+        let mut result = Ok(());
+        opts.terminal.write("\n").map_err(|e| e.to_string())?;
+        while !finished {
+            match Self::read_server_response(reader, read_header_buffer, read_body_buffer, timeout)
+                .await
+            {
+                ReadStatus::Success(res) => {
+                    opts.terminal.write(&res).map_err(|e| e.to_string())?;
+                }
+                ReadStatus::EndOfStream => {
+                    opts.terminal.write("\n\n").map_err(|e| e.to_string())?;
+                    finished = true;
+                }
+                ReadStatus::Timeout => {
+                    // Short timeout reached, notify but keep waiting
+                    spinner = Some(opts.terminal.spinner());
+                    if let Some(Some(spinner)) = &spinner {
+                        spinner.set_message("Waiting for repl response...");
+                    }
+                    timeout = Duration::from_secs(5 * 60);
+                }
+                status => {
+                    finished = true;
+                    result = Err(status.to_string());
+                }
+            };
+            read_body_buffer.clear();
+        }
+        if let Some(Some(spinner)) = &spinner {
+            spinner.finish_and_clear();
+        }
+        result
+    }
+
+    async fn read_server_response(
+        reader: &mut BufReader<tokio::net::tcp::OwnedReadHalf>,
+        read_header_buffer: &mut String,
+        read_body_buffer: &mut Vec<u8>,
+        timeout_duration: Duration,
+    ) -> ReadStatus {
+        // Use timeout only for the header read
+        read_header_buffer.clear();
+        match timeout(timeout_duration, reader.read_line(read_header_buffer)).await {
+            Ok(Ok(0)) => ReadStatus::ConnectionClosed,
+            Ok(Ok(_n)) => {
+                // Process the header as a line containing the body length
+                let body_len: usize = match read_header_buffer.trim().parse() {
+                    Ok(v) => v,
+                    Err(e) => {
+                        debug!("failed to read header length: {e}");
+                        return ReadStatus::Error("header parsing".to_string());
+                    }
+                };
+
+                if body_len == 0 {
+                    ReadStatus::EndOfStream
+                } else {
+                    // Process the body
+                    read_body_buffer.resize(body_len, 0);
+                    if let Err(e) = reader.read_exact(read_body_buffer).await {
+                        debug!("failed to read body: {e}");
+                        return ReadStatus::Error("body parsing".to_string());
+                    };
+                    let body = String::from_utf8_lossy(read_body_buffer).into_owned();
+                    ReadStatus::Success(body)
+                }
+            }
+            Ok(Err(e)) => {
+                debug!("failed to read from server: {e}");
+                ReadStatus::Error("server".to_string())
+            }
+            Err(_) => ReadStatus::Timeout,
+        }
+    }
+}
+
+/// Models the possible outcomes when reading server responses
+#[derive(Debug)]
+enum ReadStatus {
+    /// Successfully read data
+    Success(String),
+
+    /// No more data to read
+    EndOfStream,
+
+    /// Server connection was closed
+    ConnectionClosed,
+
+    /// Error occurred during reading
+    Error(String),
+
+    /// Initial read operation timed out
+    Timeout,
+}
+
+impl Display for ReadStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReadStatus::Success(_) => write!(f, "success"),
+            ReadStatus::EndOfStream => write!(f, "end of stream"),
+            ReadStatus::ConnectionClosed => write!(f, "connection closed"),
+            ReadStatus::Error(e) => write!(f, "{e}"),
+            ReadStatus::Timeout => write!(f, "timeout"),
+        }
+    }
+}
+
+struct RustylineHandler {}
+
+struct RustylineHandle {
+    lines_rx: tokio::sync::mpsc::Receiver<String>,
+    next_tx: tokio::sync::mpsc::Sender<()>,
+}
+
+impl RustylineHandle {
+    async fn read_line(&mut self) -> Option<String> {
+        match self.next_tx.send(()).await {
+            Ok(_) => self.lines_rx.recv().await.map(|line| line + "\n"),
+            Err(_) => {
+                // Channel closed, exit repl
+                None
+            }
+        }
+    }
+}
+
+#[derive(Hinter, Completer, Highlighter)]
+struct MultiLineValidatorHelper {}
+impl Validator for MultiLineValidatorHelper {
+    fn validate(
+        &self,
+        ctx: &mut ValidationContext,
+    ) -> std::result::Result<ValidationResult, ReadlineError> {
+        let input = ctx.input();
+        // We don't get the final \n here, so the first time will be just the marker,
+        // then on later calls inside this multiline input, it does have the newline between the
+        // marker and whatever the next line is.
+        if input.starts_with("\"\"\"\n") || input.eq("\"\"\"") {
+            return if input.ends_with("\n\"\"\"") || is_quit_sequence(input) {
+                Ok(ValidationResult::Valid(None))
+            } else {
+                Ok(ValidationResult::Incomplete)
+            };
+        }
+        Ok(ValidationResult::Valid(None))
+    }
+
+    fn validate_while_typing(&self) -> bool {
+        false
+    }
+}
+impl Helper for MultiLineValidatorHelper {}
+
+impl RustylineHandler {
+    async fn run_repl(
+        mut next_rx: tokio::sync::mpsc::Receiver<()>,
+        lines_tx: tokio::sync::mpsc::Sender<String>,
+        history_file_path: Option<PathBuf>,
+    ) -> Result<()> {
+        let history_file_path = Self::get_history_file_path(history_file_path)?;
+        let mut rl = Editor::new()
+            .into_diagnostic()
+            .wrap_err("Failed to initialize repl")?;
+        rl.set_max_history_size(50).into_diagnostic()?;
+        let helper = MultiLineValidatorHelper {};
+        rl.set_helper(Some(helper));
+        rl.load_history(&history_file_path).into_diagnostic()?;
+
+        loop {
+            // If we can't read from the channel, exit
+            if next_rx.recv().await.is_none() {
+                break;
+            };
+
+            // We run rustyline on their own blocking thread. The thread waits for an input line to be requested,
+            // then reads it, and delivers it. While waiting for agent response, there is no line requested,
+            // so readline is not active. If the thread terminates, the entire repl exits.
+            let readline = tokio::task::block_in_place(|| rl.readline("> "));
+            match readline {
+                Ok(line) => {
+                    if is_quit_sequence(&line) {
+                        break;
+                    }
+                    rl.add_history_entry(line.as_str()).into_diagnostic()?;
+                    if lines_tx.send(line).await.is_err() {
+                        break;
+                    }
+                    let _ = rl.append_history(&history_file_path);
+                }
+                Err(err) => {
+                    debug!("Failed to read line: {:?}", err);
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn get_history_file_path(history_file_path: Option<PathBuf>) -> Result<PathBuf> {
+        let create_history_file = |path: &PathBuf| -> Result<()> {
+            if !path.exists() {
+                if let Some(parent) = path.parent() {
+                    if !parent.exists() {
+                        std::fs::create_dir_all(parent)
+                            .into_diagnostic()
+                            .wrap_err("Failed to create history directory for repl")?;
+                    }
+                }
+                std::fs::File::create(path)
+                    .into_diagnostic()
+                    .wrap_err("Failed to create history file for repl")?;
+
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    let permissions = std::fs::Permissions::from_mode(0o600);
+                    std::fs::set_permissions(path, permissions)
+                        .into_diagnostic()
+                        .wrap_err("Failed to set permissions on history file")?;
+                }
+            }
+            Ok(())
+        };
+        match history_file_path {
+            Some(path) => {
+                if !path.exists() {
+                    create_history_file(&path)?;
+                }
+                Ok(path)
+            }
+            None => {
+                let default_path = std::env::current_dir()
+                    .into_diagnostic()
+                    .wrap_err("Failed to get current directory")?
+                    .join(".repl/history.txt");
+                create_history_file(&default_path)?;
+                Ok(default_path)
+            }
+        }
+    }
+}
+
+fn is_reconnect_sequence(input: &str) -> bool {
+    let i = input.trim();
+    let seq = [":reconnect", ":r"];
+    seq.contains(&i)
+}
+
+fn is_quit_sequence(input: &str) -> bool {
+    let i = input.trim();
+    let seq = [":quit", ":q"];
+    if seq.contains(&i) {
+        return true;
+    }
+    let last_line = i.lines().last().unwrap_or("").trim();
+    seq.contains(&last_line)
+}

--- a/implementations/rust/ockam/ockam_command/src/cluster/static/repl/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/cluster/static/repl/long_about.txt
@@ -1,0 +1,1 @@
+This command can be used to access the Repl of an agent started locally.


### PR DESCRIPTION
This PR extracts an `ockam cluster repl` command to call any `Repl` available to a local port.

Additionally it supports streaming when streamed response are returned by an agent. In order to support this the REPL server must send a `0` length message, signaling that this is the last message. When the last message is received the client resumes to waiting user input.