### PR TITLE
feat: improve logging

### DIFF
--- a/examples/001/images/main/main.py
+++ b/examples/001/images/main/main.py
@@ -1,4 +1,4 @@
-from ockam import Agent, Node
+from ockam import Agent, Node, LoggingConfig
 
 
 async def main(node):

--- a/implementations/python/examples/01.py
+++ b/implementations/python/examples/01.py
@@ -1,4 +1,6 @@
-from ockam import Node, info
+from ockam import Node, info, LOGGING_CONFIG, set_log_level
+
+set_log_level("node", "DEBUG")
 
 """
     This example shows that it is possible to start a worker written in Python,

--- a/implementations/python/examples/03.py
+++ b/implementations/python/examples/03.py
@@ -17,7 +17,7 @@ async def main(node):
     response = await model.complete_chat(
         [{"content": "respond in 20 words. who are you?", "role": "user"}],
     )
-    print(response)
+    info(f"the model response is {response}")
 
     await node.start_worker("echoer", Echoer())
     reply = await node.send_and_receive("echoer", "hello")

--- a/implementations/python/examples/04-client.py
+++ b/implementations/python/examples/04-client.py
@@ -1,6 +1,6 @@
 import sys
 
-from ockam import Node, RemoteNode
+from ockam import Node, RemoteNode, info, HttpServer
 
 """
     This example shows how an enrolled node can send messages to a remote node:
@@ -17,9 +17,9 @@ async def main(node):
     remote_node = RemoteNode(node, sys.argv[1])
     for i in range(5):
         reply = await remote_node.send_and_receive("echoer", "hello")
-        print(f"{i}> {reply}")
+        info(f"{i}> {reply}")
 
 
-Node.start(main, wait_until_interrupted=False)
+Node.start(main, wait_until_interrupted=False, http_server=HttpServer(listen_address="localhost:8001"))
 
 # OCKAM_SQLITE_IN_MEMORY=1 CLUSTER=acme NODE=node1 ENROLLMENT_TICKET="$(ockam project ticket --relay node1 --attribute cluster=acme)" uv run examples/04-client.py node2

--- a/implementations/python/examples/05.py
+++ b/implementations/python/examples/05.py
@@ -1,4 +1,4 @@
-from ockam import Agent, Model, Node
+from ockam import Agent, Model, Node, info
 
 """
     This example shows how to start an agent locally given a node.
@@ -19,9 +19,9 @@ async def main(node):
         model=Model(name="ollama_chat/llama3.2"),
     )
     identifier = await agent.identifier()
-    print(identifier)
+    info(identifier)
     reply = await agent.send("Who was Gandhi?")
-    print(reply)
+    info(reply)
 
 
 Node.start(main, wait_until_interrupted=False)

--- a/implementations/python/examples/06.py
+++ b/implementations/python/examples/06.py
@@ -1,4 +1,4 @@
-from ockam import Agent, Model, Node, Tool
+from ockam import Agent, Model, Node, Tool, info
 
 """
     This example shows how to add tools to an agent.
@@ -27,9 +27,9 @@ async def main(node):
         tools=[Tool(divide), Tool(multiply)],
     )
     reply = await agent.send("What is 56 divided by 27?")
-    print(reply)
+    info(reply)
     reply = await agent.send("What is 214 multiplied by 63?")
-    print(reply)
+    info(reply)
 
 
 Node.start(main, wait_until_interrupted=False)

--- a/implementations/python/examples/07-client.py
+++ b/implementations/python/examples/07-client.py
@@ -1,4 +1,4 @@
-from ockam import Agent, McpClient, McpTool, Model, Node, RemoteNode
+from ockam import Agent, McpClient, McpTool, Model, Node, RemoteNode, info, HttpServer
 
 import sys
 
@@ -49,9 +49,9 @@ async def main(node):
     )
 
     reply = await agent.send("Who was Gandhi?")
-    print(reply)
+    info(f"Who was Gandhi?\n\n{reply}")
     reply = await agent.send("What is dark matter?")
-    print(reply)
+    info(f"What is dark matter?\n\n{reply}")
 
 
 Node.start(
@@ -60,6 +60,7 @@ Node.start(
         McpClient(name="server-one", address="http://127.0.0.1:8000/sse"),
     ],
     wait_until_interrupted=False,
+    http_server=HttpServer(listen_address="localhost:9001"),
 )
 
 # OCKAM_SQLITE_IN_MEMORY=1 CLUSTER=acme NODE=node1 ENROLLMENT_TICKET="$(ockam project ticket --relay node1 --attribute cluster=acme)" uv run examples/07-client.py node2

