### PR TITLE
feat: more logging for agents

### DIFF
--- a/examples/006/images/main/main.py
+++ b/examples/006/images/main/main.py
@@ -1,4 +1,8 @@
-from datetime import datetime
+from datetime import datetime, UTC
+from ockam import set_log_levels
+
+set_log_levels("agent=debug,ockam_node=info,ockam=info")
+
 from ockam import Agent, Model, Node, Tool
 
 
@@ -6,7 +10,7 @@ def current_iso8601_utc_time():
     """
     Returns the current UTC time in ISO 8601 format.
     """
-    return datetime.utcnow().isoformat() + "Z"
+    return datetime.now(UTC).isoformat() + "Z"
 
 
 async def main(node):

--- a/implementations/python/examples/05.py
+++ b/implementations/python/examples/05.py
@@ -19,7 +19,8 @@ async def main(node):
         model=Model(name="ollama_chat/llama3.2"),
     )
     identifier = await agent.identifier()
-    info(identifier)
+    info(f"the agent identifier is {identifier}")
+
     reply = await agent.send("Who was Gandhi?")
     info(reply)
 

--- a/implementations/python/python/ockam/__init__.py
+++ b/implementations/python/python/ockam/__init__.py
@@ -3,7 +3,7 @@ from .clusters import Cluster, Zone
 from .flows import Flow, FlowOperation, START, END
 from .nodes.message import FlowReference
 from .memory import Memory
-from .logging import get_logging_config, info, warning, error, debug, set_log_level
+from .logging import info, warning, error, debug, set_log_levels, get_logger
 from .models import Model
 from .nodes import Node, RemoteNode, LocalNode, LocalNodeProtocol, MailboxProtocol, WorkerProtocol, ContextProtocol
 from .nodes.manager import RemoteManager
