### PR TITLE
feat: after deploying a zone, show public http server url

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/base_command.rs
+++ b/implementations/rust/ockam/ockam_command/src/base_command.rs
@@ -1,6 +1,6 @@
 use crate::branding::BrandingCompileEnvVars;
 use crate::cluster::common_args::HttpApiArgs;
-use crate::zone::common_args::{DockerBuildArgs, ZoneConfigArg};
+use crate::zone::common_args::{DockerBuildArgs, ZoneConfigArg, ZoneInletsArgs};
 use crate::zone::ctrlc::ZoneCtrlcHandler;
 use crate::zone::repl::ReplExitCondition;
 use crate::zone::zone_config::ZoneConfig;
@@ -28,20 +28,15 @@ pub struct BaseCommand {
     #[command(flatten)]
     pub http_api: HttpApiArgs,
 
+    #[command(flatten)]
+    pub inlets: ZoneInletsArgs,
+
     /// The name of the template project to download.
     /// It can be either a GitHub repository like `build-trust/ockam-cluster-template-hello`,
     /// a full URL like `git@github.com:build-trust/ockam-cluster-template-hello`,
     /// or an Ockam repository name that exists at `build-trust/ockam-cluster-template-<NAME>`
     #[arg(long, default_value = "hello", env = "INIT_REPOSITORY")]
     init_repository: String,
-
-    /// Skip the creation of the inlet to the http outlet.
-    #[arg(long)]
-    no_http: bool,
-
-    /// Skip the creation of the inlet to the logs outlet.
-    #[arg(long)]
-    no_logs: bool,
 
     /// Watch the current directory for changes and redeploy the zone when changes are detected.
     #[arg(long)]
@@ -168,6 +163,7 @@ impl BaseCommand {
             use_public_ecr: self.use_public_ecr,
             http_api: self.http_api.clone(),
             docker_build: self.docker_build.clone(),
+            inlets: self.inlets.clone(),
             ..Default::default()
         };
         let zone_config = cmd.run(ctx, opts.clone()).await?;
@@ -182,8 +178,7 @@ impl BaseCommand {
         use crate::zone::repl::ReplCommand;
         let cmd = ReplCommand {
             http_api: self.http_api.clone(),
-            no_http: self.no_http,
-            no_logs: self.no_logs,
+            inlets: self.inlets.clone(),
             ..Default::default()
         };
         cmd.run_impl(opts.clone(), restart_tx).await

--- a/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
@@ -129,3 +129,14 @@ pub struct DockerBuildArgs {
     #[arg(long, hide = true, env = "OCKAM_DOCKER_NO_PULL")]
     pub no_pull: bool,
 }
+
+#[derive(Clone, Debug, Args, Default)]
+pub struct ZoneInletsArgs {
+    /// Skip the creation of the inlet to the http outlet.
+    #[arg(long)]
+    pub no_http: bool,
+
+    /// Skip the creation of the inlet to the logs outlet.
+    #[arg(long)]
+    pub no_logs: bool,
+}

--- a/implementations/rust/ockam/ockam_command/src/zone/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/create.rs
@@ -1,7 +1,7 @@
 use crate::cluster::common_args::HttpApiArgs;
 use crate::cluster::utils::{get_api_client, get_cluster};
 use crate::node_command::InMemoryNodeCommand;
-use crate::zone::common_args::{DockerBuildArgs, SecretsConfigArg, ZoneConfigArg};
+use crate::zone::common_args::{DockerBuildArgs, SecretsConfigArg, ZoneConfigArg, ZoneInletsArgs};
 use crate::zone::secret::SecretCommand;
 use crate::zone::zone_config::ZoneConfig;
 use crate::{docs, Command, CommandGlobalOpts, Result};
@@ -48,6 +48,9 @@ pub struct CreateCommand {
 
     #[command(flatten)]
     pub http_api: HttpApiArgs,
+
+    #[command(flatten)]
+    pub inlets: ZoneInletsArgs,
 }
 
 #[derive(Clone)]
@@ -546,6 +549,20 @@ impl CreateCommand {
             color_primary(cluster)
         ))?;
         info!("Deployed zone {} in cluster {}", zone_config.name, cluster);
+
+        // Print the http server URL, if enabled
+        if !self.inlets.no_http {
+            if let Some(http_url) = zone_config.get_http_url(cluster) {
+                opts.terminal.write_line(
+                    fmt_log!(
+                        "The http server on the {} is available at:\n",
+                        color_primary(&zone_config.get_main_pod()?.name),
+                    ) + &fmt_log!("{}", color_primary(http_url)),
+                )?;
+            }
+        }
+
+        opts.terminal.write_line("")?;
 
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/zone/repl.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/repl.rs
@@ -2,7 +2,9 @@ use crate::cluster::common_args::HttpApiArgs;
 use crate::entry_point::RUNTIME;
 use crate::util::parsers::hostname_parser;
 use crate::util::port_is_free_guard;
-use crate::zone::common_args::{EnrollmentTicketConfigArg, ZoneConfigArg, ZoneNameOrConfigArg};
+use crate::zone::common_args::{
+    EnrollmentTicketConfigArg, ZoneConfigArg, ZoneInletsArgs, ZoneNameOrConfigArg,
+};
 use crate::zone::ctrlc::ZoneCtrlcHandler;
 use crate::zone::zone_config::{Outlet, ZoneConfig};
 use crate::{docs, Command, CommandGlobalOpts, Result};
@@ -48,17 +50,12 @@ pub struct ReplCommand {
     #[command(flatten)]
     pub http_api: HttpApiArgs,
 
+    #[command(flatten)]
+    pub inlets: ZoneInletsArgs,
+
     /// Network address where your repl server is listening to.
     #[arg(long, id = "SOCKET_ADDRESS", display_order = 900, value_parser = hostname_parser)]
     pub to: Option<SchemeHostnamePort>,
-
-    /// Skip the creation of the inlet to the http outlet.
-    #[arg(long)]
-    pub no_http: bool,
-
-    /// Skip the creation of the inlet to the logs outlet.
-    #[arg(long)]
-    pub no_logs: bool,
 }
 
 #[async_trait]
@@ -128,10 +125,10 @@ impl ReplCommand {
             }
         };
         let mut rest = main_pod_outlets.rest;