--- a/implementations/python/examples/07-server.py
+++ b/implementations/python/examples/07-server.py
@@ -1,4 +1,4 @@
-from ockam import Node, McpServer
+from ockam import Node, McpServer, HttpServer
 
 """
     Second part of example 07. This simply starts a McpServer worker and makes it accessible via tcp.
@@ -6,6 +6,9 @@ from ockam import Node, McpServer
     Once an agent is started, the McpServer will direct messages to it if that agent is exposed as a tool.
 """
 
-Node.start(mcp_server=McpServer(listen_address="127.0.0.1:8000"))
+Node.start(
+    mcp_server=McpServer(listen_address="127.0.0.1:8000"),
+    http_server=HttpServer(listen_address="localhost:9000"),
+)
 
 # OCKAM_SQLITE_IN_MEMORY=1 CLUSTER=acme NODE=node2 ENROLLMENT_TICKET="$(ockam project ticket --relay node2 --attribute cluster=acme)" uv run examples/07-server.py

--- a/implementations/python/examples/08.py
+++ b/implementations/python/examples/08.py
@@ -1,4 +1,4 @@
-from ockam import Agent, Model, Node, CoTPlanner
+from ockam import Agent, Model, Node, CoTPlanner, info
 
 """
     This example shows how to use a planning strategy ("Chain of Thought" or COT) to solve a complex task.
@@ -15,7 +15,7 @@ async def main(node):
         planner=CoTPlanner(),
     )
     reply = await agent.send("Estimate how many violins are in the world", timeout=60 * 2)
-    print(reply)
+    info(reply)
 
 
 Node.start(main, wait_until_interrupted=False)

--- a/implementations/python/examples/09.py
+++ b/implementations/python/examples/09.py
@@ -1,4 +1,4 @@
-from ockam import Agent, Model, Node, Tool
+from ockam import Agent, Model, Node, Tool, info
 
 """
     This example shows the difference between querying a model using local tools and
@@ -27,21 +27,25 @@ async def main(node):
         tools=[Tool(divide), Tool(multiply)],
     )
     reply = await agent.send("What is 56 divided by 27?", scope="a", conversation="1")
-    print(reply)
+    info(f"What is 56 divided by 27? {reply}")
+
     reply = await agent.send("What is 214 multiplied by 63?", scope="a", conversation="1")
-    print(reply)
+    info(f"What is 214 multiplied by 63? {reply}")
+
     reply = await agent.send(
         "Answer only yes or no: have I asked you what is 56 divided by 27?", scope="a", conversation="1"
     )
-    print(reply)
+    info(f"Answer only yes or no: have I asked you what is 56 divided by 27? {reply}")
+
     reply = await agent.send(
         "Answer only yes or no: have I asked you what is 56 divided by 3?", scope="a", conversation="1"
     )
-    print(reply)
+    info(f"Answer only yes or no: have I asked you what is 56 divided by 3? {reply}")
+
     reply = await agent.send(
         "Answer only yes or no: have I asked you what is 56 divided by 27?", scope="a", conversation="2"
     )
-    print(reply)
+    info(f"Answer only yes or no: have I asked you what is 56 divided by 27? {reply}")
 
 
 Node.start(main, wait_until_interrupted=False)