@@ -46,12 +46,12 @@ __all__ = [
     "START",
     "END",
     # from .logging
-    "get_logging_config",
+    "get_logger",
     "info",
     "warning",
     "error",
     "debug",
-    "set_log_level",
+    "set_log_levels",
     # from .ockam_in_rust_for_python
     "Mailbox",
     "McpClient",

--- a/implementations/python/python/ockam/agents/agent.py
+++ b/implementations/python/python/ockam/agents/agent.py
@@ -32,13 +32,7 @@ from ..nodes.message import (
 )
 from .names import validate_name
 
-from ..ockam_in_rust_for_python import info, warn, debug
-
-from ..logging.logging import get_logging_config
-import logging.config
-
-logging.config.dictConfig(get_logging_config())
-logger = logging.getLogger("agent")
+from ..ockam_in_rust_for_python import warn
 
 
 class AgentState(Enum):
@@ -258,7 +252,18 @@ class AgentStateMachine:
 
 
 class Agent:
+    _logger = None
     tools: Dict[str, InvokableTool]
+
+    @classmethod
+    def logger(cls):
+        if cls._logger:
+            return cls._logger
+        else:
+            from ..logging.logging import get_logger
+
+            cls._logger = get_logger("agent")
+            return cls._logger
 
     def __init__(
         self,
@@ -273,7 +278,8 @@ class Agent:
         knowledge: KnowledgeProvider,
         max_knowledge_size: int,
     ):
-        logger.info("starting agent")
+        self.logger = Agent.logger()
+        self.logger.info(f"start agent '{name}'")
         self.node = node
 
         self.tools = tools
@@ -296,8 +302,7 @@ class Agent:
 
     async def handle_message(self, context, message):
         try:
-            logger.info("received a message")
-            logger.debug(f"the message is {message}")
+            self.logger.debug(f"agent '{self.name}' received: {message}")
 
             message = self.converter.message_from_json(message)
             handlers = {
@@ -316,7 +321,7 @@ class Agent:
                 if handler is not None:
                     reply = await handler(message)
                 else:
-                    logger.error(f"unexpected message: {message}")
+                    self.logger.error(f"unexpected message: {message}")
                     reply = Error(f"Unexpected Message: {message}")
 
                 if reply is not None:
@@ -479,7 +484,7 @@ class Agent:
                 role = delta.role
 
             if choice.finish_reason is not None:
-                debug(f"finished streaming reply with reason {choice.get('finish_reason', 'unknown')}")
+                self.logger.debug(f"finished streaming reply with reason {choice.get('finish_reason', 'unknown')}")
                 finished = True
                 response = {"role": role}
             else:
@@ -522,7 +527,7 @@ class Agent:
         node: NodeProtocol,
         instructions: str,
         name: Optional[str] = None,
-        model: Model = Model(name="llama3.2"),
+        model: Model = None,
         tools: Optional[List[InvokableTool]] = None,
         planner: Planner = None,
         exposed_as: Optional[str] = None,
@@ -534,6 +539,9 @@ class Agent:
 
         validate_name(name)
 
+        if model is None:
+            model = Model(name="llama3.2")
+
         match node:
             case node if isinstance(node, LocalNodeProtocol):
                 await Agent.start_agent_impl(
@@ -543,7 +551,7 @@ class Agent:
                 await node.start_agent(
                     instructions, name, model, tools, planner, exposed_as, knowledge, max_knowledge_size
                 )
-                info(f"Successfully started agent {name} on a remote node")
+                Agent.logger().info(f"Successfully started agent {name} on a remote node")
             case _:
                 raise ValueError("Node must be either a LocalNodeProtocol or a RemoteNode")
 
@@ -558,12 +566,15 @@ class Agent:
         node: NodeProtocol,
         instructions: str,
         number_of_agents: int,
-        model: Model = Model(name="llama3.2"),
+        model: Model = None,
         tools: Optional[list] = None,
         planner=None,
         knowledge: Optional[KnowledgeProvider] = None,
         max_knowledge_size: int = 4096,
     ):
+        if model is None:
+            model = Model(name="llama3.2")
+
         agents = []
 
         match node:
@@ -582,7 +593,7 @@ class Agent:
                 for name in names:
                     agents.append(AgentReference(name, node))
 
-                info("Successfully started agents on a remote node")
+                Agent.logger().info("Successfully started agents on a remote node")
             case _:
                 raise ValueError("Node must be either a LocalNodeProtocol or a RemoteNode")
 
@@ -609,11 +620,9 @@ class Agent:
                 node, name, instructions, model, tools_specs, tools, planner, memory, knowledge, max_knowledge_size
             )
 
-        info(f"Starting agent {name}")
-
         await node.start_spawner(name, agent_creator, key_extractor, None, exposed_as)
 
-        info(f"Successfully started agent {name}")
+        Agent.logger().debug(f"successfully started agent {name}")
 
 
 def key_extractor(message):

--- a/implementations/python/python/ockam/agents/http.py
+++ b/implementations/python/python/ockam/agents/http.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import os
-import logging
 import uvicorn
 
 from dataclasses import asdict, is_dataclass
@@ -13,7 +12,6 @@ from .socket_address import parse_host_and_port
 from ..agents import AgentReference
 from ..nodes.message import GetConversationsRequest, StreamedConversationSnippet, Phase
 
-logger = logging.getLogger("http")
 
 """
     This class starts an HTTP server allowing a user to interact with a node and its agents.
@@ -24,7 +22,20 @@ DEFAULT_PORT = int(os.environ.get("DEFAULT_PORT_HTTP", "8000"))
 
 
 class HttpServer:
+    _logger = None
+
+    @classmethod
+    def logger(cls):
+        if cls._logger:
+            return cls._logger
+        else:
+            from ..logging.logging import get_logger
+
+            cls._logger = get_logger("http")
+            return cls._logger
+
     def __init__(self, listen_address=f"{DEFAULT_HOST}:{DEFAULT_PORT}", log_level: str = "error", api=None):
+        self.logger = HttpServer.logger()
         self.node = None
         self.host = DEFAULT_HOST
         self.port = DEFAULT_PORT
@@ -45,34 +56,34 @@ class HttpServer:
 
         @self.app.get("/agents")
         async def get_agents(node=Depends(self.get_node)):
-            logger.info("get agents")
+            self.logger.info("get agents")
             return {"agents": await node.list_agents()}
 
         @self.app.get("/workers")
         async def get_workers(node=Depends(self.get_node)):
-            logger.info("get workers")
+            self.logger.info("get workers")
             return {"workers": await node.list_workers()}
 
         @self.app.get("/agents/{name}")
         async def get_agent_by_name(name: str, node=Depends(self.get_node)):
-            logger.info(f"get agent by name: {name}")
+            self.logger.info(f"get agent by name: {name}")
             return await find_agent(node, name)
 
         @self.app.get("/agents/{name}/conversations")
         async def get_conversations_by_agent_name(name: str, node=Depends(self.get_node)):
-            logger.info(f"get conversations by agent name: {name}")
+            self.logger.info(f"get conversations by agent name: {name}")
             return await get_agent_by_name_and_scope_and_conversation_impl(name, None, None, node)
 
         @self.app.get("/agents/{name}/scopes/{scope}/conversations")
         async def get_conversations_by_agent_name_and_scope(name: str, scope: str, node=Depends(self.get_node)):
-            logger.info(f"get conversations by agent {name} and scope {scope}")
+            self.logger.info(f"get conversations by agent {name} and scope {scope}")
             return await get_agent_by_name_and_scope_and_conversation_impl(name, scope, None, node)
 
         @self.app.get("/agents/{name}/scopes/{scope}/conversations/{conversation}")
         async def get_agent_by_name_and_scope_and_conversation(
             name: str, scope: str, conversation: str, node=Depends(self.get_node)
         ):
-            logger.info(f"getting conversations by agent {name}, scope {scope} and conversation {conversation}")
+            self.logger.info(f"getting conversations by agent {name}, scope {scope} and conversation {conversation}")
             return await get_agent_by_name_and_scope_and_conversation_impl(name, scope, conversation, node)
 
         async def get_agent_by_name_and_scope_and_conversation_impl(
@@ -87,7 +98,7 @@ class HttpServer:
                 response = await agent.send_and_receive_request(query)
                 return response
             except Exception as e:
-                logger.error(f"Failed to get the conversations for agent '{name}': {e}")
+                self.logger.error(f"Failed to get the conversations for agent '{name}': {e}")
                 raise HTTPException(status_code=500, detail="Failed to get the conversations for agent '{name}'")
 
         @self.app.post("/agents/{name}")
@@ -99,7 +110,7 @@ class HttpServer:
             timeout: int = 60,
             node=Depends(self.get_node),
         ):
-            logger.info(f"send a message to agent '{name}'")
+            self.logger.info(f"send a message to agent '{name}'")
             await find_agent(node, name)
 
             try:
@@ -140,17 +151,17 @@ class HttpServer:
                 else:
                     return await agent.send(msg, scope, conversation, timeout=timeout)
             except Exception as e:
-                logger.error(f"failed to send message to agent '{name}': {e}")
+                self.logger.error(f"failed to send message to agent '{name}': {e}")
                 raise HTTPException(status_code=500, detail="Failed to send message")
 
         @self.app.get("/tools")
         async def get_tools(node=Depends(self.get_node)):
-            logger.info("get the exposed tools")
+            self.logger.info("get the exposed tools")
             return node.list_tools()
 
         @self.app.get("/tools/{name}")
         async def get_tool_by_name(name: str, node=Depends(self.get_node)):
-            logger.info(f"get tool by name: {name}")
+            self.logger.info(f"get tool by name: {name}")
             return find_tool(node, name)
 
         # mount the custom routes

--- a/implementations/python/python/ockam/agents/repl.py
+++ b/implementations/python/python/ockam/agents/repl.py
@@ -6,20 +6,28 @@ import os
 from ockam.nodes.message import StreamedConversationSnippet
 from ockam.agents.socket_address import parse_host_and_port
 
-from ..logging.logging import get_logging_config
-import logging.config
-
-logging.config.dictConfig(get_logging_config())
-logger = logging.getLogger("repl")
 
 DEFAULT_HOST = os.environ.get("DEFAULT_HOST_REPL", "127.0.0.1")
 DEFAULT_PORT = int(os.environ.get("DEFAULT_PORT_REPL", "7000"))
 
 
 class Repl:
+    _logger = None
+
+    @classmethod
+    def logger(cls):
+        if cls._logger:
+            return cls._logger
+        else:
+            from ..logging.logging import get_logger
+
+            cls._logger = get_logger("repl")
+            return cls._logger
+
     def __init__(
         self, agent_reference, listen_address=f"{DEFAULT_HOST}:{DEFAULT_PORT}", functions=None, timeout=120, stream=True
     ):
+        self.logger = Repl.logger()
         self.functions = functions or {}
         self.host = DEFAULT_HOST
         self.port = DEFAULT_PORT
@@ -47,7 +55,7 @@ class Repl:
     async def start(
         agent_reference, listen_address=f"{DEFAULT_HOST}:{DEFAULT_PORT}", functions=None, timeout=None, stream=True
     ):
-        logger.info("starting the REPL")
+        Repl.logger().info("starting the REPL")
         repl = Repl(agent_reference, listen_address, functions, timeout, stream)
         # start the repl in a separate thread since we might also have a HTTP server running
         asyncio.create_task(repl.start_impl())
@@ -61,7 +69,7 @@ class Repl:
             raise ValueError(f"Invalid listen_address: {listen_address}")
 
     async def list_functions(self, writer):
-        logger.debug("list functions")
+        self.logger.debug("list functions")
         functions_list = "\n".join([f"{name}" for name in self.functions.keys()])
         await self.write_repl_message(writer, functions_list)
 
@@ -196,7 +204,7 @@ class Repl:
                     await writer.drain()
 
         except Exception as e:
-            logger.error(f"Error: {e}")
+            self.logger.error(f"Error: {e}")
             print(f"Error: {e}", flush=True)
         finally:
             writer.close()
@@ -208,7 +216,7 @@ class Repl:
             await self.server.serve_forever()
 
     async def stop(self):
-        logger.info("stop the REPL")
+        self.logger.info("stop the REPL")
         if self.server:
             self.server.close()
             await self.server.wait_closed()

--- a/implementations/python/python/ockam/flows/flow.py
+++ b/implementations/python/python/ockam/flows/flow.py
@@ -17,16 +17,21 @@ from ..nodes.message import (
     StreamedConversationSnippet,
 )
 
-from ..ockam_in_rust_for_python import info, debug
-
 
 class Flow:
+    @classmethod
+    def logger(cls):
+        from ..logging.logging import get_logger
+
+        return get_logger("flow")
+
     def __init__(self, name=None, iteration_timeout=120, iteration_limit=20):
         if name is None:
             name = secrets.token_hex(12)
         else:
             validate_name(name)
 
+        self.logger = Flow.logger()
         self.name = name
         self.iteration_timeout = iteration_timeout
         self.iteration_limit = iteration_limit
@@ -55,6 +60,7 @@ class Flow:
 
 class FlowWorker:
     def __init__(self, name: str, node: LocalNodeProtocol, flow: Flow, iteration_limit: int, iteration_timeout: int):
+        self.logger = Flow.logger()
         self.name = name
         self.node = node
         self.flow = flow
@@ -100,7 +106,7 @@ class FlowWorker:
         if not snippet.conversation:
             snippet.conversation = secrets.token_hex(16)
 
-        debug(f"INIT: {snippet}\n\n")
+        self.logger.debug(f"INIT: {snippet}\n\n")
 
         self.flow.state.reset()
 
@@ -127,7 +133,7 @@ class FlowWorker:
                 snippet_to_send = ConversationSnippet(snippet.scope, conversation, [last_message])
 
             if next_vertex == END:
-                info(f"Flow converged in {i} iterations")
+                self.logger.info(f"Flow converged in {i} iterations")
                 snippet.messages[:] = snippet.messages[-1:]
                 return snippet
 
@@ -135,7 +141,7 @@ class FlowWorker:
                 raise RuntimeError(f"Unexpected next_vertex: {next_vertex}")
 
             next_vertex_id = vertex_to_id(next_vertex)
-            debug(f"Iteration: {i} To: {next_vertex_id} Sending: {snippet_to_send}\n\n")
+            self.logger.debug(f"Iteration: {i} To: {next_vertex_id} Sending: {snippet_to_send}\n\n")
 
             reply = await next_vertex.send_and_receive_request(
                 snippet_to_send, converter=self.converter, timeout=self.iteration_timeout
@@ -148,6 +154,6 @@ class FlowWorker:
                     reply_to_append.messages.append(UserMessage(content=message.content))
 
             snippet.messages.extend(reply_to_append.messages)
-            debug(f"Iteration: {i} From {next_vertex_id} Received: {reply}\n\n")
+            self.logger.debug(f"Iteration: {i} From {next_vertex_id} Received: {reply}\n\n")
 
         raise RuntimeError(f"Flow did not converge in {self.iteration_limit} iterations")

--- a/implementations/python/python/ockam/knowledge/knowledge.py
+++ b/implementations/python/python/ockam/knowledge/knowledge.py
@@ -86,7 +86,7 @@ class SearchableKnowledge(KnowledgeProvider):
     def __init__(
         self,
         name: str,
-        model: Model = Model("ollama/nomic-embed-text"),
+        model: Model = None,
         storage: Storage = InMemory(),
         text_extractor: TextExtractor = None,
         chunker: Chunker = NaiveChunker(),
@@ -111,6 +111,9 @@ class SearchableKnowledge(KnowledgeProvider):
         :param max_distance: Maximum allowable distance for operations. Defaults to 0.2.
         :type max_distance: float
         """
+        if model is None:
+            model = Model("ollama/nomic-embed-text")
+
         if text_extractor is None:
             text_extractor = create_extractor()
 

--- a/implementations/python/python/ockam/logging/__init__.py
+++ b/implementations/python/python/ockam/logging/__init__.py
@@ -1,13 +1,13 @@
-from .logging import info, debug, error, warning, set_log_level, get_logging_config
+from .logging import info, debug, error, warning, set_log_levels, get_logger
 from .colored_formatter import OckamColoredFormatter
 
 __all__ = [
-    "get_logging_config",
     "OckamColoredFormatter",
     "info",
     "debug",
     "warning",
     "debug",
     "error",
-    "set_log_level",
+    "get_logger",
+    "set_log_levels",
 ]

--- a/implementations/python/python/ockam/logging/colored_formatter.py
+++ b/implementations/python/python/ockam/logging/colored_formatter.py
@@ -12,13 +12,19 @@ class OckamColoredFormatter(colorlog.ColoredFormatter):
         super().__init__(*args, **kwargs)
 
     def formatTime(self, record, datefmt=None):
-        dt = datetime.fromtimestamp(record.created, UTC)
-        if datefmt:
-            return dt.strftime(datefmt)
-        return super().formatTime(record, datefmt)
+        try:
+            dt = datetime.fromtimestamp(record.created, UTC)
+            if datefmt:
+                return dt.strftime(datefmt)
+            return super().formatTime(record, datefmt)
+        except Exception:
+            return ""
 
     def formatMessage(self, record):
-        original_asctime = self.formatTime(record, self.datefmt)
-        record.asctime = f"{self.GREY}{original_asctime}{self.RESET}"
-        record.name = f"{self.GREY}{record.name}{self.RESET}"
-        return super().formatMessage(record)
+        try:
+            original_asctime = self.formatTime(record, self.datefmt)
+            record.asctime = f"{self.GREY}{original_asctime}{self.RESET}"
+            record.name = f"{self.GREY}{record.name}{self.RESET}"
+            return super().formatMessage(record)
+        except Exception:
+            return ""

--- a/implementations/python/python/ockam/logging/logging.py
+++ b/implementations/python/python/ockam/logging/logging.py
@@ -1,83 +1,135 @@
-import logging.config
 import os
+import logging.config
 
-LOGGING_CONFIG = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "default": {
-            "()": "ockam.logging.colored_formatter.OckamColoredFormatter",
-            "format": "%(asctime)s %(log_color)s%(levelname)s%(reset)s %(name)s: %(message)s",
-            "log_colors": {
-                "DEBUG": "cyan",
-                "INFO": "green",
-                "WARNING": "yellow",
-                "ERROR": "red",
-                "CRITICAL": "bold_red",
-            },
-        },
-    },
-    "handlers": {
-        "default": {
-            "level": "DEBUG",
-            "formatter": "default",
-            "class": "logging.StreamHandler",
-        },
-    },
-    "loggers": {
-        "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
-        "uvicorn.error": {"handlers": ["default"], "level": "INFO", "propagate": False},
-        "uvicorn.access": {"handlers": ["default"], "level": "INFO", "propagate": False},
-        "http": {"handlers": ["default"], "level": "INFO", "propagate": False},
-        "httpx": {"handlers": ["default"], "level": "WARNING", "propagate": False},
-        "LiteLLM": {"handlers": ["default"], "level": "WARNING", "propagate": False},
-        "agent": {"handlers": ["default"], "level": "DEBUG", "propagate": False},
-        "node": {"handlers": ["default"], "level": "DEBUG", "propagate": False},
-    },
-    "root": {"level": "INFO", "handlers": ["default"]},
-}
+DEFAULT_LOG_FORMAT = os.getenv(
+    "DEFAULT_LOG_FORMAT", "%(asctime)s %(log_color)s%(levelname)5s%(reset)s %(name)-14s %(message)s"
+)
+FORMAT = DEFAULT_LOG_FORMAT + (" [%(pathname)s:%(lineno)d]" if os.getenv("OCKAM_LOG_SHOW_SOURCE", False) else "")
+
+LOG_LEVELS = {}
 
 
-def get_logging_config():
-    config = LOGGING_CONFIG
+def get_logging_config() -> dict[str, int | bool | dict | str | None]:
     # Disable logging if explicitly set to 0; otherwise, assume it's enabled
     if os.environ.get("OCKAM_LOGGING", "1") == "0":
         return {
             "version": 1,
         }
