### PR TITLE
fix: close a remote connection when a mailbox has received a message

### DIFF
--- a/implementations/python/python/ockam/nodes/protocol.py
+++ b/implementations/python/python/ockam/nodes/protocol.py
@@ -10,6 +10,8 @@ class MailboxProtocol(Protocol):
 
     async def receive(self, policy: Optional[str] = None, timeout: Optional[int] = None) -> str: ...
 
+    async def close_remote_connection(self, node: str) -> str: ...
+
 
 @runtime_checkable
 class ContextProtocol(Protocol):

--- a/implementations/python/src/nodes/mailbox.rs
+++ b/implementations/python/src/nodes/mailbox.rs
@@ -84,8 +84,20 @@ impl PyMailbox {
                 .receive_extended::<String>(options)
                 .await
                 .map_err(py_error)?;
-
             result.into_body().map_err(py_error)
+        })
+    }
+
+    #[pyo3(signature = (node))]
+    fn close_remote_connection<'a>(
+        &self,
+        py: Python<'a>,
+        node: String,
+    ) -> PyResult<Bound<'a, PyAny>> {
+        let node_clone = self.node.clone();
+
+        future_into_py(py, async move {
+            node_clone.close_remote_route(node).await.map_err(py_error)
         })
     }
 }
@@ -104,7 +116,7 @@ impl PyMailbox {
 
         future_into_py(py, async move {
             node_clone
-                .with_route(node, destination, move |route| async move {
+                .with_route(node, destination, false, move |route| async move {
                     let outgoing_ac = Arc::new(AllowAll);
 
                     let ctx = self_clone.ctx.read().await;

--- a/implementations/python/src/nodes/node.rs
+++ b/implementations/python/src/nodes/node.rs
@@ -18,6 +18,7 @@ use ockam::{
 use ockam_api::cli_state::{EnrollmentTicket, ExportedEnrollmentTicket, NamedIdentity};
 use ockam_api::enroll::enrollment::{EnrollStatus, Enrollment};
 use ockam_api::multiaddr::MultiAddr;
+use ockam_api::nodes::connection::Connection;
 use ockam_api::nodes::models::relay::ReturnTiming;
 use ockam_api::nodes::service::{
     NodeManager, NodeManagerGeneralOptions, NodeManagerTransport, NodeManagerTransportOptions,
@@ -64,6 +65,7 @@ pub struct PyNode {
 struct CachedRemoteRoute {
     last_used: Instant,
     route: Route,
+    connection: Connection,
 }
 
 impl PyNode {
@@ -834,6 +836,7 @@ impl PyNode {
         &self,
         node_name: Option<String>,
         destination: String,
+        close_on_completion: bool,
         fut: F,
     ) -> Result<R>
     where
@@ -870,16 +873,28 @@ impl PyNode {
                     .await?;
                 let route = connection.route()?;
 
-                // FIXME
-                // let result = fut(route).await;
-                // _ = connection.close(&self.node_manager);
-                // result
-
-                fut(route).await
+                if close_on_completion {
+                    let result = fut(route).await;
+                    _ = connection.close(&self.node_manager);
+                    result
+                } else {
+                    fut(route).await
+                }
             }
         } else {
             fut(destination.into()).await
         }
+    }
+
+    /// Close a route to a remote node if a project is specified.
+    pub(crate) async fn close_remote_route(&self, node_name: String) -> Result<()> {
+        if let Some(project) = &self.project {
+            if let Some(cache) = &self.remote_connection_cache {
+                self.remove_cached_connection(cache, project.name().to_string(), node_name)
+                    .await;
+            }
+        };
+        Ok(())
     }
 
     async fn get_remote_route_to_node(
@@ -917,6 +932,7 @@ impl PyNode {
             CachedRemoteRoute {
                 last_used: now,
                 route: route.clone(),
+                connection,
             },
         );
         Ok(route)
@@ -930,7 +946,9 @@ impl PyNode {
     ) {
         let key = &(project_name, node_name);
         let mut cache = cache.write().await;
-        cache.remove(key);
+        if let Some(cached) = cache.remove(key) {
+            _ = cached.connection.close(&self.node_manager);
+        };
     }
 
     fn send_and_receive_impl<'a>(
@@ -947,7 +965,7 @@ impl PyNode {
 
         future_into_py(py, async move {
             self_clone
-                .with_route(node, destination, move |route| async move {
+                .with_route(node, destination, true, move |route| async move {
                     let (incoming_ac, outgoing_ac) = (Arc::new(AllowAll), Arc::new(AllowAll));
 
                     let options = MessageSendReceiveOptions::new()

--- a/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod connection;
+pub mod connection;
 pub mod models;
 pub mod registry;
 pub mod service;


### PR DESCRIPTION
This PR adds a function to be able to close a remote connection when a mailbox is not used anymore.
It is still the responsibility of the user to ensure that this method is called though.