### PR TITLE
feat: more http streaming

### DIFF
--- a/implementations/python/python/ockam/agents/http.py
+++ b/implementations/python/python/ockam/agents/http.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import os
-
 import uvicorn
 
 from dataclasses import asdict, is_dataclass
@@ -10,8 +9,9 @@ from fastapi import FastAPI, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse, FileResponse
 
 from ..agents import AgentReference
-from ..nodes.message import GetConversationsRequest
+from ..nodes.message import GetConversationsRequest, ConversationMessage, AssistantMessage
 from ..ockam_in_rust_for_python import info, error
+
 
 """
     This class starts an HTTP server allowing a user to interact with a node and its agents.
@@ -89,7 +89,7 @@ class HttpServer:
                 raise HTTPException(status_code=500, detail="Failed to get the conversations for agent '{name}'")
 
         @self.app.post("/agents/{name}")
-        async def send_message_to_agent(name: str, message: Request, stream: bool = False, node=Depends(self.get_node)):
+        async def send_message_to_agent(name: str, message: Request, stream: bool = False, content_size: int = 50, node=Depends(self.get_node)):
             info(f"Sending a message to agent '{name}'")
             await find_agent(node, name)
 
@@ -104,10 +104,20 @@ class HttpServer:
                 conversation = message_json.get("conversation", None)
 
                 if stream:
-
                     async def stream_response():
+                        received_snippet = None
+
                         async for response in agent.send_stream(msg, scope, conversation):
-                            yield json.dumps(response.snippet, default=default) + "\n"
+                            received = response.snippet
+                            if not received_snippet:
+                                received_snippet = received
+                            else:
+                                received_snippet.messages += received.messages
+                            total_size = sum(len(m.content) for m in received_snippet.messages)
+                            if total_size > content_size or response.finished:
+                                received_snippet = received_snippet.compact_assistant_messages()
+                                yield json.dumps(received_snippet, default=default) + "\n"
+                                received_snippet = None
                             if response.finished:
                                 break
 
@@ -175,3 +185,5 @@ def default(obj):
     if isinstance(obj, Enum):
         return obj.value
     raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
+
+

--- a/implementations/python/python/ockam/agents/http.py
+++ b/implementations/python/python/ockam/agents/http.py
@@ -54,7 +54,7 @@ class HttpServer:
         @self.app.get("/agents/{name}")
         async def get_agent_by_name(name: str, node=Depends(self.get_node)):
             info(f"getting agent by name: {name}")
-            return find_agent(node, name)
+            return await find_agent(node, name)
 
         @self.app.get("/agents/{name}/conversations")
         async def get_conversations_by_agent_name(name: str, node=Depends(self.get_node)):
@@ -77,7 +77,7 @@ class HttpServer:
             name: str, scope: None | str, conversation: None | str, node
         ):
             # Check if the agent exists
-            find_agent(node, name)
+            await find_agent(node, name)
 
             try:
                 agent = AgentReference(name, node)
@@ -91,7 +91,7 @@ class HttpServer:
         @self.app.post("/agents/{name}")
         async def send_message_to_agent(name: str, message: Request, stream: bool = False, node=Depends(self.get_node)):
             info(f"Sending a message to agent '{name}'")
-            find_agent(node, name)
+            await find_agent(node, name)
 
             try:
                 agent = AgentReference(name, node)
@@ -133,15 +133,15 @@ class HttpServer:
             self.api.routes(self.node)
             self.app.mount("/", self.api.api)
 
-        def find_agent(node, name):
-            agents = node.list_agents()
+        async def find_agent(node, name):
+            agents = await node.list_agents()
             agent = next((a for a in agents if a.get("name") == name), None)
             if agent is None:
                 raise HTTPException(status_code=404, detail=f"Agent '{name}' not found")
             return agent
 
-        def find_tool(node, name):
-            tools = node.list_tools()
+        async def find_tool(node, name):
+            tools = await node.list_tools()
             tool = next((t for t in tools if t.get("name") == name), None)
             if tool is None:
                 raise HTTPException(status_code=404, detail=f"Tool '{name}' not found")

--- a/implementations/python/python/ockam/nodes/message.py
+++ b/implementations/python/python/ockam/nodes/message.py
@@ -243,6 +243,24 @@ class ConversationSnippet:
     messages: list[ConversationMessage] = field(default_factory=list)
     type: MessageType = MessageType.CONVERSATION_SNIPPET
 
+    def compact_assistant_messages(self):
+        messages = self.messages
+        all_messages = []
+        assistant_message = None
+        for m in messages:
+            if isinstance(m, AssistantMessage):
+                if assistant_message is None:
+                    assistant_message = m
+                else:
+                    assistant_message.content += m.content
+            else:
+                all_messages.append(m)
+
+        if assistant_message is not None:
+            all_messages.append(assistant_message)
+        self.messages = all_messages
+        return self
+
 
 @dataclass
 class StreamedConversationSnippet:


### PR DESCRIPTION
This PR fixes a bug when calling agents (due to some previous code changes) and adds some buffering for the responses coming from models:

- Only `AssistantMessages` are buffered
- We emit a response when the buffered content size is greater than the `content_size` query parameter (the default value is `50`)