### PR TITLE
refactor: delete local images after all have been pushed

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/base_command.rs
+++ b/implementations/rust/ockam/ockam_command/src/base_command.rs
@@ -1,6 +1,6 @@
 use crate::branding::BrandingCompileEnvVars;
 use crate::cluster::common_args::HttpApiArgs;
-use crate::zone::common_args::ZoneConfigArg;
+use crate::zone::common_args::{DockerBuildArgs, ZoneConfigArg};
 use crate::zone::ctrlc::ZoneCtrlcHandler;
 use crate::zone::repl::ReplExitCondition;
 use crate::zone::zone_config::ZoneConfig;
@@ -22,10 +22,8 @@ pub struct BaseCommand {
     #[arg(long)]
     pub use_public_ecr: bool,
 
-    /// Whether to use the Docker cache when building the image.
-    /// It can be set using the `OCKAM_IGNORE_DOCKER_CACHE` environment variable.
-    #[arg(long, env = "OCKAM_IGNORE_DOCKER_CACHE")]
-    pub no_docker_cache: bool,
+    #[command(flatten)]
+    pub docker_build: DockerBuildArgs,
 
     #[command(flatten)]
     pub http_api: HttpApiArgs,
@@ -170,7 +168,7 @@ impl BaseCommand {
         let cmd = CreateCommand {
             use_public_ecr: self.use_public_ecr,
             http_api: self.http_api.clone(),
-            no_docker_cache: self.no_docker_cache,
+            docker_build: self.docker_build.clone(),
             ..Default::default()
         };
         let zone_config = cmd.run(ctx, opts.clone()).await?;

--- a/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
+++ b/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
@@ -11,6 +11,8 @@ CLI Behavior
 - NO_INPUT: a `boolean` that, if set, the CLI won't ask the user for input.
   Otherwise, let the terminal decide based the terminal features (tty).
 - PAGER: a `string` that defines the pager to use for long help/usage messages. Defaults to `less`.
+- OCKAM_DOCKER_NO_CACHE: a `boolean` to disable using the Docker cache when building images.
+- OCKAM_DOCKER_NO_PULL: a `boolean` to not pull the Docker images when building them.
 
 Logging
 - OCKAM_LOG (deprecated, use OCKAM_LOGGING and OCKAM_LOG_LEVEL instead): a `string` that defines the verbosity of the logs when the `--verbose` argument is not passed: `info`, `warn`, `error`, `debug` or `trace`.

--- a/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
@@ -116,3 +116,16 @@ impl EnrollmentTicketConfigArg {
             .await.wrap_err("Failed to generate an enrollment ticket for the inlet. Please provide one with the --enrollment-ticket argument")
     }
 }
+
+#[derive(Clone, Debug, Args, Default)]
+pub struct DockerBuildArgs {
+    /// Whether to use the Docker cache when building the image.
+    /// It can be set using the `OCKAM_DOCKER_NO_CACHE` environment variable.
+    #[arg(long, env = "OCKAM_DOCKER_NO_CACHE")]
+    pub no_cache: bool,
+
+    /// Whether to build the image with the `--pull` option.
+    /// It can be set using the `OCKAM_DOCKER_NO_PULL` environment variable.
+    #[arg(long, hide = true, env = "OCKAM_DOCKER_NO_PULL")]
+    pub no_pull: bool,
+}

--- a/implementations/rust/ockam/ockam_command/src/zone/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/create.rs
@@ -1,7 +1,7 @@
 use crate::cluster::common_args::HttpApiArgs;
 use crate::cluster::utils::{get_api_client, get_cluster};
 use crate::node_command::InMemoryNodeCommand;
-use crate::zone::common_args::{SecretsConfigArg, ZoneConfigArg};
+use crate::zone::common_args::{DockerBuildArgs, SecretsConfigArg, ZoneConfigArg};
 use crate::zone::secret::SecretCommand;
 use crate::zone::zone_config::ZoneConfig;
 use crate::{docs, Command, CommandGlobalOpts, Result};
@@ -43,10 +43,8 @@ pub struct CreateCommand {
     #[arg(long)]
     pub use_public_ecr: bool,
 
-    /// Whether to use the Docker cache when building the image.
-    /// It can be set using the `OCKAM_IGNORE_DOCKER_CACHE` environment variable.
-    #[arg(long, env = "OCKAM_IGNORE_DOCKER_CACHE")]
-    pub no_docker_cache: bool,
+    #[command(flatten)]
+    pub docker_build: DockerBuildArgs,
 
     #[command(flatten)]
     pub http_api: HttpApiArgs,
@@ -178,8 +176,9 @@ impl CreateCommand {
         // Push the images
         let res = self.push_local_images(opts, &images_data).await;
         for image_data in images_data.iter() {
-            self.delete_local_image(&image_data.image_name, &image_data.repository_uri_tag)
-                .await?;
+            let _ = self
+                .delete_local_image(&image_data.image_name, &image_data.repository_uri_tag)
+                .await;
         }
         res?;
 
@@ -303,7 +302,6 @@ impl CreateCommand {
                 vec![
                     "build",
                     "--load",
-                    "--pull",
                     "--platform",
                     "linux/amd64",
                     "-t",
@@ -316,7 +314,6 @@ impl CreateCommand {
             (
                 vec![
                     "build",
-                    "--pull",
                     "--platform",
                     "linux/amd64",
                     "-t",
@@ -335,8 +332,11 @@ impl CreateCommand {
             for arg in cmd_args {
                 command.arg(arg);
             }
-            if self.no_docker_cache {
+            if self.docker_build.no_cache {
                 command.arg("--no-cache");
+            }
+            if !self.docker_build.no_pull {
+                command.arg("--pull");
             }
             for (env_name, env_value) in env_vars {
                 match env_value {

--- a/implementations/rust/ockam/ockam_command/src/zone/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/create.rs
@@ -176,7 +176,12 @@ impl CreateCommand {
         }
 
         // Push the images
-        self.push_local_images(opts, &images_data).await?;
+        let res = self.push_local_images(opts, &images_data).await;
+        for image_data in images_data.iter() {
+            self.delete_local_image(&image_data.image_name, &image_data.repository_uri_tag)
+                .await?;
+        }
+        res?;
 
         opts.terminal.write_line("")?;
 
@@ -305,7 +310,7 @@ impl CreateCommand {
                     &repository_uri_tag,
                     ".",
                 ],
-                vec![("DOCKER_BUILDKIT", "1")],
+                vec![("DOCKER_BUILDKIT", Some("1"))],
             ),
             // With buildkit disabled
             (
@@ -318,7 +323,7 @@ impl CreateCommand {
                     &repository_uri_tag,
                     ".",
                 ],
-                vec![("DOCKER_BUILDKIT", "0")],
+                vec![("DOCKER_BUILDKIT", None)],
             ),
         ];
 
@@ -334,7 +339,10 @@ impl CreateCommand {
                 command.arg("--no-cache");
             }
             for (env_name, env_value) in env_vars {
-                command.env(env_name, env_value);
+                match env_value {
+                    Some(value) => command.env(env_name, value),
+                    None => command.env_remove(env_name),
+                };
             }
 
             info!(
@@ -440,9 +448,6 @@ impl CreateCommand {
             set.spawn(async move {
                 _self
                     .push_local_image(&image_data.image_name, &image_data.repository_uri_tag)
-                    .await?;
-                _self
-                    .delete_local_image(&image_data.image_name, &image_data.repository_uri_tag)
                     .await?;
                 Ok(image_data.image_name)
             });


### PR DESCRIPTION
- add `--no-pull` argument to `ockam` and `ockam zone create`, also enabled with `OCKAM_DOCKER_NO_PULL`
- rename `OCKAM_IGNORE_DOCKER_CACHE` to `OCKAM_DOCKER_NO_CACHE`