### PR TITLE
chore(rust): adjust default port and hosts

### DIFF
--- a/implementations/python/python/ockam/agents/http.py
+++ b/implementations/python/python/ockam/agents/http.py
@@ -18,7 +18,7 @@ from ..ockam_in_rust_for_python import info, error
 """
 
 HOST = "0.0.0.0"
-PORT = 9001
+PORT = 8000
 
 
 class HttpServer:

--- a/implementations/rust/ockam/ockam_command/src/zone/zone_config.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/zone_config.rs
@@ -160,7 +160,7 @@ impl ZoneConfig {
                 .for_each(|pod| {
                     pod.portals.outlets.push(Outlet {
                         name: Some("http".to_string()),
-                        to: "127.0.0.1:8000".to_string(),
+                        to: "localhost:8000".to_string(),
                         ..Default::default()
                     })
                 });
@@ -172,7 +172,7 @@ impl ZoneConfig {
                 .for_each(|pod| {
                     pod.portals.outlets.push(Outlet {
                         name: Some("logs".to_string()),
-                        to: "127.0.0.1:3000".to_string(),
+                        to: "localhost:3000".to_string(),
                         pod_name: Some("logs-pod".to_string()),
                         ..Default::default()
                     })


### PR DESCRIPTION
use localhost in the portal definition. Listen on 8000 by default on http server