-    return config
+
+    global LOG_LEVELS
+    if not LOG_LEVELS:
+        set_log_levels(None)
+    return create_logging_config(LOG_LEVELS, FORMAT)
+
+
+def set_log_levels(log_levels: str):
+    global LOG_LEVELS
+    LOG_LEVELS = create_log_levels(log_levels)
+
+    # By default, silence the Ockam rust modules
+    if os.environ.get("OCKAM_LOG_LEVEL") is None or LOG_LEVELS.get("ockam_rust_modules") is not None:
+        os.environ["OCKAM_LOG_LEVEL"] = LOG_LEVELS.get("ockam_rust_modules")
+
+
+def create_logging_config(levels: dict, log_format: str) -> dict[str, int | bool | dict | str | None]:
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "default": {
+                "()": "ockam.logging.colored_formatter.OckamColoredFormatter",
+                "format": log_format,
+                "log_colors": {
+                    "DEBUG": "blue",
+                    "INFO": "green",
+                    "WARNING": "yellow",
+                    "ERROR": "red",
+                    "CRITICAL": "bold_red",
+                },
+            },
+        },
+        "handlers": {
+            "default": {
+                "level": levels.get("default"),
+                "formatter": "default",
+                "class": "logging.StreamHandler",
+            },
+            "ockam": {
+                "level": levels.get("ockam"),
+                "formatter": "default",
+                "class": "logging.StreamHandler",
+            },
+        },
+        "loggers": {
+            "asyncio": {"handlers": ["default"], "level": levels.get("asyncio", "WARNING"), "propagate": False},
+            "uvicorn": {"handlers": ["default"], "level": levels.get("uvicorn", "WARNING"), "propagate": False},
+            "http": {"handlers": ["default"], "level": levels.get("http", "WARNING"), "propagate": False},
+            "httpcore": {"handlers": ["default"], "level": levels.get("httpcore", "WARNING"), "propagate": False},
+            "httpx": {"handlers": ["default"], "level": levels.get("httpx", "WARNING"), "propagate": False},
+            "LiteLLM": {"handlers": ["default"], "level": levels.get("LiteLLM", "WARNING"), "propagate": False},
+            "agent": {
+                "handlers": ["ockam"],
+                "level": levels.get("agent") or levels.get("default"),
+                "propagate": False,
+            },
+            "model": {
+                "handlers": ["default"],
+                "level": levels.get("model") or levels.get("default"),
+                "propagate": False,
+            },
+            "node": {"handlers": ["ockam"], "level": levels.get("node") or levels.get("default"), "propagate": False},
+            "tool": {"handlers": ["ockam"], "level": levels.get("tool") or levels.get("default"), "propagate": False},
+        },
+        "root": {"level": levels.get("default"), "handlers": ["default"]},
+    }
+
+
+def create_log_levels(log_levels: str) -> dict[str, str]:
+    """
+    Create log levels for python modules
+    """
+    result = {"default": "INFO", "ockam_rust_modules": "WARN"}
+    if log_levels is not None:
+        # set log levels for each python module if defined in the log_levels string
+        ockam_rust_levels = []
+        for level in log_levels.split(","):
+            key_value = level.split("=")
+            if len(key_value) == 1:
+                result["default"] = level.upper()
+            else:
+                key = key_value[0].strip()
+                value = key_value[1].strip()
+                if key.startswith("ockam_") or "ockam" == key:
+                    ockam_rust_levels.append(f"{key}={value}")
+                else:
+                    result[key] = value.upper()
+        # if the user does not specify anything for the ockam rust modules, then set them to warn
+        if len(ockam_rust_levels) > 0:
+            result["ockam_rust_modules"] = ",".join(ockam_rust_levels)
+
+    return result
+
+
+def get_logger(logger_name):
+    logging.config.dictConfig(get_logging_config())
+    return logging.getLogger(logger_name)
 
 
 def info(msg, *args, **kwargs):
     logger = logging.getLogger("node")