--- a/implementations/python/examples/18/main.py
+++ b/implementations/python/examples/18/main.py
@@ -7,14 +7,15 @@ http --stream -b POST ':8000/agents/henry?timeout=60' message="Estimate how many
 ```
 
 """
+
+
 async def main(node):
     await Agent.start(
         node=node,
         name="henry",
         instructions="You are an assistant who solves complex tasks by planning them carefully before solving them.",
-        planner=CoTPlanner(model=Model(name="deepseek-r1")),
+        planner=CoTPlanner(model=Model(name="llama3.2")),
     )
-
 
 
 Node.start(main)

--- a/implementations/python/pyproject.toml
+++ b/implementations/python/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "attrs>=25.3.0",
   "boto3>=1.38.8",
   "cattrs>=24.1.3",
+  "colorlog>=6.9",
   "dill>=0.4.0",
   "docstring-parser>=0.16",
   "fastapi>=0.103.1",

--- a/implementations/python/python/ockam/__init__.py
+++ b/implementations/python/python/ockam/__init__.py
@@ -3,6 +3,7 @@ from .clusters import Cluster, Zone
 from .flows import Flow, FlowOperation, START, END
 from .nodes.message import FlowReference
 from .memory import Memory
+from .logging import LOGGING_CONFIG, info, warning, error, debug, set_log_level
 from .models import Model
 from .nodes import Node, RemoteNode, LocalNode, LocalNodeProtocol, MailboxProtocol, WorkerProtocol, ContextProtocol
 from .nodes.manager import RemoteManager
@@ -26,7 +27,7 @@ from .knowledge import (
 )
 from .gather import gather
 
-from .ockam_in_rust_for_python import Mailbox, McpClient, McpServer, info, warn, error, debug
+from .ockam_in_rust_for_python import Mailbox, McpClient, McpServer
 
 __doc__ = ""
 __all__ = [
@@ -44,14 +45,17 @@ __all__ = [
     "FlowOperation",
     "START",
     "END",
+    # from .logging
+    "LOGGING_CONFIG",
+    "info",
+    "warning",
+    "error",
+    "debug",
+    "set_log_level",
     # from .ockam_in_rust_for_python
     "Mailbox",
     "McpClient",
     "McpServer",
-    "info",
-    "warn",
-    "error",
-    "debug",
     # from .tools
     "McpTool",
     "Tool",

--- a/implementations/python/python/ockam/agents/agent.py
+++ b/implementations/python/python/ockam/agents/agent.py
@@ -33,6 +33,12 @@ from ..nodes.message import (
 from ..ockam_in_rust_for_python import info, warn, debug
 from ..planning.protocol import STEP_BY_STEP_EXECUTION
 
+from ..logging.logging import LOGGING_CONFIG
+import logging.config
+
+logging.config.dictConfig(LOGGING_CONFIG)
+logger = logging.getLogger("agent")
+
 
 class Agent:
     def __init__(
@@ -48,6 +54,7 @@ class Agent:
         knowledge: KnowledgeProvider,
         max_knowledge_size: int,
     ):
+        logger.info("starting agent")
         self.node = node
 
         self.tools = tools
@@ -70,6 +77,9 @@ class Agent:
 
     async def handle_message(self, context, message):
         try:
+            logger.info("received a message")
+            logger.debug(f"the message is {message}")
+
             message = self.converter.message_from_json(message)
             handlers = {
                 ConversationSnippet: self.handle__conversation_snippet,
@@ -87,6 +97,7 @@ class Agent:
                 if handler is not None:
                     reply = await handler(message)
                 else:
+                    logger.error(f"unexpected message: {message}")
                     reply = Error(f"Unexpected Message: {message}")
 
                 if reply is not None:

--- a/implementations/python/python/ockam/agents/http.py
+++ b/implementations/python/python/ockam/agents/http.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import logging
 import uvicorn
 
 from dataclasses import asdict, is_dataclass
@@ -12,6 +13,7 @@ from ..agents import AgentReference
 from ..nodes.message import GetConversationsRequest, ConversationMessage, AssistantMessage, StreamedConversationSnippet
 from ..ockam_in_rust_for_python import info, error
 
+logger = logging.getLogger("http")
 
 """
     This class starts an HTTP server allowing a user to interact with a node and its agents.
@@ -22,7 +24,7 @@ PORT = 8000
 
 
 class HttpServer:
-    def __init__(self, listen_address=f"{HOST}:{PORT}", log_level: str = "debug", api=None):
+    def __init__(self, listen_address=f"{HOST}:{PORT}", log_level: str = "error", api=None):
         self.node = None
         self.host = HOST
         self.port = PORT
@@ -43,34 +45,34 @@ class HttpServer:
 
         @self.app.get("/agents")
         async def get_agents(node=Depends(self.get_node)):
-            info("getting the agents")
+            logger.info("get agents")
             return {"agents": await node.list_agents()}
 
         @self.app.get("/workers")
         async def get_workers(node=Depends(self.get_node)):
-            info("getting the workers")
+            logger.info("get workers")
             return {"workers": await node.list_workers()}
 
         @self.app.get("/agents/{name}")
         async def get_agent_by_name(name: str, node=Depends(self.get_node)):
-            info(f"getting agent by name: {name}")
+            logger.info(f"get agent by name: {name}")
             return await find_agent(node, name)
 
         @self.app.get("/agents/{name}/conversations")
         async def get_conversations_by_agent_name(name: str, node=Depends(self.get_node)):
-            info(f"getting conversations by agent {name}")
+            logger.info(f"get conversations by agent name: {name}")
             return await get_agent_by_name_and_scope_and_conversation_impl(name, None, None, node)
 
         @self.app.get("/agents/{name}/scopes/{scope}/conversations")
         async def get_conversations_by_agent_name_and_scope(name: str, scope: str, node=Depends(self.get_node)):
-            info(f"getting conversations by agent {name} and scope {scope}")
+            logger.info(f"get conversations by agent {name} and scope {scope}")
             return await get_agent_by_name_and_scope_and_conversation_impl(name, scope, None, node)
 
         @self.app.get("/agents/{name}/scopes/{scope}/conversations/{conversation}")
         async def get_agent_by_name_and_scope_and_conversation(
             name: str, scope: str, conversation: str, node=Depends(self.get_node)
         ):
-            info(f"getting conversations by agent {name}, scope {scope} and conversation {conversation}")
+            logger.info(f"getting conversations by agent {name}, scope {scope} and conversation {conversation}")
             return await get_agent_by_name_and_scope_and_conversation_impl(name, scope, conversation, node)
 
         async def get_agent_by_name_and_scope_and_conversation_impl(
@@ -85,12 +87,12 @@ class HttpServer:
                 response = await agent.send_and_receive_request(query)
                 return response
             except Exception as e:
-                error(f"Failed to get the conversations for agent '{name}': {e}")
+                logger.error(f"Failed to get the conversations for agent '{name}': {e}")
                 raise HTTPException(status_code=500, detail="Failed to get the conversations for agent '{name}'")
 
         @self.app.post("/agents/{name}")
-        async def send_message_to_agent(name: str, message: Request, stream: bool = False, content_size: int = 50, timeout: int = 60, node=Depends(self.get_node)):
-            info(f"Sending a message to agent '{name}'")
+        async def send_message_to_agent(name: str, message: Request, stream: bool = False, node=Depends(self.get_node)):
+            logger.info(f"Send a message to agent '{name}'")
             await find_agent(node, name)
 
             try:
@@ -135,17 +137,17 @@ class HttpServer:
                 else:
                     return await agent.send(msg, scope, conversation, timeout=timeout)
             except Exception as e:
-                error(f"Failed to send message to agent '{name}': {e}")
+                logger.error(f"Failed to send message to agent '{name}': {e}")
                 raise HTTPException(status_code=500, detail="Failed to send message")
 
         @self.app.get("/tools")
         async def get_tools(node=Depends(self.get_node)):
-            info("getting the exposed tools")
+            logger.info("get the exposed tools")
             return node.list_tools()
 
         @self.app.get("/tools/{name}")
         async def get_tool_by_name(name: str, node=Depends(self.get_node)):
-            info(f"getting tool by name: {name}")
+            logger.info(f"get tool by name: {name}")
             return find_tool(node, name)
 
         # mount the custom routes

--- a/implementations/python/python/ockam/agents/http.py
+++ b/implementations/python/python/ockam/agents/http.py
@@ -91,8 +91,15 @@ class HttpServer:
                 raise HTTPException(status_code=500, detail="Failed to get the conversations for agent '{name}'")
 
         @self.app.post("/agents/{name}")
-        async def send_message_to_agent(name: str, message: Request, stream: bool = False, node=Depends(self.get_node)):
-            logger.info(f"Send a message to agent '{name}'")
+        async def send_message_to_agent(
+            name: str,
+            message: Request,
+            stream: bool = False,
+            content_size: int = 50,
+            timeout: int = 60,
+            node=Depends(self.get_node),
+        ):
+            logger.info(f"send a message to agent '{name}'")
             await find_agent(node, name)
 
             try:
@@ -106,6 +113,7 @@ class HttpServer:
                 conversation = message_json.get("conversation", None)
 
                 if stream:
+
                     async def stream_response():
                         received_snippet = None
 
@@ -137,7 +145,7 @@ class HttpServer:
                 else:
                     return await agent.send(msg, scope, conversation, timeout=timeout)
             except Exception as e:
-                logger.error(f"Failed to send message to agent '{name}': {e}")
+                logger.error(f"failed to send message to agent '{name}': {e}")
                 raise HTTPException(status_code=500, detail="Failed to send message")
 
         @self.app.get("/tools")
@@ -197,5 +205,3 @@ def default(obj):
     if isinstance(obj, Enum):
         return obj.value
     raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
-
-

--- a/implementations/python/python/ockam/agents/repl.py
+++ b/implementations/python/python/ockam/agents/repl.py
@@ -4,6 +4,12 @@ import re
 
 from ockam.nodes.message import StreamedConversationSnippet
 
+from ..logging.logging import LOGGING_CONFIG
+import logging.config
+
+logging.config.dictConfig(LOGGING_CONFIG)
+logger = logging.getLogger("repl")
+
 HOST = "127.0.0.1"
 PORT = 7000
 
@@ -33,6 +39,7 @@ class Repl:
     # TODO: should be on Reference class
     @staticmethod
     async def start(agent_reference, listen_address=f"{HOST}:{PORT}", functions=None, timeout=None, stream=True):
+        logger.info("starting the REPL")
         repl = Repl(agent_reference, listen_address, functions, timeout, stream)
         # start the repl in a separate thread since we might also have a HTTP server running
         asyncio.create_task(repl.start_impl())
@@ -53,6 +60,7 @@ class Repl:
             raise ValueError(f"Invalid listen_address: {listen_address}")
 
     async def list_functions(self, writer):
+        logger.debug("list functions")
         functions_list = "\n".join([f"{name}" for name in self.functions.keys()])
         await self.write_repl_message(writer, functions_list)
 
@@ -186,6 +194,7 @@ class Repl:
                     await writer.drain()
 
         except Exception as e:
+            logger.error(f"Error: {e}")
             print(f"Error: {e}", flush=True)
         finally:
             writer.close()
@@ -197,6 +206,7 @@ class Repl:
             await self.server.serve_forever()
 
     async def stop(self):
+        logger.info("stop the REPL")
         if self.server:
             self.server.close()
             await self.server.wait_closed()

--- a/implementations/python/python/ockam/flows/flow.py
+++ b/implementations/python/python/ockam/flows/flow.py
@@ -12,7 +12,8 @@ from ..nodes.message import (
     FlowReference,
     Reference,
     AssistantMessage,
-    UserMessage, StreamedConversationSnippet,
+    UserMessage,
+    StreamedConversationSnippet,
 )
 
 from ..ockam_in_rust_for_python import info, debug

--- a/implementations/python/python/ockam/logging/__init__.py
+++ b/implementations/python/python/ockam/logging/__init__.py
@@ -1,0 +1,13 @@
+from .logging import LOGGING_CONFIG, info, debug, error, warning, set_log_level
+from .colored_formatter import OckamColoredFormatter
+
+__all__ = [
+    "LOGGING_CONFIG",
+    "OckamColoredFormatter",
+    "info",
+    "debug",
+    "warning",
+    "debug",
+    "error",
+    "set_log_level",
+]

--- a/implementations/python/python/ockam/logging/colored_formatter.py
+++ b/implementations/python/python/ockam/logging/colored_formatter.py
@@ -1,0 +1,12 @@
+import colorlog
+
+class OckamColoredFormatter(colorlog.ColoredFormatter):
+    GREY = "\033[90m"
+    CYAN = "\033[36m"
+    RESET = "\033[0m"
+
+    def formatMessage(self, record):
+        original_asctime = self.formatTime(record, self.datefmt)
+        record.asctime = f"{self.CYAN}{original_asctime}{self.RESET}"
+        record.name = f"{self.GREY}{record.name}{self.RESET}"
+        return super().formatMessage(record)

--- a/implementations/python/python/ockam/logging/colored_formatter.py
+++ b/implementations/python/python/ockam/logging/colored_formatter.py
@@ -1,12 +1,24 @@
 import colorlog
+from datetime import datetime
+
 
 class OckamColoredFormatter(colorlog.ColoredFormatter):
     GREY = "\033[90m"
     CYAN = "\033[36m"
     RESET = "\033[0m"
 
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("datefmt", "%Y-%m-%dT%H:%M:%S.%fZ")
+        super().__init__(*args, **kwargs)
+
+    def formatTime(self, record, datefmt=None):
+        dt = datetime.utcfromtimestamp(record.created)
+        if datefmt:
+            return dt.strftime(datefmt)
+        return super().formatTime(record, datefmt)
+
     def formatMessage(self, record):
         original_asctime = self.formatTime(record, self.datefmt)
-        record.asctime = f"{self.CYAN}{original_asctime}{self.RESET}"
+        record.asctime = f"{self.GREY}{original_asctime}{self.RESET}"
         record.name = f"{self.GREY}{record.name}{self.RESET}"
         return super().formatMessage(record)

--- a/implementations/python/python/ockam/logging/logging.py
+++ b/implementations/python/python/ockam/logging/logging.py
@@ -1,4 +1,4 @@
-from ..logging.colored_formatter import OckamColoredFormatter
+import logging.config
 
 LOGGING_CONFIG = {
     "version": 1,
@@ -6,7 +6,7 @@ LOGGING_CONFIG = {
     "formatters": {
         "default": {
             "()": "ockam.logging.colored_formatter.OckamColoredFormatter",
-            "format": "[%(asctime)s] %(log_color)s[%(levelname)s]%(reset)s %(name)s: %(message)s",
+            "format": "%(asctime)s %(log_color)s%(levelname)s%(reset)s %(name)s: %(message)s",
             "log_colors": {
                 "DEBUG": "cyan",
                 "INFO": "green",
@@ -18,7 +18,7 @@ LOGGING_CONFIG = {
     },
     "handlers": {
         "default": {
-            "level": "INFO",
+            "level": "DEBUG",
             "formatter": "default",
             "class": "logging.StreamHandler",
         },
@@ -27,9 +27,45 @@ LOGGING_CONFIG = {
         "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
         "uvicorn.error": {"handlers": ["default"], "level": "INFO", "propagate": False},
         "uvicorn.access": {"handlers": ["default"], "level": "INFO", "propagate": False},
-        "node": {"handlers": ["default"], "level": "INFO", "propagate": False},
         "http": {"handlers": ["default"], "level": "INFO", "propagate": False},
+        "httpx": {"handlers": ["default"], "level": "WARNING", "propagate": False},
+        "LiteLLM": {"handlers": ["default"], "level": "WARNING", "propagate": False},
+        "agent": {"handlers": ["default"], "level": "DEBUG", "propagate": False},
+        "node": {"handlers": ["default"], "level": "DEBUG", "propagate": False},
     },
     "root": {"level": "INFO", "handlers": ["default"]},
 }
 
+
+def info(msg, *args, **kwargs):
+    logger = logging.getLogger("node")
+    logger.info(msg, *args, **kwargs)
+
+
+def warning(msg, *args, **kwargs):
+    import logging.config
+
+    logger = logging.getLogger("node")
+    logger.warning(msg, *args, **kwargs)
+
+
+def debug(msg, *args, **kwargs):
+    import logging.config
+
+    logger = logging.getLogger("node")
+    logger.debug(msg, *args, **kwargs)
+
+
+def error(msg, *args, **kwargs):
+    import logging.config
+
+    logger = logging.getLogger("node")
+    logger.error(msg, *args, **kwargs)
+
+
+def set_log_level(logger_name, level):
+    if logger_name in LOGGING_CONFIG["loggers"]:
+        LOGGING_CONFIG["loggers"][logger_name]["level"] = level
+        import logging.config
+
+        logging.config.dictConfig(LOGGING_CONFIG)

--- a/implementations/python/python/ockam/logging/logging.py
+++ b/implementations/python/python/ockam/logging/logging.py
@@ -1,0 +1,35 @@
+from ..logging.colored_formatter import OckamColoredFormatter
+
+LOGGING_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "default": {
+            "()": "ockam.logging.colored_formatter.OckamColoredFormatter",
+            "format": "[%(asctime)s] %(log_color)s[%(levelname)s]%(reset)s %(name)s: %(message)s",
+            "log_colors": {
+                "DEBUG": "cyan",
+                "INFO": "green",
+                "WARNING": "yellow",
+                "ERROR": "red",
+                "CRITICAL": "bold_red",
+            },
+        },
+    },
+    "handlers": {
+        "default": {
+            "level": "INFO",
+            "formatter": "default",
+            "class": "logging.StreamHandler",
+        },
+    },
+    "loggers": {
+        "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
+        "uvicorn.error": {"handlers": ["default"], "level": "INFO", "propagate": False},
+        "uvicorn.access": {"handlers": ["default"], "level": "INFO", "propagate": False},
+        "node": {"handlers": ["default"], "level": "INFO", "propagate": False},
+        "http": {"handlers": ["default"], "level": "INFO", "propagate": False},
+    },
+    "root": {"level": "INFO", "handlers": ["default"]},
+}
+

--- a/implementations/python/python/ockam/nodes/node.py
+++ b/implementations/python/python/ockam/nodes/node.py
@@ -7,8 +7,14 @@ from typing import Awaitable, Callable, Optional
 from .local import LocalNode
 from .manager import RemoteManager
 
-from ..ockam_in_rust_for_python import Node as RustNode, info
+from ..ockam_in_rust_for_python import Node as RustNode, debug
 from ..nodes.protocol import LocalNodeProtocol
+
+from ..logging.logging import LOGGING_CONFIG
+import logging.config
+
+logging.config.dictConfig(LOGGING_CONFIG)
+logger = logging.getLogger("node")
 
 
 class Node:
@@ -23,6 +29,7 @@ class Node:
         cache_secure_channels: bool = False,
         use_local_db: bool = False,
         llm_debug: bool = False,
+        ockam_log_level: str = "WARN",
         **kwargs,
     ):
         # This will make the node use a local SQLite database instead of the Postgres database
@@ -33,14 +40,14 @@ class Node:
             os.environ["OCKAM_TELEMETRY_EXPORT"] = "false"
             os.environ["OCKAM_SQLITE_IN_MEMORY"] = "true"
 
+        os.environ["OCKAM_LOG_LEVEL"] = ockam_log_level
+
         if llm_debug:
             litellm._turn_on_debug()
 
         name = pick_name(name)
         ticket = pick_ticket(ticket)
         cluster = pick_cluster()
-
-        info(f"Starting node {name}")
 
         if allow is None and cluster:
             allow = f"message.is_local or cluster={cluster}"
@@ -65,8 +72,9 @@ class Node:
             RustNode.start(
                 start_node, name=name, ticket=ticket, allow=allow, cache_secure_channels=cache_secure_channels, **kwargs
             )
+
         except KeyboardInterrupt:
-            info(f"\nNode {name} shutting down")
+            debug(f"\nNode {name} shutting down")
 
 
 def wait_until_interrupted_decorator(func=None):

--- a/implementations/python/python/ockam/nodes/node.py
+++ b/implementations/python/python/ockam/nodes/node.py
@@ -13,9 +13,6 @@ from ..nodes.protocol import LocalNodeProtocol
 from ..logging.logging import LOGGING_CONFIG
 import logging.config
 
-logging.config.dictConfig(LOGGING_CONFIG)
-logger = logging.getLogger("node")
-
 
 class Node:
     @staticmethod
@@ -32,6 +29,9 @@ class Node:
         ockam_log_level: str = "WARN",
         **kwargs,
     ):
+        logging.config.dictConfig(LOGGING_CONFIG)
+        logger = logging.getLogger("node")
+
         # This will make the node use a local SQLite database instead of the Postgres database
         if use_local_db:
             os.environ.pop("OCKAM_DATABASE_INSTANCE", None)
@@ -69,11 +69,12 @@ class Node:
             await main(node)
 
         try:
+            logger.info("starting node")
             RustNode.start(
                 start_node, name=name, ticket=ticket, allow=allow, cache_secure_channels=cache_secure_channels, **kwargs
             )
-
         except KeyboardInterrupt:
+            logger.debug("shutting down node due to KeyboardInterrupt")
             debug(f"\nNode {name} shutting down")
 
 

--- a/implementations/python/src/nodes/logging.rs
+++ b/implementations/python/src/nodes/logging.rs
@@ -1,0 +1,32 @@
+#![allow(dead_code)]
+
+use pyo3::prelude::{PyAnyMethods, PyModule};
+use pyo3::{PyResult, Python};
+
+/// Log an INFO message using Python's logging
+pub fn py_info(py: Python, msg: impl ToString) -> PyResult<()> {
+    py_log(py, "info", msg)
+}
+
+/// Log a WARNING message using Python's logging
+pub fn py_warning(py: Python, msg: impl ToString) -> PyResult<()> {
+    py_log(py, "warning", msg)
+}
+
+/// Log an ERROR message using Python's logging
+pub fn py_error(py: Python, msg: impl ToString) -> PyResult<()> {
+    py_log(py, "error", msg)
+}
+
+/// Log a DEBUG message using Python's logging
+pub fn py_debug(py: Python, msg: impl ToString) -> PyResult<()> {
+    py_log(py, "debug", msg)
+}
+
+/// Log a message using Python's logging
+fn py_log(py: Python, level: &str, msg: impl ToString) -> PyResult<()> {
+    let logging = PyModule::import(py, "logging")?;
+    let logger = logging.call_method1("getLogger", ("node",))?;
+    logger.call_method1(level, (msg.to_string(),))?;
+    Ok(())
+}

--- a/implementations/python/src/nodes/mod.rs
+++ b/implementations/python/src/nodes/mod.rs
@@ -13,5 +13,7 @@ use worker::*;
 mod started_agents;
 use started_agents::*;
 
+mod logging;
 mod started_workers;
+
 use started_workers::*;

--- a/implementations/python/src/nodes/node.rs
+++ b/implementations/python/src/nodes/node.rs
@@ -32,6 +32,7 @@ use pyo3_async_runtimes::tokio::future_into_py;
 
 use miette::{IntoDiagnostic, miette};
 
+use crate::nodes::logging::py_debug;
 use crate::nodes::runtime::PythonAsyncExecutor;
 use ockam::access_control::AllowAll;
 use serde::Serialize;
@@ -748,6 +749,8 @@ impl PyNode {
         exposed_as: Option<String>,
     ) -> PyResult<Bound<'a, PyAny>> {
         let name = name.to_string();
+        py_debug(py, format!("starting worker '{name}'"))?;
+
         let address: Address = name.clone().into();
         if let Some(api_sc_listener) = self.node_manager.api_sc_listener() {
             self.ctx()

--- a/implementations/python/src/nodes/node.rs
+++ b/implementations/python/src/nodes/node.rs
@@ -146,7 +146,9 @@ impl PyNode {
         let _ = pyo3_async_runtimes::tokio::init_with_runtime(get_runtime_ref());
 
         let node = get_runtime().block_on(async move {
-            let node_builder = NodeBuilder::new().with_runtime(get_runtime());
+            let node_builder = NodeBuilder::new()
+                .with_runtime(get_runtime())
+                .with_logging(false);
             let (ctx, executor) = node_builder.build();
 
             let node = if let Some(ticket) = ticket {

--- a/implementations/python/src/nodes/spawner.rs
+++ b/implementations/python/src/nodes/spawner.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use crate::errors::ockam_error;
 use crate::nodes::started_agents::StartedAgents;
 
+use crate::nodes::logging::py_debug;
 use ockam::access_control::{AllowAll, IncomingAccessControl, OutgoingAccessControl};
 use ockam::{Address, Context, ContextRouter, Result, Routed, Worker, WorkerBuilder, route};
 use pyo3::{PyObject, Python};
@@ -94,12 +95,20 @@ impl Spawner {
 
     async fn create_worker(&self, ctx: &mut Context) -> ockam::Result<Address> {
         let address = Address::random_tagged(&self.agent_name);
+        let agent_name = self.agent_name.clone();
 
         let worker_constructor = self.worker_constructor.clone();
         let worker = ctx
             .runtime()
             .spawn_blocking(move || {
-                Python::with_gil(|py| worker_constructor.call0(py)).map_err(ockam_error)
+                Python::with_gil(|py| {
+                    py_debug(
+                        py,
+                        format!("create a new worker for agent '{}'", agent_name),
+                    )?;
+                    worker_constructor.call0(py)
+                })
+                .map_err(ockam_error)
             })
             .await
             .unwrap()?;

--- a/implementations/python/tests/agent_test.py
+++ b/implementations/python/tests/agent_test.py
@@ -41,12 +41,10 @@ async def main_agent(node):
         """),
         model=Model(name="ollama_chat/llama3.2"),
     )
-    evaluation = await evaluator.send(
-        "Article:\n" + reply[0].content +
-        "\n\n\nQuestion: Is this article about Gandhi?"
-    )
+    evaluation = await evaluator.send("Article:\n" + reply[0].content + "\n\n\nQuestion: Is this article about Gandhi?")
     converter = MessageConverter(node)
-    assert {"role": "assistant", "content": "YES", 'tool_calls': []} == converter.message_to_dict(evaluation[0])
+    assert {"role": "assistant", "content": "YES", "tool_calls": []} == converter.message_to_dict(evaluation[0])
+
 
 # def test_agent_can_call_agents_via_mcp():
 #     Node.start(
@@ -58,6 +56,7 @@ async def main_agent(node):
 #         wait_until_interrupted=False,
 #         http_server=HttpServer(listen_address="127.0.0.1:0")
 #     )
+
 
 async def main_agent_can_call_agents_via_mcp(node):
     await Agent.start(
@@ -78,6 +77,7 @@ async def main_agent_can_call_agents_via_mcp(node):
 
     reply = await agent.send("Give me a random number")
     assert "163728" in reply[0].content
+
 
 # def test_agent_can_call_tools():
 #     Node.start(main_agent_can_call_tools, wait_until_interrupted=False, http_server=HttpServer(listen_address="127.0.0.1:0"))

--- a/implementations/python/uv.lock
+++ b/implementations/python/uv.lock
@@ -269,6 +269,18 @@ wheels = [
 ]
 
 [[package]]
+name = "colorlog"
+version = "6.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/7a/359f4d5df2353f26172b3cc39ea32daa39af8de522205f512f458923e677/colorlog-6.9.0.tar.gz", hash = "sha256:bfba54a1b93b94f54e1f4fe48395725a3d92fd2a4af702f6bd70946bdc0c6ac2", size = 16624 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/51/9b208e85196941db2f0654ad0357ca6388ab3ed67efdbfc799f35d1f83aa/colorlog-6.9.0-py3-none-any.whl", hash = "sha256:5906e71acd67cb07a71e779c47c4bcb45fb8c2993eebe9e5adcd6a6f1b283eff", size = 11424 },
+]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -899,6 +911,7 @@ dependencies = [
     { name = "attrs" },
     { name = "boto3" },
     { name = "cattrs" },
+    { name = "colorlog" },
     { name = "dill" },
     { name = "docstring-parser" },
     { name = "fastapi" },
@@ -930,6 +943,7 @@ requires-dist = [
     { name = "attrs", specifier = ">=25.3.0" },
     { name = "boto3", specifier = ">=1.38.8" },
     { name = "cattrs", specifier = ">=24.1.3" },
+    { name = "colorlog", specifier = ">=6.9" },
     { name = "dill", specifier = ">=0.4.0" },
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", specifier = ">=0.103.1" },


### PR DESCRIPTION
This PR:

 - Adds a Python logging configuration for various parts of the Python library:
   - The Node
   - The Agent
   - The default user code
   - The HTTP server
 - The `info`, `debug`, `warning`, `error` functions now delegate to the Python logging instead of Ockam's one.
 - Coloring and a formatting of the log output is customized to look like Ockam's internal logging
 - By default the Ockam logging is restricted to warnings and errors to avoid low-level log messages that a user cannot understand.
 - Some examples have been fixed and retrofitted to use logs instead of prints (now that `info` etc... work out of the box).
 
 There is obviously more work to do, but we can start iterating on this.