### PR TITLE
zone cmds ux improvements

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/base_command.rs
+++ b/implementations/rust/ockam/ockam_command/src/base_command.rs
@@ -84,7 +84,7 @@ impl BaseCommand {
         self.enroll(ctx, opts).await?;
         self.zone_init(ctx, opts).await?;
         self.zone_deploy(ctx, opts).await?;
-        self.zone_repl(opts, ctx).await?;
+        self.zone_attach(opts, ctx).await?;
         Ok(())
     }
 
@@ -133,9 +133,9 @@ impl BaseCommand {
         Ok(())
     }
 
-    async fn zone_repl(&self, opts: &CommandGlobalOpts, ctx: &Context) -> Result<()> {
-        use crate::zone::repl::ReplCommand;
-        let cmd = ReplCommand {
+    async fn zone_attach(&self, opts: &CommandGlobalOpts, ctx: &Context) -> Result<()> {
+        use crate::zone::attach::AttachCommand;
+        let cmd = AttachCommand {
             http_api: self.http_api.clone(),
             inlets: self.inlets.clone(),
             ..Default::default()

--- a/implementations/rust/ockam/ockam_command/src/cluster/common_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/common_args.rs
@@ -8,7 +8,7 @@ use ockam_node::Context;
 #[derive(Clone, Debug, Args, Default)]
 pub struct ClusterArg {
     /// The Cluster that hosts the Zone.
-    #[arg(long)]
+    #[arg(long, hide = true)]
     pub cluster: Option<String>,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/cluster/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/cluster/ticket.rs
@@ -9,7 +9,7 @@ use ockam_node::Context;
 
 use super::utils::{get_api_client, get_cluster};
 use crate::cluster::common_args::HttpApiArgs;
-use crate::zone::common_args::ZoneNameOrConfigArg;
+use crate::zone::common_args::ZoneNameLongOrConfigArg;
 use crate::{docs, node_command::InMemoryNodeCommand, Command, CommandGlobalOpts, Result};
 
 const LONG_ABOUT: &str = include_str!("./static/ticket/long_about.txt");
@@ -25,7 +25,7 @@ after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct TicketCommand {
     #[command(flatten)]
-    pub zone: ZoneNameOrConfigArg,
+    pub zone: ZoneNameLongOrConfigArg,
 
     #[command(flatten)]
     pub http_api: HttpApiArgs,

--- a/implementations/rust/ockam/ockam_command/src/util/parsers.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/parsers.rs
@@ -13,6 +13,14 @@ use ockam_core::env::parse_duration;
 use crate::util::validators::cloud_resource_name_validator;
 use crate::Result;
 
+pub(crate) fn alphanumeric_parser(s: &str) -> miette::Result<String> {
+    if s.chars().all(char::is_alphanumeric) {
+        Ok(s.to_owned())
+    } else {
+        Err(miette!("must contain only alphanumeric characters"))
+    }
+}
+
 /// Helper function for parsing a socket from user input by using
 /// [`SchemeHostnamePort::from_str()`]
 pub(crate) fn hostname_parser(input: &str) -> Result<SchemeHostnamePort> {

--- a/implementations/rust/ockam/ockam_command/src/zone/attach.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/attach.rs
@@ -122,14 +122,6 @@ impl AttachCommand {
                 .await?;
             Ok::<(Executor, Option<SchemeHostnamePort>), miette::Error>((executor, Some(from)))
         };
-        let repl_address = match main_pod_outlets.repl {
-            None => None,
-            Some(repl_outlet) => {
-                let (executor, repl_address) = create_inlet(repl_outlet).await?;
-                executors.push(executor);
-                repl_address
-            }
-        };
         let mut rest = main_pod_outlets.rest;
         if !self.inlets.no_http {
             rest.push(main_pod_outlets.http.clone());
@@ -148,6 +140,14 @@ impl AttachCommand {
             }
             executors.push(executor);
         }
+        let repl_address = match main_pod_outlets.repl {
+            None => None,
+            Some(repl_outlet) => {
+                let (executor, repl_address) = create_inlet(repl_outlet).await?;
+                executors.push(executor);
+                repl_address
+            }
+        };
         let services = ServicesAddresses {
             http: http_address,
             logs: logs_address,

--- a/implementations/rust/ockam/ockam_command/src/zone/attach.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/attach.rs
@@ -1,0 +1,284 @@
+use crate::cluster::common_args::HttpApiArgs;
+use crate::entry_point::RUNTIME;
+use crate::node_command::InMemoryNodeCommand;
+use crate::util::port_is_free_guard;
+use crate::zone::common_args::{
+    EnrollmentTicketConfigArg, ZoneConfigArg, ZoneInletsArgs, ZoneNameOrConfigArg,
+};
+use crate::zone::ctrlc::ZoneCtrlcHandler;
+use crate::zone::get_cluster_name::GetClusterName;
+use crate::zone::repl::ReplCommand;
+use crate::zone::services_addresses::ServicesAddresses;
+use crate::zone::zone_config::{Outlet, ZoneConfig};
+use crate::{docs, Command, CommandGlobalOpts, Result};
+use async_trait::async_trait;
+use clap::Args;
+use colorful::Colorful;
+use miette::{miette, IntoDiagnostic};
+use ockam::transport::SchemeHostnamePort;
+use ockam_api::address::get_free_address;
+use ockam_api::colors::color_primary;
+use ockam_api::{fmt_log, fmt_ok, fmt_separator};
+use ockam_node::{Context, Executor, NodeBuilder};
+use std::net::SocketAddr;
+use std::str::FromStr;
+
+const LONG_ABOUT: &str = include_str!("./static/attach/long_about.txt");
+const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/attach/after_long_help.txt");
+
+/// Open the portals to an Ockam AI Zone
+#[derive(Clone, Debug, Args, Default)]
+#[command(
+long_about = docs::about(LONG_ABOUT),
+before_help = docs::before_help(PREVIEW_TAG),
+after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
+pub struct AttachCommand {
+    #[command(flatten)]
+    pub zone: ZoneConfigArg,
+
+    #[command(flatten)]
+    pub http_api: HttpApiArgs,
+
+    #[command(flatten)]
+    pub inlets: ZoneInletsArgs,
+}
+
+#[async_trait]
+impl Command for AttachCommand {
+    const NAME: &'static str = "zone attach";
+
+    async fn run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
+        self.run_impl(opts, ctx).await
+    }
+}
+
+impl AttachCommand {
+    pub async fn run_impl(self, opts: CommandGlobalOpts, ctx: &Context) -> Result<()> {
+        let zone_config = self.zone.zone_config()?;
+        let (executors, services_addresses) = self.zone_inlets(&opts, &zone_config).await?;
+
+        opts.terminal.write_line(fmt_separator!())?;
+
+        // Print the http server URL, if enabled
+        if !self.inlets.no_http {
+            let cluster = GetClusterName.execute(ctx, opts.state.clone()).await?;
+            if let Some(http_url) = zone_config.get_http_url(&cluster) {
+                let http_local_address = if let Some(http_address) = services_addresses.http {
+                    let local = format!("http://localhost:{}\n", http_address.port());
+                    &fmt_log!("{}", color_primary(local))
+                } else {
+                    ""
+                };
+                opts.terminal.write_line(
+                    fmt_log!(
+                        "The http server on the {} is available at:\n",
+                        color_primary(&zone_config.get_main_pod()?.name),
+                    ) + &fmt_log!("{}\n", color_primary(http_url))
+                        + http_local_address,
+                )?;
+            }
+        }
+
+        if let Some(logs_address) = services_addresses.logs {
+            let local_logs = format!("http://localhost:{}\n", logs_address.port());
+            opts.terminal.write_line(
+                fmt_log!("Logs for this zone are available at:\n")
+                    + &fmt_log!("{}\n", color_primary(local_logs)),
+            )?;
+        }
+
+        if let Some(to) = services_addresses.repl {
+            let repl_command = ReplCommand { to };
+            repl_command.open_repl(&opts).await
+        } else {
+            // No repl outlet. Wait for ctrlc to exit the command
+            let portals_str = if executors.len() > 1 {
+                "all portals"
+            } else {
+                "the portal"
+            };
+            opts.terminal
+                .write_line(fmt_log!("Press Ctrl+C to stop {portals_str} and exit"))?;
+            let _ = ZoneCtrlcHandler::wait_for_message().await;
+            Ok(())
+        }
+    }
+
+    async fn zone_inlets(
+        &self,
+        opts: &CommandGlobalOpts,
+        zone_config: &ZoneConfig,
+    ) -> miette::Result<(Vec<Executor>, ServicesAddresses)> {
+        let mut executors = Vec::new();
+        let main_pod = zone_config.get_main_pod()?;
+        let main_pod_outlets = main_pod.get_outlets();
+        let create_inlet = |outlet: Outlet| async move {
+            let from = Self::get_address_for_inlet(&outlet)?;
+            let to = outlet.name.as_ref().unwrap_or(&main_pod.name);
+            let pod_name = outlet.pod_name.as_ref().unwrap_or(&main_pod.name);
+            let executor = self
+                .zone_inlet(opts, &zone_config.name, pod_name, from.clone(), to)
+                .await?;
+            Ok::<(Executor, Option<SchemeHostnamePort>), miette::Error>((executor, Some(from)))
+        };
+        let repl_address = match main_pod_outlets.repl {
+            None => None,
+            Some(repl_outlet) => {
+                let (executor, repl_address) = create_inlet(repl_outlet).await?;
+                executors.push(executor);
+                repl_address
+            }
+        };
+        let mut rest = main_pod_outlets.rest;
+        if !self.inlets.no_http {
+            rest.push(main_pod_outlets.http.clone());
+        }
+        if !self.inlets.no_logs {
+            rest.push(main_pod_outlets.logs.clone());
+        }
+        let mut http_address = None;
+        let mut logs_address = None;
+        for outlet in rest {
+            let (executor, inlet_address) = create_inlet(outlet.clone()).await?;
+            if outlet == main_pod_outlets.http {
+                http_address = inlet_address
+            } else if outlet == main_pod_outlets.logs {
+                logs_address = inlet_address
+            }
+            executors.push(executor);
+        }
+        let services = ServicesAddresses {
+            http: http_address,
+            logs: logs_address,
+            repl: repl_address,
+        };
+        Ok((executors, services))
+    }
+
+    fn get_address_for_inlet(outlet: &Outlet) -> miette::Result<SchemeHostnamePort> {
+        let outlet_port = match outlet.get_port() {
+            Some(port) => {
+                let socket_addr =
+                    SocketAddr::from_str(&format!("127.0.0.1:{port}")).into_diagnostic()?;
+                if port_is_free_guard(&socket_addr).is_ok() {
+                    port
+                } else {
+                    get_free_address()?.port()
+                }
+            }
+            None => get_free_address()?.port(),
+        };
+        SchemeHostnamePort::from_str(&format!("localhost:{outlet_port}")).into_diagnostic()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn zone_inlet(
+        &self,
+        opts: &CommandGlobalOpts,
+        zone_name: &str,
+        pod_name: &str,
+        from: SchemeHostnamePort,
+        to: &str,
+    ) -> miette::Result<Executor> {
+        let spinner = opts.terminal.spinner();
+        if let Some(spinner) = &spinner {
+            spinner.set_message(format!(
+                "Opening a portal to the outlet {} on {} from {}...",
+                color_primary(to),
+                color_primary(pod_name),
+                color_primary(from.to_string())
+            ));
+        }
+
+        // Disable terminal output for the following commands
+        let mut no_output_opts = opts.clone();
+        no_output_opts.terminal = opts.terminal.disable();
+
+        use crate::zone::inlet::InletCommand;
+        let inlet_command = InletCommand {
+            zone: ZoneNameOrConfigArg::from_zone_name(zone_name.to_string()),
+            http_api: self.http_api.clone(),
+            pod: pod_name.to_string(),
+            enrollment_ticket: EnrollmentTicketConfigArg {
+                enrollment_ticket: None,
+            },
+            from: from.clone(),
+            to: Some(to.to_string()),
+            background: true,
+            no_ctrlc_handler: true,
+            ..Default::default()
+        };
+        let (ctx, executor) = {
+            let rt = RUNTIME
+                .get()
+                .ok_or_else(|| miette!("Failed to get the runtime"))?
+                .clone();
+            NodeBuilder::new()
+                .with_runtime(rt)
+                .with_logging(false)
+                .build()
+        };
+        inlet_command.run(&ctx, no_output_opts).await?;
+
+        if let Some(spinner) = &spinner {
+            spinner.finish_and_clear();
+        }
+        opts.terminal.write_line(fmt_ok!(
+            "Opened a portal to the outlet {} on {} from {}",
+            color_primary(to),
+            color_primary(pod_name),
+            color_primary(from.to_string())
+        ))?;
+
+        Ok(executor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::zone::zone_config::Outlet;
+    use std::net::TcpListener;
+    use tokio::time::Duration;
+
+    #[test]
+    fn test_get_address_for_outlet_with_port() -> miette::Result<()> {
+        let listener = TcpListener::bind("127.0.0.1:0").into_diagnostic()?;
+        let test_port = listener.local_addr().into_diagnostic()?.port();
+        drop(listener);
+        std::thread::sleep(Duration::from_secs(1));
+
+        // Create an outlet with a specific port
+        let outlet = Outlet {
+            name: Some("test-outlet".to_string()),
+            to: format!("localhost:{}", test_port),
+            ..Default::default()
+        };
+
+        let address = AttachCommand::get_address_for_inlet(&outlet)?;
+        assert_eq!(address.port(), test_port);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_address_for_outlet_with_occupied_port() -> miette::Result<()> {
+        // Bind to a port and keep it occupied
+        let listener = TcpListener::bind("127.0.0.1:0").into_diagnostic()?;
+        let occupied_port = listener.local_addr().into_diagnostic()?.port();
+
+        // Create an outlet with the occupied port
+        let outlet = Outlet {
+            name: Some("test-outlet".to_string()),
+            to: format!("localhost:{}", occupied_port),
+            ..Default::default()
+        };
+
+        let address = AttachCommand::get_address_for_inlet(&outlet)?;
+        assert_ne!(address.port(), occupied_port);
+
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/zone/attach.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/attach.rs
@@ -8,7 +8,6 @@ use crate::zone::common_args::{
 use crate::zone::ctrlc::ZoneCtrlcHandler;
 use crate::zone::get_cluster_name::GetClusterName;
 use crate::zone::repl::ReplCommand;
-use crate::zone::services_addresses::ServicesAddresses;
 use crate::zone::zone_config::{Outlet, ZoneConfig};
 use crate::{docs, Command, CommandGlobalOpts, Result};
 use async_trait::async_trait;
@@ -39,10 +38,10 @@ pub struct AttachCommand {
     pub zone: ZoneConfigArg,
 
     #[command(flatten)]
-    pub http_api: HttpApiArgs,
+    pub inlets: ZoneInletsArgs,
 
     #[command(flatten)]
-    pub inlets: ZoneInletsArgs,
+    pub http_api: HttpApiArgs,
 }
 
 #[async_trait]
@@ -234,6 +233,14 @@ impl AttachCommand {
 
         Ok(executor)
     }
+}
+
+/// This struct stores the inlet addresses created to access remote services
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ServicesAddresses {
+    http: Option<SchemeHostnamePort>,
+    logs: Option<SchemeHostnamePort>,
+    repl: Option<SchemeHostnamePort>,
 }
 
 #[cfg(test)]

--- a/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
@@ -7,15 +7,20 @@ use ockam_node::Context;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+const ZONE_CONFIG_HELP: &str = include_str!("./static/common_args/zone_config.txt");
+const ZONE_NAME_HELP: &str = "The name of the Zone";
+
 #[derive(Clone, Debug, Args, Default)]
 pub struct ZoneConfigArg {
-    /// The path to the Zone configuration file, in yaml or json format.
-    /// If not set, the `./ockam.yaml` file from the current directory will be used.
-    #[arg(long, visible_alias = "config")]
+    #[arg(long, visible_alias = "config", help = ZONE_CONFIG_HELP)]
     pub zone_config: Option<String>,
 }
 
 impl ZoneConfigArg {
+    pub fn new(zone_config: Option<String>) -> Self {
+        Self { zone_config }
+    }
+
     pub fn zone_config_path(&self) -> crate::Result<PathBuf> {
         match &self.zone_config {
             Some(path) => Ok(PathBuf::from(path)),
@@ -47,35 +52,36 @@ impl ZoneConfigArg {
 #[derive(Clone, Debug, Args, Default)]
 #[group(multiple = false)]
 pub struct ZoneNameOrConfigArg {
-    /// The name of the Zone
-    #[arg(long = "zone")]
+    #[arg(help = ZONE_NAME_HELP)]
     pub zone_name: Option<String>,
 
-    #[command(flatten)]
-    pub zone_config: ZoneConfigArg,
+    #[arg(long, visible_alias = "config", help = ZONE_CONFIG_HELP)]
+    pub zone_config: Option<String>,
 }
 
 impl From<ZoneConfigArg> for ZoneNameOrConfigArg {
     fn from(zone_config: ZoneConfigArg) -> Self {
         Self {
-            zone_name: None,
-            zone_config,
+            zone_name: zone_config.zone_name().ok(),
+            zone_config: zone_config.zone_config,
+        }
+    }
+}
+
+impl From<ZoneNameLongOrConfigArg> for ZoneNameOrConfigArg {
+    fn from(zone_name_or_config: ZoneNameLongOrConfigArg) -> Self {
+        Self {
+            zone_name: zone_name_or_config.zone_name,
+            zone_config: zone_name_or_config.zone_config,
         }
     }
 }
 
 impl ZoneNameOrConfigArg {
-    pub fn from_zone_config(zone_config: ZoneConfigArg) -> Self {
-        Self {
-            zone_name: None,
-            zone_config,
-        }
-    }
-
     pub fn from_zone_name(zone_name: String) -> Self {
         Self {
             zone_name: Some(zone_name),
-            zone_config: ZoneConfigArg::default(),
+            zone_config: None,
         }
     }
 
@@ -83,7 +89,24 @@ impl ZoneNameOrConfigArg {
         if let Some(zone_name) = &self.zone_name {
             return Ok(zone_name.clone());
         }
-        self.zone_config.zone_name()
+        let zone_config = ZoneConfigArg::new(self.zone_config.clone());
+        zone_config.zone_name()
+    }
+}
+
+#[derive(Clone, Debug, Args, Default)]
+#[group(multiple = false)]
+pub struct ZoneNameLongOrConfigArg {
+    #[arg(long = "zone", help = ZONE_NAME_HELP)]
+    pub zone_name: Option<String>,
+
+    #[arg(long, visible_alias = "config", help = ZONE_CONFIG_HELP)]
+    pub zone_config: Option<String>,
+}
+
+impl ZoneNameLongOrConfigArg {
+    pub fn zone_name(&self) -> crate::Result<String> {
+        ZoneNameOrConfigArg::from(self.clone()).zone_name()
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
@@ -93,6 +93,11 @@ impl ZoneNameOrConfigArg {
         let zone_config = ZoneConfigArg::new(self.zone_config.clone());
         zone_config.zone_name()
     }
+
+    pub fn zone_config(&self) -> crate::Result<ZoneConfig> {
+        let zone_config = ZoneConfigArg::new(self.zone_config.clone());
+        zone_config.zone_config()
+    }
 }
 
 #[derive(Clone, Debug, Args, Default)]

--- a/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
@@ -1,4 +1,5 @@
 use crate::docs;
+use crate::util::parsers::alphanumeric_parser;
 use crate::zone::zone_config::ZoneConfig;
 use clap::Args;
 use miette::{miette, Context as _, IntoDiagnostic};
@@ -52,7 +53,7 @@ impl ZoneConfigArg {
 #[derive(Clone, Debug, Args, Default)]
 #[group(multiple = false)]
 pub struct ZoneNameOrConfigArg {
-    #[arg(help = ZONE_NAME_HELP)]
+    #[arg(value_parser = alphanumeric_parser, help = ZONE_NAME_HELP)]
     pub zone_name: Option<String>,
 
     #[arg(long, visible_alias = "config", help = ZONE_CONFIG_HELP)]
@@ -97,7 +98,7 @@ impl ZoneNameOrConfigArg {
 #[derive(Clone, Debug, Args, Default)]
 #[group(multiple = false)]
 pub struct ZoneNameLongOrConfigArg {
-    #[arg(long = "zone", help = ZONE_NAME_HELP)]
+    #[arg(long = "zone", value_parser = alphanumeric_parser, help = ZONE_NAME_HELP)]
     pub zone_name: Option<String>,
 
     #[arg(long, visible_alias = "config", help = ZONE_CONFIG_HELP)]

--- a/implementations/rust/ockam/ockam_command/src/zone/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/create.rs
@@ -25,7 +25,7 @@ after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct CreateCommand {
     #[command(flatten)]
-    pub zone_config: ZoneNameOrConfigArg,
+    pub zone: ZoneNameOrConfigArg,
 
     #[command(flatten)]
     pub http_api: HttpApiArgs,
@@ -44,7 +44,7 @@ impl InMemoryNodeCommand for CreateNodeCommand {
         let use_http_api = self.command.http_api.use_http_api();
         let api_client = get_api_client(&node, use_http_api).await?;
         let cluster = get_cluster(ctx, &node).await?;
-        let zone_name = self.command.zone_config.zone_name()?;
+        let zone_name = self.command.zone.zone_name()?;
         api_client
             .create_zone(ctx, Some(&cluster), &zone_name)
             .await?;

--- a/implementations/rust/ockam/ockam_command/src/zone/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/delete.rs
@@ -132,6 +132,13 @@ impl DeleteCommandTui for DeleteTui {
     }
 
     async fn list_items_names(&self) -> miette::Result<Vec<String>> {
+        // Only remove the zone defined in the config if `all` is not set.
+        if !self.cmd.all {
+            if let Ok(zone_config) = self.cmd.zone.zone_config() {
+                return Ok(vec![zone_config.name]);
+            }
+        }
+        // Otherwise, list all zones in the cluster to let the user choose which ones to delete.
         self.api_client
             .list_zones(&self.ctx, Some(&self.cluster))
             .await

--- a/implementations/rust/ockam/ockam_command/src/zone/deploy.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/deploy.rs
@@ -42,7 +42,7 @@ pub struct DeployCommand {
     pub secrets: SecretsConfigArg,
 
     /// Whether to use a public AWS ECR
-    #[arg(long)]
+    #[arg(long, hide = true)]
     pub use_public_ecr: bool,
 
     #[command(flatten)]

--- a/implementations/rust/ockam/ockam_command/src/zone/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod attach;
 pub(crate) mod common_args;
 pub(crate) mod create;
 pub(crate) mod ctrlc;
@@ -21,6 +22,7 @@ use deploy::DeployCommand;
 use init::InitCommand;
 use ockam_node::Context;
 
+use crate::zone::attach::AttachCommand;
 use crate::zone::delete::DeleteCommand;
 use crate::zone::inlet::InletCommand;
 use crate::zone::list::ListCommand;
@@ -60,6 +62,7 @@ impl ZoneCommand {
             ZoneSubcommand::Delete(c) => c.run(ctx, opts).await,
             ZoneSubcommand::Inlet(c) => c.run(ctx, opts).await,
             ZoneSubcommand::Outlet(c) => c.run(ctx, opts).await,
+            ZoneSubcommand::Attach(c) => c.run(ctx, opts).await.map(|_| ()),
             ZoneSubcommand::Repl(c) => c.run(ctx, opts).await.map(|_| ()),
         }
     }
@@ -79,6 +82,8 @@ pub enum ZoneSubcommand {
     Outlet(OutletCommand),
     #[command(hide = true)]
     Repl(ReplCommand),
+    #[command(hide = true)]
+    Attach(AttachCommand),
 }
 
 impl ZoneSubcommand {
@@ -93,6 +98,7 @@ impl ZoneSubcommand {
             ZoneSubcommand::Inlet(c) => c.name(),
             ZoneSubcommand::Outlet(c) => c.name(),
             ZoneSubcommand::Repl(c) => c.name(),
+            ZoneSubcommand::Attach(c) => c.name(),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/zone/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/mod.rs
@@ -11,7 +11,6 @@ pub mod list;
 mod outlet;
 pub(crate) mod repl;
 pub(crate) mod secret;
-mod services_addresses;
 pub mod watcher;
 pub mod zone_config;
 

--- a/implementations/rust/ockam/ockam_command/src/zone/repl.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/repl.rs
@@ -1,16 +1,6 @@
-use crate::cluster::common_args::HttpApiArgs;
-use crate::entry_point::RUNTIME;
-use crate::node_command::InMemoryNodeCommand;
 use crate::util::parsers::hostname_parser;
-use crate::util::port_is_free_guard;
-use crate::zone::common_args::{
-    EnrollmentTicketConfigArg, ZoneConfigArg, ZoneInletsArgs, ZoneNameOrConfigArg,
-};
 use crate::zone::ctrlc::ZoneCtrlcHandler;
-use crate::zone::get_cluster_name::GetClusterName;
-use crate::zone::services_addresses::ServicesAddresses;
 use crate::zone::watcher::DirectoryWatcher;
-use crate::zone::zone_config::{Outlet, ZoneConfig};
 use crate::{docs, Command, CommandGlobalOpts, Result};
 use async_trait::async_trait;
 use clap::Args;
@@ -18,19 +8,16 @@ use colorful::Colorful;
 use indicatif::ProgressBar;
 use miette::{miette, IntoDiagnostic, WrapErr};
 use ockam::transport::SchemeHostnamePort;
-use ockam_api::address::get_free_address;
 use ockam_api::colors::color_primary;
-use ockam_api::{fmt_log, fmt_ok, fmt_separator};
-use ockam_node::{Context, Executor, NodeBuilder};
+use ockam_api::fmt_ok;
+use ockam_node::Context;
 use rustyline::config::Configurer;
 use rustyline::error::ReadlineError;
 use rustyline::validate::{ValidationContext, ValidationResult, Validator};
 use rustyline::{Completer, Editor, Helper, Highlighter, Hinter};
 use std::cmp::PartialEq;
 use std::fmt::{Display, Formatter};
-use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::task::JoinHandle;
@@ -41,7 +28,7 @@ const LONG_ABOUT: &str = include_str!("./static/repl/long_about.txt");
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/repl/after_long_help.txt");
 
-/// Open a repl to an Outlet of an Ockam AI Zone
+/// Open a repl to a local server
 #[derive(Clone, Debug, Args, Default)]
 #[command(
 long_about = docs::about(LONG_ABOUT),
@@ -49,18 +36,9 @@ before_help = docs::before_help(PREVIEW_TAG),
 after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct ReplCommand {
-    #[command(flatten)]
-    pub zone: ZoneConfigArg,
-
-    #[command(flatten)]
-    pub http_api: HttpApiArgs,
-
-    #[command(flatten)]
-    pub inlets: ZoneInletsArgs,
-
     /// Network address where your repl server is listening to.
-    #[arg(long, id = "SOCKET_ADDRESS", display_order = 900, value_parser = hostname_parser)]
-    pub to: Option<SchemeHostnamePort>,
+    #[arg(long, id = "SOCKET_ADDRESS", value_parser = hostname_parser)]
+    pub to: SchemeHostnamePort,
 }
 
 #[async_trait]
@@ -73,197 +51,16 @@ impl Command for ReplCommand {
 }
 
 impl ReplCommand {
-    pub async fn run_impl(self, opts: CommandGlobalOpts, ctx: &Context) -> Result<()> {
-        if let Some(address) = &self.to {
-            // Open the repl to the given address without creating any inlets
-            self.open_repl(&opts, address.clone()).await
-        } else {
-            let zone_config = self.zone.zone_config()?;
-            let (executors, services_addresses) = self.zone_inlets(&opts, &zone_config).await?;
-
-            opts.terminal.write_line(fmt_separator!())?;
-
-            // Print the http server URL, if enabled
-            if !self.inlets.no_http {
-                let cluster = GetClusterName.execute(ctx, opts.state.clone()).await?;
-                if let Some(http_url) = zone_config.get_http_url(&cluster) {
-                    let http_local_address = if let Some(http_address) = services_addresses.http {
-                        let local = format!("http://localhost:{}\n", http_address.port());
-                        &fmt_log!("{}", color_primary(local))
-                    } else {
-                        ""
-                    };
-                    opts.terminal.write_line(
-                        fmt_log!(
-                            "The http server on the {} is available at:\n",
-                            color_primary(&zone_config.get_main_pod()?.name),
-                        ) + &fmt_log!("{}\n", color_primary(http_url))
-                            + http_local_address,
-                    )?;
-                }
-            }
-
-            if let Some(logs_address) = services_addresses.logs {
-                let local_logs = format!("http://localhost:{}\n", logs_address.port());
-                opts.terminal.write_line(
-                    fmt_log!("Logs for this zone are available at:\n")
-                        + &fmt_log!("{}\n", color_primary(local_logs)),
-                )?;
-            }
-
-            if let Some(address) = services_addresses.repl {
-                self.open_repl(&opts, address).await
-            } else {
-                // No repl outlet. Wait for ctrlc to exit the command
-                let portals_str = if executors.len() > 1 {
-                    "all portals"
-                } else {
-                    "the portal"
-                };
-                opts.terminal
-                    .write_line(fmt_log!("Press Ctrl+C to stop {portals_str} and exit"))?;
-                let _ = ZoneCtrlcHandler::wait_for_message().await;
-                Ok(())
-            }
-        }
+    pub async fn run_impl(self, opts: CommandGlobalOpts, _ctx: &Context) -> Result<()> {
+        // Open the repl to the given address, without an inlet
+        self.open_repl(&opts).await
     }
 
-    async fn zone_inlets(
-        &self,
-        opts: &CommandGlobalOpts,
-        zone_config: &ZoneConfig,
-    ) -> miette::Result<(Vec<Executor>, ServicesAddresses)> {
-        let mut executors = Vec::new();
-        let main_pod = zone_config.get_main_pod()?;
-        let main_pod_outlets = main_pod.get_outlets();
-        let create_inlet = |outlet: Outlet| async move {
-            let from = Self::get_address_for_inlet(&outlet)?;
-            let to = outlet.name.as_ref().unwrap_or(&main_pod.name);
-            let pod_name = outlet.pod_name.as_ref().unwrap_or(&main_pod.name);
-            let executor = self
-                .zone_inlet(opts, &zone_config.name, pod_name, from.clone(), to)
-                .await?;
-            Ok::<(Executor, Option<SchemeHostnamePort>), miette::Error>((executor, Some(from)))
-        };
-        let repl_address = match main_pod_outlets.repl {
-            None => None,
-            Some(repl_outlet) => {
-                let (executor, repl_address) = create_inlet(repl_outlet).await?;
-                executors.push(executor);
-                repl_address
-            }
-        };
-        let mut rest = main_pod_outlets.rest;
-        if !self.inlets.no_http {
-            rest.push(main_pod_outlets.http.clone());
-        }
-        if !self.inlets.no_logs {
-            rest.push(main_pod_outlets.logs.clone());
-        }
-        let mut http_address = None;
-        let mut logs_address = None;
-        for outlet in rest {
-            let (executor, inlet_address) = create_inlet(outlet.clone()).await?;
-            if outlet == main_pod_outlets.http {
-                http_address = inlet_address
-            } else if outlet == main_pod_outlets.logs {
-                logs_address = inlet_address
-            }
-            executors.push(executor);
-        }
-        let services = ServicesAddresses {
-            http: http_address,
-            logs: logs_address,
-            repl: repl_address,
-        };
-        Ok((executors, services))
-    }
-
-    fn get_address_for_inlet(outlet: &Outlet) -> miette::Result<SchemeHostnamePort> {
-        let outlet_port = match outlet.get_port() {
-            Some(port) => {
-                let socket_addr =
-                    SocketAddr::from_str(&format!("127.0.0.1:{port}")).into_diagnostic()?;
-                if port_is_free_guard(&socket_addr).is_ok() {
-                    port
-                } else {
-                    get_free_address()?.port()
-                }
-            }
-            None => get_free_address()?.port(),
-        };
-        SchemeHostnamePort::from_str(&format!("localhost:{outlet_port}")).into_diagnostic()
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    async fn zone_inlet(
-        &self,
-        opts: &CommandGlobalOpts,
-        zone_name: &str,
-        pod_name: &str,
-        from: SchemeHostnamePort,
-        to: &str,
-    ) -> miette::Result<Executor> {
-        let spinner = opts.terminal.spinner();
-        if let Some(spinner) = &spinner {
-            spinner.set_message(format!(
-                "Opening a portal to the outlet {} on {} from {}...",
-                color_primary(to),
-                color_primary(pod_name),
-                color_primary(from.to_string())
-            ));
-        }
-
-        // Disable terminal output for the following commands
-        let mut no_output_opts = opts.clone();
-        no_output_opts.terminal = opts.terminal.disable();
-
-        use crate::zone::inlet::InletCommand;
-        let inlet_command = InletCommand {
-            zone: ZoneNameOrConfigArg::from_zone_name(zone_name.to_string()),
-            http_api: self.http_api.clone(),
-            pod: pod_name.to_string(),
-            enrollment_ticket: EnrollmentTicketConfigArg {
-                enrollment_ticket: None,
-            },
-            from: from.clone(),
-            to: Some(to.to_string()),
-            background: true,
-            no_ctrlc_handler: true,
-            ..Default::default()
-        };
-        let (ctx, executor) = {
-            let rt = RUNTIME
-                .get()
-                .ok_or_else(|| miette!("Failed to get the runtime"))?
-                .clone();
-            NodeBuilder::new()
-                .with_runtime(rt)
-                .with_logging(false)
-                .build()
-        };
-        inlet_command.run(&ctx, no_output_opts).await?;
-
-        if let Some(spinner) = &spinner {
-            spinner.finish_and_clear();
-        }
-        opts.terminal.write_line(fmt_ok!(
-            "Opened a portal to the outlet {} on {} from {}",
-            color_primary(to),
-            color_primary(pod_name),
-            color_primary(from.to_string())
-        ))?;
-
-        Ok(executor)
-    }
-
-    pub async fn open_repl(
-        &self,
-        opts: &CommandGlobalOpts,
-        inlet_address: SchemeHostnamePort,
-    ) -> miette::Result<()> {
+    pub async fn open_repl(&self, opts: &CommandGlobalOpts) -> miette::Result<()> {
         use tokio::net::TcpStream;
         use tokio::time::sleep;
+
+        let server_address = self.to.clone();
 
         let (next_tx, next_rx) = tokio::sync::mpsc::channel(16);
         let (lines_tx, lines_rx) = tokio::sync::mpsc::channel(16);
@@ -304,7 +101,7 @@ impl ReplCommand {
             let mut read_body_buffer = Vec::new();
             'repl: loop {
                 // 1: Try to connect to the inlet
-                let stream = match connect_to_inlet(&inlet_address).await {
+                let stream = match connect_to_inlet(&server_address).await {
                     Ok(s) => s,
                     Err(_e) => {
                         sleep(Duration::from_secs(1)).await;
@@ -806,52 +603,5 @@ pub(super) mod dummy_server {
                 .wrap_err("Failed to flush message")?;
             Ok(())
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::zone::zone_config::Outlet;
-    use std::net::TcpListener;
-    use tokio::time::Duration;
-
-    #[test]
-    fn test_get_address_for_outlet_with_port() -> miette::Result<()> {
-        let listener = TcpListener::bind("127.0.0.1:0").into_diagnostic()?;
-        let test_port = listener.local_addr().into_diagnostic()?.port();
-        drop(listener);
-        std::thread::sleep(Duration::from_secs(1));
-
-        // Create an outlet with a specific port
-        let outlet = Outlet {
-            name: Some("test-outlet".to_string()),
-            to: format!("localhost:{}", test_port),
-            ..Default::default()
-        };
-
-        let address = ReplCommand::get_address_for_inlet(&outlet)?;
-        assert_eq!(address.port(), test_port);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_get_address_for_outlet_with_occupied_port() -> miette::Result<()> {
-        // Bind to a port and keep it occupied
-        let listener = TcpListener::bind("127.0.0.1:0").into_diagnostic()?;
-        let occupied_port = listener.local_addr().into_diagnostic()?.port();
-
-        // Create an outlet with the occupied port
-        let outlet = Outlet {
-            name: Some("test-outlet".to_string()),
-            to: format!("localhost:{}", occupied_port),
-            ..Default::default()
-        };
-
-        let address = ReplCommand::get_address_for_inlet(&outlet)?;
-        assert_ne!(address.port(), occupied_port);
-
-        Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/zone/secret.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/secret.rs
@@ -30,10 +30,10 @@ after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct SecretCommand {
     #[command(flatten)]
-    pub secrets_config: SecretsConfigArg,
+    pub zone: ZoneNameOrConfigArg,
 
     #[command(flatten)]
-    pub zone: ZoneNameOrConfigArg,
+    pub secrets_config: SecretsConfigArg,
 
     #[command(flatten)]
     pub http_api: HttpApiArgs,

--- a/implementations/rust/ockam/ockam_command/src/zone/services_addresses.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/services_addresses.rs
@@ -1,9 +1,0 @@
-use ockam::transport::SchemeHostnamePort;
-
-/// This struct stores the inlet addresses created to access remote services
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ServicesAddresses {
-    pub(crate) http: Option<SchemeHostnamePort>,
-    pub(crate) logs: Option<SchemeHostnamePort>,
-    pub(crate) repl: Option<SchemeHostnamePort>,
-}

--- a/implementations/rust/ockam/ockam_command/src/zone/static/attach/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/zone/static/attach/long_about.txt
@@ -1,0 +1,1 @@
+This command can be used to access the Repl of an agent started locally.

--- a/implementations/rust/ockam/ockam_command/src/zone/static/common_args/zone_config.txt
+++ b/implementations/rust/ockam/ockam_command/src/zone/static/common_args/zone_config.txt
@@ -1,0 +1,2 @@
+The path to the Zone configuration file, in yaml or json format.
+If not set, the `./ockam.yaml` file from the current directory will be used.


### PR DESCRIPTION
- split repl into attach/repl subcommands
- use positional argument for the zone name in zone subcommands (instead of `--zone`)
- add validation for zone name (return error if contains non alphanumeric chars)