-    logger.info(msg, *args, **kwargs)
+    logger.info(msg, stacklevel=2, *args, **kwargs)
 
 
 def warning(msg, *args, **kwargs):
-    import logging.config
-
     logger = logging.getLogger("node")
-    logger.warning(msg, *args, **kwargs)
+    logger.warning(msg, stacklevel=2, *args, **kwargs)
 
 
 def debug(msg, *args, **kwargs):
-    import logging.config
-
     logger = logging.getLogger("node")
-    logger.debug(msg, *args, **kwargs)
+    logger.debug(msg, stacklevel=2, *args, **kwargs)
 
 
 def error(msg, *args, **kwargs):
-    import logging.config
-
     logger = logging.getLogger("node")
-    logger.error(msg, *args, **kwargs)
-
-
-def set_log_level(logger_name, level):
-    logging_config = get_logging_config()
-    if logger_name in logging_config.get("loggers", {}):
-        logging_config["loggers"][logger_name]["level"] = level
-        import logging.config
-
-        logging.config.dictConfig(logging_config)
+    logger.error(msg, stacklevel=2, *args, **kwargs)

--- a/implementations/python/python/ockam/logging/logging_test.py
+++ b/implementations/python/python/ockam/logging/logging_test.py
@@ -1,0 +1,53 @@
+import os
+import pytest
+
+from .logging import create_log_levels
+
+
+@pytest.fixture(autouse=True)
+def clear_ockam_log_level():
+    os.environ.pop("OCKAM_LOG_LEVEL", None)
+    yield
+    os.environ.pop("OCKAM_LOG_LEVEL", None)
+
+
+def test_create_log_levels_when_no_variable_is_defined():
+    result = create_log_levels(None)
+    assert result == {"default": "INFO", "ockam_rust_modules": "WARN"}, (
+        "the default level for python modules is info, rust modules is warn"
+    )
+
+
+def test_create_log_levels_when_only_a_level_is_defined():
+    result = create_log_levels("DEBUG")
+
+    assert result == {"default": "DEBUG", "ockam_rust_modules": "WARN"}, (
+        "the default level for python modules is debug, rust modules is warn"
+    )
+
+
+def test_create_log_levels_when_only_a_module_is_defined():
+    result = create_log_levels("agent=debug")
+
+    assert result == {"default": "INFO", "agent": "DEBUG", "ockam_rust_modules": "WARN"}, (
+        "the default level for python modules is info, debug for the agent module, rust modules is warn"
+    )
+
+
+def test_create_log_levels_when_some_python_modules_are_defined():
+    result = create_log_levels("DEBUG,agent=info")
+
+    assert result == {"default": "DEBUG", "agent": "INFO", "ockam_rust_modules": "WARN"}, (
+        "the default level for python modules is debug, agent is info, rust modules is warn"
+    )
+
+
+def test_create_log_levels_when_some_python_modules_and_ockam_modules_are_defined():
+    result = create_log_levels("DEBUG,agent=info,ockam_core=info")
+
+    assert result == {"default": "DEBUG", "agent": "INFO", "ockam_rust_modules": "ockam_core=info"}, (
+        "the default level for python modules is debug, agent is info, rust modules is info for ockam_core only"
+    )
+    assert result.get("node", result.get("default")) == "DEBUG", (
+        "the default level can be used for an unspecified module"
+    )

