### PR TITLE
feat: restrict the names of agent, workers and flows

### DIFF
--- a/examples/009/images/main/main.py
+++ b/examples/009/images/main/main.py
@@ -6,7 +6,7 @@ from sys import argv
 async def main(node):
     triage = await Agent.start(
         node=node,
-        name="Security Task Triage",
+        name="security-task-triage",
         instructions="""
         You are an information security triage agent.
 
@@ -46,7 +46,7 @@ async def main(node):
 
     network_expert = await Agent.start(
         node=node,
-        name="Network Security Expert",
+        name="network-security-expert",
         instructions="""
             You are a network security expert.
             Answer network security questions.
@@ -55,7 +55,7 @@ async def main(node):
 
     code_security_fixer = await Agent.start(
         node=node,
-        name="Code Security Fixer",
+        name="code-security-fixer",
         instructions="""
             You are a codding expert who knows the Python programming language.
 
@@ -70,7 +70,7 @@ async def main(node):
 
     code_evaluator = await Agent.start(
         node=node,
-        name="Code Evaluator",
+        name="code-evaluator",
         instructions="""
             Your goal is to check if a python code snippet has any commonly made
             security mistakes or not.
@@ -185,7 +185,7 @@ async def main(node):
 
     bouncer = await Agent.start(
         node=node,
-        name="Polite Bouncer",
+        name="polite-bouncer",
         instructions="""
             You MUST politely reject the user question explaining that only
             security or networking questions can be asked. Be terse and concise.

--- a/implementations/python/examples/00.py
+++ b/implementations/python/examples/00.py
@@ -4,7 +4,7 @@ from ockam import Agent, Flow, Node, START, END, TRY_AGAIN
 async def main(node):
     triage = await Agent.start(
         node=node,
-        name="Language Triage",
+        name="language-triage",
         instructions="""
             You are a language triage agent.
 
@@ -19,25 +19,25 @@ async def main(node):
 
     english_support = await Agent.start(
         node=node,
-        name="English assistant",
+        name="english-assistant",
         instructions="You are an assistant who answers questions in English.",
     )
 
     french_support = await Agent.start(
         node=node,
-        name="French assistant",
+        name="french-assistant",
         instructions="You are an assistant who answers questions in French.",
     )
 
     spanish_support = await Agent.start(
         node=node,
-        name="Spanish assistant",
+        name="spanish-assistant",
         instructions="You are an assistant who answers questions in Spanish.",
     )
 
     hindi_support = await Agent.start(
         node=node,
-        name="Hindi assistant",
+        name="hindi-assistant",
         instructions="""
             You are an assistant who answers questions in Hindi.
             You respond in hindi written in the latin alphabet.
@@ -46,7 +46,7 @@ async def main(node):
 
     english_quality_check = await Agent.start(
         node=node,
-        name="English quality check",
+        name="english-quality-check",
         instructions=f"""
             You are an English quality check agent.
 
@@ -61,7 +61,7 @@ async def main(node):
 
     french_quality_check = await Agent.start(
         node=node,
-        name="French quality check",
+        name="french-quality-check",
         instructions=f"""
             You are a French quality check agent.
 
@@ -76,7 +76,7 @@ async def main(node):
 
     spanish_quality_check = await Agent.start(
         node=node,
-        name="Spanish quality check",
+        name="spanish-quality-check",
         instructions=f"""
             You are a Spanish quality check agent.
 
@@ -91,7 +91,7 @@ async def main(node):
 
     hindi_quality_check = await Agent.start(
         node=node,
-        name="Hindi quality check",
+        name="hindi-quality-check",
         instructions=f"""
             You are a Hindi quality check agent.
 

--- a/implementations/python/examples/000.py
+++ b/implementations/python/examples/000.py
@@ -4,7 +4,7 @@ from ockam import Agent, Flow, Node, START, END, Repl, FlowOperation
 async def main(node):
     triage = await Agent.start(
         node=node,
-        name="Security Task Triage",
+        name="security-task-triage",
         instructions="""
 You are an information security agent.
 
@@ -40,13 +40,13 @@ Examples:
 
     network_expert = await Agent.start(
         node=node,
-        name="Network Security Expert",
+        name="network-security-expert",
         instructions="You are a network security expert. Answer network security questions.",
     )
 
     code_security_expert = await Agent.start(
         node=node,
-        name="Code Security Expert",
+        name="code-security-expert",
         instructions="""
 You are a codding expert who knows the Python programming language.
 
@@ -57,7 +57,7 @@ Only print the fixed code snippet. Under no circumstances print anything else ex
 
     code_evaluator = await Agent.start(
         node=node,
-        name="Code Evaluator",
+        name="code-evaluator",
         instructions="""
 Your goal is to figure out if a python code snippet has any vulnerabilities.
 

--- a/implementations/python/examples/01.py
+++ b/implementations/python/examples/01.py
@@ -1,4 +1,4 @@
-from ockam import Node, info, LOGGING_CONFIG, set_log_level
+from ockam import Node, info, set_log_level
 
 set_log_level("node", "DEBUG")
 

--- a/implementations/python/examples/05.py
+++ b/implementations/python/examples/05.py
@@ -14,7 +14,7 @@ from ockam import Agent, Model, Node, info
 async def main(node):
     agent = await Agent.start(
         node=node,
-        name="History Teacher",
+        name="history-teacher",
         instructions="You are an assistant who is an expert in history.",
         model=Model(name="ollama_chat/llama3.2"),
     )

--- a/implementations/python/python/ockam/agents/__init__.py
+++ b/implementations/python/python/ockam/agents/__init__.py
@@ -1,4 +1,5 @@
 from .agent import Agent
+from .names import validate_name
 from .conversation_response import ConversationResponse
 from .repl import Repl
 from ..nodes.message import AgentReference
@@ -10,4 +11,5 @@ __all__ = [
     "ConversationResponse",
     "HttpServer",
     "Repl",
+    "validate_name",
 ]

--- a/implementations/python/python/ockam/agents/agent.py
+++ b/implementations/python/python/ockam/agents/agent.py
@@ -2,7 +2,6 @@ import json
 import traceback
 from typing import Optional, AsyncGenerator
 
-import regex as re
 import secrets
 
 from ..nodes import RemoteNode, LocalNodeProtocol
@@ -29,6 +28,7 @@ from ..nodes.message import (
     UserMessage,
     Phase,
 )
+from .names import validate_name
 
 from ..ockam_in_rust_for_python import info, warn, debug
 from ..planning.protocol import STEP_BY_STEP_EXECUTION
@@ -360,8 +360,8 @@ class Agent:
         if name is None:
             name = secrets.token_hex(12)
 
-        if exposed_as is not None and re.match(r"^[a-z0-9_-]+$", name) is None:
-            raise ValueError("Agent name may only contain [a-z0-9_-] when exposed")
+        if exposed_as is not None:
+            validate_name(name)
 
         if isinstance(node, LocalNodeProtocol):
             await Agent.start_agent_impl(

--- a/implementations/python/python/ockam/agents/agent.py
+++ b/implementations/python/python/ockam/agents/agent.py
@@ -25,7 +25,6 @@ from ..nodes.message import (
     ToolCall,
     GetConversationsRequest,
     GetConversationsResponse,
-    UserMessage,
     Phase,
 )
 from .names import validate_name
@@ -360,8 +359,7 @@ class Agent:
         if name is None:
             name = secrets.token_hex(12)
 
-        if exposed_as is not None:
-            validate_name(name)
+        validate_name(name)
 
         if isinstance(node, LocalNodeProtocol):
             await Agent.start_agent_impl(

--- a/implementations/python/python/ockam/agents/agent_test.py
+++ b/implementations/python/python/ockam/agents/agent_test.py
@@ -1,0 +1,8 @@
+import pytest
+
+from .agent import Agent
+
+
+async def test_agent_name():
+    with pytest.raises(ValueError):
+        await Agent.start(name="!123-abc~", exposed_as="henry", node=None, instructions=None)

--- a/implementations/python/python/ockam/agents/conversation_response.py
+++ b/implementations/python/python/ockam/agents/conversation_response.py
@@ -19,6 +19,4 @@ class ConversationResponse:
 
     def make_finished_snippet(self):
         self.counter += 1
-        return StreamedConversationSnippet(
-            ConversationSnippet(self.scope, self.conversation, []), self.counter, True
-        )
+        return StreamedConversationSnippet(ConversationSnippet(self.scope, self.conversation, []), self.counter, True)

--- a/implementations/python/python/ockam/agents/http.py
+++ b/implementations/python/python/ockam/agents/http.py
@@ -10,8 +10,7 @@ from fastapi import FastAPI, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse, FileResponse
 
 from ..agents import AgentReference
-from ..nodes.message import GetConversationsRequest, ConversationMessage, AssistantMessage, StreamedConversationSnippet
-from ..ockam_in_rust_for_python import info, error
+from ..nodes.message import GetConversationsRequest, StreamedConversationSnippet
 
 logger = logging.getLogger("http")
 

--- a/implementations/python/python/ockam/agents/names.py
+++ b/implementations/python/python/ockam/agents/names.py
@@ -1,0 +1,9 @@
+import re
+
+
+def validate_name(name: str):
+    """
+    Raises ValueError if `name` contains characters other than a-z, A-Z, 0-9, -, or _.
+    """
+    if not re.fullmatch(r"[a-zA-Z0-9_-]+", name):
+        raise ValueError(f"Invalid name '{name}'. Only alphanumeric characters, '-' and '_' are allowed.")

--- a/implementations/python/python/ockam/flows/flow.py
+++ b/implementations/python/python/ockam/flows/flow.py
@@ -1,7 +1,9 @@
 import secrets
+import re
 
 from .operation import FlowOperation, END
 from .flow_state import FlowState, FlowEdge, vertex_to_id
+from ..agents import validate_name
 from ..nodes import LocalNodeProtocol
 from ..nodes.message import (
     ConversationSnippet,
@@ -23,6 +25,8 @@ class Flow:
     def __init__(self, name=None, iteration_timeout=120, iteration_limit=20):
         if name is None:
             name = secrets.token_hex(12)
+        else:
+            validate_name(name)
 
         self.name = name
         self.iteration_timeout = iteration_timeout

--- a/implementations/python/python/ockam/flows/flow.py
+++ b/implementations/python/python/ockam/flows/flow.py
@@ -1,5 +1,4 @@
 import secrets
-import re
 
 from .operation import FlowOperation, END
 from .flow_state import FlowState, FlowEdge, vertex_to_id

--- a/implementations/python/python/ockam/flows/flow_test.py
+++ b/implementations/python/python/ockam/flows/flow_test.py
@@ -1,0 +1,11 @@
+import pytest
+from .flow import Flow
+
+
+def test_flow_name():
+    # this must not raise an exception
+    Flow(name="123-abc")
+
+    # but this should
+    with pytest.raises(ValueError):
+        Flow(name="!123-abc~")

--- a/implementations/python/python/ockam/nodes/local.py
+++ b/implementations/python/python/ockam/nodes/local.py
@@ -47,6 +47,9 @@ class LocalNode(LocalNodeProtocol):
     async def start_worker(
         self, name: str, worker: WorkerProtocol, policy: Optional[str] = None, exposed_as: Optional[str] = None
     ):
+        from ..agents import validate_name
+
+        validate_name(name)
         return await self.rust_node.start_worker(name, worker, policy, exposed_as)
 
     async def start_internal_worker(

--- a/implementations/python/python/ockam/nodes/node.py
+++ b/implementations/python/python/ockam/nodes/node.py
@@ -8,7 +8,6 @@ from .local import LocalNode
 from .manager import RemoteManager
 
 from ..ockam_in_rust_for_python import Node as RustNode, debug
-from ..nodes.protocol import LocalNodeProtocol
 
 from ..logging.logging import LOGGING_CONFIG
 import logging.config

--- a/implementations/python/python/ockam/nodes/node_protocol_test.py
+++ b/implementations/python/python/ockam/nodes/node_protocol_test.py
@@ -1,0 +1,27 @@
+import pytest
+from .local import LocalNode
+from .remote import RemoteNode
+
+
+async def test_local_worker_name():
+    node = LocalNode(None)
+    # this must not raise a ValueError exception
+    # the attribute error corresponds to the None worker
+    with pytest.raises(AttributeError):
+        await node.start_worker(name="123-abc", worker=None)
+
+    # but this should
+    with pytest.raises(ValueError):
+        await node.start_worker(name="!123-abc~", worker=None)
+
+
+async def test_remote_worker_name():
+    node = RemoteNode(LocalNode(None), "remote")
+    # this must not raise a ValueError exception
+    # the attribute error corresponds to the None worker
+    with pytest.raises(AttributeError):
+        await node.start_worker(name="123-abc", worker=None)
+
+    # but this should
+    with pytest.raises(ValueError):
+        await node.start_worker(name="!123-abc~", worker=None)

--- a/implementations/python/python/ockam/nodes/remote.py
+++ b/implementations/python/python/ockam/nodes/remote.py
@@ -32,6 +32,9 @@ class RemoteNode(NodeProtocol):
         return await client.identifier()
 
     async def start_worker(self, name: str, worker: WorkerProtocol, policy: Optional[str] = None, exposed_as=None):
+        from ..agents import validate_name
+
+        validate_name(name)
         client = RemoteManagerClient(self)
         await client.start_worker(name, worker, policy, exposed_as)
 

--- a/implementations/python/python/ockam/planning/cot.py
+++ b/implementations/python/python/ockam/planning/cot.py
@@ -2,8 +2,8 @@ from typing import Optional, AsyncGenerator
 
 from ockam.nodes.message import UserMessage
 
-from .protocol import Planner, Plan, STEP_BY_STEP_EXECUTION
-from ..nodes.message import ConversationMessage, SystemMessage, AssistantMessage
+from .protocol import Planner, Plan
+from ..nodes.message import ConversationMessage, SystemMessage
 from ..models import Model
 
 

--- a/implementations/python/python/ockam/planning/dynamic.py
+++ b/implementations/python/python/ockam/planning/dynamic.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, AsyncGenerator
+from typing import Optional, AsyncGenerator
 from .protocol import Planner, Plan
 from ..nodes.message import ConversationMessage, SystemMessage, UserMessage
 from ..models import Model

--- a/implementations/python/python/ockam/planning/react.py
+++ b/implementations/python/python/ockam/planning/react.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, AsyncGenerator
+from typing import Optional, AsyncGenerator
 
 from .protocol import Planner, Plan
 from ..nodes.message import SystemMessage, ConversationMessage, UserMessage, ConversationRole

--- a/implementations/python/tests/agent_test.py
+++ b/implementations/python/tests/agent_test.py
@@ -24,14 +24,14 @@ async def main_simple_node(node):
 async def main_agent(node):
     agent = await Agent.start(
         node=node,
-        name="History Teacher",
+        name="history-teacher",
         instructions="You are an assistant who is an expert in history.",
         model=Model(name="ollama_chat/llama3.2"),
     )
     reply = await agent.send("Who was Gandhi?")
     evaluator = await Agent.start(
         node=node,
-        name="History Article Evaluator",
+        name="history-article-evaluator",
         instructions=textwrap.dedent("""You are an assistant who is an expert at history.
 
         You will be given an article and a question about the article,


### PR DESCRIPTION
The names are now limited to "a-zA-z0-9-_". This makes it easier to use those names in HTTP query when needed.