-        if !self.no_http {
+        if !self.inlets.no_http {
             rest.push(main_pod_outlets.http);
         }
-        if !self.no_logs {
+        if !self.inlets.no_logs {
             rest.push(main_pod_outlets.logs);
         }
         for outlet in rest {

--- a/implementations/rust/ockam/ockam_command/src/zone/zone_config.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/zone_config.rs
@@ -15,6 +15,8 @@ pub struct ZoneConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Pod {
     pub name: String,
+    #[serde(default)]
+    pub public: bool,
     pub containers: Vec<Container>,
     #[serde(default, alias = "portal")]
     pub portals: Portals,
@@ -268,6 +270,17 @@ impl ZoneConfig {
                 })
         }
     }
+
+    pub fn get_http_url(&self, cluster_name: &str) -> Option<String> {
+        if self.get_main_pod().ok()?.public {
+            Some(format!(
+                "https://{}-{}.ai.ockam.network",
+                cluster_name, self.name
+            ))
+        } else {
+            None
+        }
+    }
 }
 
 impl Pod {
@@ -406,6 +419,7 @@ pods:
             pods: vec![
                 Pod {
                     name: "pod1".to_string(),
+                    public: false,
                     containers: vec![
                         Container {
                             name: "abc".to_string(),
@@ -423,6 +437,7 @@ pods:
                 },
                 Pod {
                     name: "pod2".to_string(),
+                    public: false,
                     containers: vec![
                         Container {
                             name: "abc".to_string(),
@@ -445,6 +460,7 @@ pods:
                 },
                 Pod {
                     name: "pod3".to_string(),
+                    public: false,
                     containers: vec![
                         Container {
                             name: "abc".to_string(),
@@ -478,6 +494,7 @@ pods:
             name: "valid-zone".to_string(),
             pods: vec![Pod {
                 name: "pod1".to_string(),
+                public: false,
                 containers: vec![Container {
                     name: "abc".to_string(),
                     image: "image1".to_string(),
@@ -497,6 +514,7 @@ pods:
             name: "this-zone-name-is-too-long".to_string(),
             pods: vec![Pod {
                 name: "pod1".to_string(),
+                public: false,
                 containers: vec![Container {
                     name: "abc".to_string(),
                     image: "image1".to_string(),
@@ -521,6 +539,7 @@ pods:
             name: "zone".to_string(),
             pods: vec![Pod {
                 name: "pod-name-too-long".to_string(),
+                public: false,
                 containers: vec![Container {
                     name: "abc".to_string(),
                     image: "image1".to_string(),
@@ -545,6 +564,7 @@ pods:
             name: "zone".to_string(),
             pods: vec![Pod {
                 name: "pod1".to_string(),
+                public: false,
                 containers: vec![Container {
                     name: "container-name-is-too-long".to_string(),
                     image: "image1".to_string(),
@@ -571,6 +591,7 @@ pods:
             pods: vec![
                 Pod {
                     name: "pod1".to_string(),
+                    public: false,
                     containers: vec![Container {
                         name: "container1".to_string(),
                         image: "image1".to_string(),
@@ -581,6 +602,7 @@ pods:
                 },
                 Pod {
                     name: "pod1".to_string(), // Duplicate pod name
+                    public: false,
                     containers: vec![Container {
                         name: "container2".to_string(),
                         image: "image2".to_string(),
@@ -604,6 +626,7 @@ pods:
             name: "zone".to_string(),
             pods: vec![Pod {
                 name: "pod1".to_string(),
+                public: false,
                 containers: vec![
                     Container {
                         name: "container1".to_string(),
@@ -635,6 +658,7 @@ pods:
             name: "long-zone-name".to_string(),
             pods: vec![Pod {
                 name: "long-pod-name".to_string(),
+                public: false,
                 containers: vec![Container {
                     name: "container-name-is-too-long".to_string(),
                     image: "image1".to_string(),
@@ -794,6 +818,7 @@ pods:
             name: "zone".to_string(),
             pods: vec![Pod {
                 name: "pod1".to_string(),
+                public: false,
                 containers: vec![Container {
                     name: "app".to_string(),
                     image: "image1".to_string(),
@@ -920,6 +945,7 @@ pods:
         // Setup pod with multiple outlets including a "repl" outlet
         let pod = Pod {
             name: "test-pod".to_string(),
+            public: false,
             containers: vec![Container {
                 name: "app".to_string(),
                 image: "app-image".to_string(),
@@ -1005,6 +1031,7 @@ pods:
         // Setup pod with a single named outlet (not named "repl")
         let pod = Pod {
             name: "test-pod".to_string(),
+            public: false,
             containers: vec![Container {
                 name: "app".to_string(),
                 image: "app-image".to_string(),
@@ -1039,6 +1066,7 @@ pods:
         // Setup pod with a single unnamed outlet (not named "repl")
         let pod = Pod {
             name: "test-pod".to_string(),
+            public: false,
             containers: vec![Container {
                 name: "app".to_string(),
                 image: "app-image".to_string(),
@@ -1073,6 +1101,7 @@ pods:
         // Setup pod with unnamed outlets
         let pod = Pod {
             name: "test-pod".to_string(),
+            public: false,
             containers: vec![Container {
                 name: "app".to_string(),
                 image: "app-image".to_string(),
@@ -1111,6 +1140,7 @@ pods:
         // Setup pod with no outlets
         let pod = Pod {
             name: "test-pod".to_string(),
+            public: false,
             containers: vec![Container {
                 name: "app".to_string(),
                 image: "app-image".to_string(),
@@ -1138,6 +1168,7 @@ pods:
         // Setup pod with multiple outlets but no "repl"
         let pod = Pod {
             name: "test-pod".to_string(),
+            public: false,
             containers: vec![Container {
                 name: "app".to_string(),
                 image: "app-image".to_string(),
@@ -1185,6 +1216,7 @@ pods:
         // Setup pod with http and logs outlets explicitly defined
         let pod = Pod {
             name: "test-pod".to_string(),
+            public: false,
             containers: vec![Container {
                 name: "app".to_string(),
                 image: "app-image".to_string(),


### PR DESCRIPTION
When the `public` field is used, the http server url is printed:

```yaml
name: example
pods:
  - name: main-pod
    public: true
    containers:
...
```