--- a/implementations/python/python/ockam/models/model.py
+++ b/implementations/python/python/ockam/models/model.py
@@ -6,7 +6,6 @@ import boto3
 import threading
 
 from ..nodes.message import ConversationMessage
-from ..ockam_in_rust_for_python import warn
 
 PROVIDER_ALIASES = {
     "litellm_proxy": {
@@ -106,11 +105,13 @@ def construct_bedrock_arn(model_identifier: str, original_name: str) -> Optional
 
                 cluster_id = os.environ.get("CLUSTER")
                 if not cluster_id:
-                    warn("CLUSTER is not set. Cannot automatically manage inference profiles. Returning None.")
+                    Model.logger().warning(
+                        "CLUSTER is not set. Cannot automatically manage inference profiles. Returning None."
+                    )
                     return None
 
             except Exception as e:
-                warn(f"Could not construct Bedrock ARN: {e}")
+                Model.logger().warning(f"Could not construct Bedrock ARN: {e}")
                 return None
 
     sanitized_model_name = original_name.replace(":", "_").replace(".", "_")
@@ -133,7 +134,7 @@ def construct_bedrock_arn(model_identifier: str, original_name: str) -> Optional
                             _inference_profile_cache[cache_key] = arn
                             return arn
             except Exception as e:
-                warn(f"An error occurred while listing existing inference profiles: {e}")
+                Model.logger().warning(f"An error occurred while listing existing inference profiles: {e}")
                 return None
 
             # Determine the source ARN for the new profile
@@ -165,7 +166,20 @@ def construct_bedrock_arn(model_identifier: str, original_name: str) -> Optional
 
 
 class Model:
+    _logger = None
+
+    @classmethod
+    def logger(cls):
+        if cls._logger:
+            return cls._logger
+        else:
+            from ..logging.logging import get_logger
+
+            cls._logger = get_logger("model")
+            return cls._logger
+
     def __init__(self, name, **kwargs):
+        self.logger = Model.logger()
         if os.environ.get("LITELLM_PROXY_API_BASE"):
             provider = "litellm_proxy"
         elif os.environ.get("AWS_WEB_IDENTITY_TOKEN_FILE"):
@@ -173,6 +187,7 @@ class Model:
         else:
             provider = "ollama"
 
+        self.original_name = name
         resolved_name = None
         provider_aliases = PROVIDER_ALIASES.get(provider, {})
         original_name = name
@@ -191,6 +206,7 @@ class Model:
                 f"Model '{original_name}' (resolved to '{resolved_name}') is not supported or enabled by any configured provider."
             )
 
+        self.logger.debug(f"the resolved model name is '{resolved_name}'")
         self.name = resolved_name
         self.kwargs = kwargs
         self.kwargs["drop_params"] = True
@@ -216,7 +232,7 @@ class Model:
                     if arn:
                         self.kwargs["model_id"] = arn
                     else:
-                        warn(
+                        Model.logger().warning(
                             f"Failed to obtain/create inference profile ARN for model_identifier: {model_identifier}. Model will be called directly."
                         )
 
@@ -229,6 +245,9 @@ class Model:
         return "bedrock" not in self.name and "litellm_proxy" not in self.name
 
     async def complete_chat(self, messages: List[dict] | List[ConversationMessage], stream: bool = False, **kwargs):
+        self.logger.info(f"send {len(messages)} messages to model '{self.original_name}'")
+        self.logger.debug(f"the messages are: {messages} (stream={stream})")
+
         messages = normalize_messages(messages, self.support_tools(), self.support_forced_assistant_answer())
 
         # slightly modify the parameters to accommodate services
@@ -241,7 +260,9 @@ class Model:
         if "tools" in kwargs and len(kwargs["tools"]) == 0:
             del kwargs["tools"]
 
-        return await litellm.acompletion(self.name, messages=messages, stream=stream, **kwargs)
+        response = await litellm.acompletion(self.name, messages=messages, stream=stream, **kwargs)
+        self.logger.debug(f"got a response from the model '{self.original_name}': {response}")
+        return response
 
     async def embeddings(self, text: List[str], **kwargs) -> List[List[float]]:
         # parameters provided in kwargs will override the default parameters

--- a/implementations/python/python/ockam/nodes/node.py
+++ b/implementations/python/python/ockam/nodes/node.py
@@ -7,13 +7,22 @@ from typing import Awaitable, Callable, Optional
 from .local import LocalNode
 from .manager import RemoteManager
 
-from ..ockam_in_rust_for_python import Node as RustNode, debug
-
-from ..logging.logging import get_logging_config
-import logging.config
+from ..ockam_in_rust_for_python import Node as RustNode
 
 
 class Node:
+    _logger = None
+
+    @classmethod
+    def logger(cls):
+        if cls._logger:
+            return cls._logger
+        else:
+            from ..logging.logging import get_logger
+
+            cls._logger = get_logger("node")
+            return cls._logger
+
     @staticmethod
     def start(
         main: Optional[Callable[[LocalNode], Awaitable[None]]] = None,
@@ -25,12 +34,8 @@ class Node:
         cache_secure_channels: bool = False,
         use_local_db: bool = False,
         llm_debug: bool = False,
-        ockam_log_level: str = "WARN",
         **kwargs,
     ):
-        logging.config.dictConfig(get_logging_config())
-        logger = logging.getLogger("node")
-
         # This will make the node use a local SQLite database instead of the Postgres database
         if use_local_db:
             os.environ.pop("OCKAM_DATABASE_INSTANCE", None)
@@ -38,8 +43,6 @@ class Node:
             os.environ.pop("OCKAM_DATABASE_INSTANCE", None)
             os.environ["OCKAM_TELEMETRY_EXPORT"] = "false"
             os.environ["OCKAM_SQLITE_IN_MEMORY"] = "true"
-
-        os.environ["OCKAM_LOG_LEVEL"] = ockam_log_level
 
         if llm_debug:
             litellm._turn_on_debug()
@@ -68,13 +71,13 @@ class Node:
             await main(node)
 
         try:
-            logger.info("starting node")
+            Node.logger().info(f"start node '{name}'")
             RustNode.start(
                 start_node, name=name, ticket=ticket, allow=allow, cache_secure_channels=cache_secure_channels, **kwargs
             )
         except KeyboardInterrupt:
-            logger.debug("shutting down node due to KeyboardInterrupt")
-            debug(f"\nNode {name} shutting down")
+            Node.logger().debug("shutting down node due to KeyboardInterrupt")
+            Node.logger().debug(f"\nNode {name} shutting down")
 
 
 def wait_until_interrupted_decorator(func=None):

--- a/implementations/python/python/ockam/planning/cot.py
+++ b/implementations/python/python/ockam/planning/cot.py
@@ -80,7 +80,10 @@ Make sure that the last step reaches the goal of the task.
 
 
 class CoTPlanner(Planner):
-    def __init__(self, model=Model(name="deepseek-r1")):
+    def __init__(self, model: Model = None):
+        if model is None:
+            model = Model(name="deepseek-r1")
+
         self.model = model
 
     async def plan(

--- a/implementations/python/python/ockam/planning/dynamic.py
+++ b/implementations/python/python/ockam/planning/dynamic.py
@@ -183,7 +183,10 @@ The key features include a homepage, blog section, about page, and contact form.
 
 
 class DynamicPlanner(Planner):
-    def __init__(self, model=Model("deepseek-r1")):
+    def __init__(self, model: Model = None):
+        if model is None:
+            model = Model(name="deepseek-r1")
+
         self.model = model
 
     async def plan(

--- a/implementations/python/python/ockam/planning/react.py
+++ b/implementations/python/python/ockam/planning/react.py
@@ -24,7 +24,10 @@ class ReActPlan(Plan):
 
 
 class ReActPlanner(Planner):
-    def __init__(self, model=Model("deepseek-r1")):
+    def __init__(self, model: Model = None):
+        if model is None:
+            model = Model("deepseek-r1")
+
         self.model = model
 
     async def plan(

--- a/implementations/python/python/ockam/tools/tool.py
+++ b/implementations/python/python/ockam/tools/tool.py
@@ -10,7 +10,20 @@ from .protocol import InvokableTool
 
 
 class Tool(InvokableTool):
+    _logger = None
+
+    @classmethod
+    def logger(cls):
+        if cls._logger:
+            return cls._logger
+        else:
+            from ..logging.logging import get_logger
+
+            cls._logger = get_logger("tool")
+            return cls._logger
+
     def __init__(self, func):
+        self.logger = Tool.logger()
         name, spec = function_spec(func)
         self.func = wrap(func)
         self.name = name
@@ -23,11 +36,18 @@ class Tool(InvokableTool):
         return self._spec
 
     async def invoke(self, json_argument: Optional[str]) -> str:
-        if json_argument is None or json_argument == "":
-            args = {}
-        else:
-            args = json.loads(json_argument)
-        tool_response = str(await self.func(**args))
+        self.logger.info(f"invoke tool '{self.name}'")
+        self.logger.debug(f"the arguments are: {json_argument}")
+        try:
+            if json_argument is None or json_argument == "":
+                args = {}
+            else:
+                args = json.loads(json_argument)
+            tool_response = str(await self.func(**args))
+            self.logger.debug("the tool call succeeded: {tool_response}")
+        except Exception as e:
+            tool_response = f"the tool call failed with error: {e}"
+            self.logger.error(tool_response)
         return tool_response
 
 

--- a/implementations/python/src/nodes/node.rs
+++ b/implementations/python/src/nodes/node.rs
@@ -145,11 +145,10 @@ impl PyNode {
         cache_secure_channels: bool,
     ) -> PyResult<PyObject> {
         let _ = pyo3_async_runtimes::tokio::init_with_runtime(get_runtime_ref());
-
         let node = get_runtime().block_on(async move {
             let node_builder = NodeBuilder::new()
                 .with_runtime(get_runtime())
-                .with_logging(false);
+                .with_logging(true);
             let (ctx, executor) = node_builder.build();
 
             let node = if let Some(ticket) = ticket {


### PR DESCRIPTION
This PR:

- Adds a few more logs for: `Model`, `Tool`
- Enables the logging of ockam Rust components.
- Allows the user to specify a string setting the logging configuration from inside the `main` code.

For example:

```
set_log_levels("agent=debug") 
```

Will set the logs of the `agent` actions to the debug level, whereas:
``` 
set_log_levels("debug,agent=info")
```
Will set the logs of all the python modules to `debug` but the ones from `agent` to `info`. 

See some other variations in `logging_test.py`.

### Notes

 - The loggers are loaded lazily when their corresponding class is accessed for the first time (not just loaded).
 - The convention I've used is:
   - At the `INFO` level: "do action", for example "start agent 'x'"
   - At the `DEBUG` level: "the action is done" or "the action is done with result: y"

