### PR TITLE
feat: hide all commands from "help" except `cluster`

### DIFF
--- a/implementations/rust/ockam/ockam_command/build.rs
+++ b/implementations/rust/ockam/ockam_command/build.rs
@@ -34,7 +34,7 @@ fn binary_name() {
     println!("cargo:rustc-env=COMPILE_OCKAM_HOME={home_dir}");
     println!("cargo:rerun-if-env-changed=COMPILE_OCKAM_HOME");
 
-    let commands = env::var("COMPILE_OCKAM_COMMANDS").unwrap_or("".to_string());
+    let commands = env::var("COMPILE_OCKAM_COMMANDS").unwrap_or("cluster".to_string());
     println!("cargo:rustc-env=COMPILE_OCKAM_COMMANDS={commands}");
     println!("cargo:rerun-if-env-changed=COMPILE_OCKAM_COMMANDS");
 

--- a/implementations/rust/ockam/ockam_command/src/subcommand.rs
+++ b/implementations/rust/ockam/ockam_command/src/subcommand.rs
@@ -72,7 +72,7 @@ pub enum OckamSubcommand {
     #[command(name = command::name("enroll"), hide = command::hide("enroll"))]
     Enroll(EnrollCommand),
 
-    #[command(name = command::name("cluster"), hide = true)]
+    #[command(name = command::name("cluster"), hide = command::hide("cluster"))]
     Cluster(ClusterCommand),
 
     #[command(name = command::name("node"), hide = command::hide("node"))]


### PR DESCRIPTION
By default, only the `cluster` subcommand is shown in the help. The rest are hidden.