### PR TITLE
feat: normalize start / end log messages

### DIFF
--- a/implementations/python/python/ockam/__init__.py
+++ b/implementations/python/python/ockam/__init__.py
@@ -3,7 +3,7 @@ from .clusters import Cluster, Zone
 from .flows import Flow, FlowOperation, START, END
 from .nodes.message import FlowReference
 from .memory import Memory
-from .logging import info, warning, error, debug, set_log_level, set_log_levels, get_logger
+from .logging import info, warning, error, debug, set_log_level, set_log_levels, get_logger, InfoContext, DebugContext
 from .models import Model
 from .nodes import Node, RemoteNode, LocalNode, LocalNodeProtocol, MailboxProtocol, WorkerProtocol, ContextProtocol
 from .nodes.manager import RemoteManager
@@ -54,6 +54,8 @@ __all__ = [
     "debug",
     "set_log_level",
     "set_log_levels",
+    "InfoContext",
+    "DebugContext",
     # from .ockam_in_rust_for_python
     "Mailbox",
     "McpClient",

--- a/implementations/python/python/ockam/agents/agent.py
+++ b/implementations/python/python/ockam/agents/agent.py
@@ -174,7 +174,7 @@ class AgentStateMachine:
 
         self.tool_calls = []
         async for err, finished, model_response in self.agent.complete_chat(
-                self.scope, self.conversation, self.contextual_knowledge, stream=self.stream
+            self.scope, self.conversation, self.contextual_knowledge, stream=self.stream
         ):
             if err:
                 yield self.streaming_response.make_snippet(err)
@@ -275,19 +275,19 @@ class Agent(InfoContext, DebugContext):
             return cls._logger
 
     def __init__(
-            self,
-            node: LocalNodeProtocol,
-            name: str,
-            instructions: str,
-            model: Model,
-            memory_model: Optional[Model],
-            memory_embeddings_model: Optional[Model],
-            tool_specs: List[dict],
-            tools: Dict[str, InvokableTool],
-            planner: Planner,
-            memory: Memory,
-            knowledge: KnowledgeProvider,
-            maximum_iterations: int,
+        self,
+        node: LocalNodeProtocol,
+        name: str,
+        instructions: str,
+        model: Model,
+        memory_model: Optional[Model],
+        memory_embeddings_model: Optional[Model],
+        tool_specs: List[dict],
+        tools: Dict[str, InvokableTool],
+        planner: Planner,
+        memory: Memory,
+        knowledge: KnowledgeProvider,
+        maximum_iterations: int,
     ):
         self.logger = Agent.class_logger()
         with self.info(f"Starting agent '{name}'", f"Started agent '{name}'"):
@@ -353,7 +353,7 @@ class Agent(InfoContext, DebugContext):
         return GetConversationsResponse(self.memory.get_messages_only(message.scope, message.conversation))
 
     async def handle__conversation_snippet(
-            self, snippet: StreamedConversationSnippet | ConversationSnippet
+        self, snippet: StreamedConversationSnippet | ConversationSnippet
     ) -> AsyncGenerator[StreamedConversationSnippet | ConversationSnippet | Error, None]:
         stream = type(snippet) is StreamedConversationSnippet
         if stream:
@@ -454,9 +454,9 @@ class Agent(InfoContext, DebugContext):
         while True:
             self.memory_knowledge = await AgentMemoryKnowledge.create(self.memory_model, self.memory_embeddings_model)
             for i in range(0, len(skipped_message_history), 2):
-                self.logger.info(f"ADDING MESSAGES to knowledge: {skipped_message_history[i: i + 2]}")
+                self.logger.info(f"ADDING MESSAGES to knowledge: {skipped_message_history[i : i + 2]}")
                 await self.memory_knowledge.add(
-                    scope=scope, conversation=conversation, messages=skipped_message_history[i: i + 2]
+                    scope=scope, conversation=conversation, messages=skipped_message_history[i : i + 2]
                 )
 
             # We should actually clear knowledge in this function each time...
@@ -497,7 +497,7 @@ class Agent(InfoContext, DebugContext):
             iterations += 1
 
     async def complete_chat(
-            self, scope, conversation, contextual_knowledge, stream: bool = False
+        self, scope, conversation, contextual_knowledge, stream: bool = False
     ) -> AsyncGenerator[Tuple[Optional[Exception], bool, AssistantMessage], None]:
         input_context = await self.determine_input_context(scope, conversation, contextual_knowledge)
         self.logger.info(
@@ -597,17 +597,17 @@ class Agent(InfoContext, DebugContext):
 
     @staticmethod
     async def start(
-            node: NodeProtocol,
-            instructions: str,
-            name: Optional[str] = None,
-            model: Model = None,
-            memory_model: Optional[Model] = None,
-            memory_embeddings_model: Optional[Model] = None,
-            tools: Optional[List[InvokableTool]] = None,
-            planner: Planner = None,
-            exposed_as: Optional[str] = None,
-            knowledge: KnowledgeProvider = NoopKnowledge(),
-            max_iterations: int = 14,
+        node: NodeProtocol,
+        instructions: str,
+        name: Optional[str] = None,
+        model: Model = None,
+        memory_model: Optional[Model] = None,
+        memory_embeddings_model: Optional[Model] = None,
+        tools: Optional[List[InvokableTool]] = None,
+        planner: Planner = None,
+        exposed_as: Optional[str] = None,
+        knowledge: KnowledgeProvider = NoopKnowledge(),
+        max_iterations: int = 14,
     ):
         if name is None:
             name = secrets.token_hex(12)
@@ -657,16 +657,16 @@ class Agent(InfoContext, DebugContext):
 
     @staticmethod
     async def start_many(
-            node: NodeProtocol,
-            instructions: str,
-            number_of_agents: int,
-            model: Model = None,
-            memory_model: Optional[Model] = None,
-            memory_embeddings_model: Optional[Model] = None,
-            tools: Optional[list] = None,
-            planner=None,
-            knowledge: Optional[KnowledgeProvider] = None,
-            max_iterations: int = 14,
+        node: NodeProtocol,
+        instructions: str,
+        number_of_agents: int,
+        model: Model = None,
+        memory_model: Optional[Model] = None,
+        memory_embeddings_model: Optional[Model] = None,
+        tools: Optional[list] = None,
+        planner=None,
+        knowledge: Optional[KnowledgeProvider] = None,
+        max_iterations: int = 14,
     ):
         if model is None:
             model = Model(name="llama3.2")
@@ -715,17 +715,17 @@ class Agent(InfoContext, DebugContext):
 
     @staticmethod
     async def start_agent_impl(
-            node: LocalNodeProtocol,
-            instructions: str,
-            name: Optional[str],
-            model: Model,
-            memory_model: Optional[Model],
-            memory_embeddings_model: Optional[Model],
-            tools: Optional[List[InvokableTool]],
-            planner: Planner,
-            exposed_as: Optional[str],
-            knowledge: Optional[KnowledgeProvider],
-            max_iterations: int,
+        node: LocalNodeProtocol,
+        instructions: str,
+        name: Optional[str],
+        model: Model,
+        memory_model: Optional[Model],
+        memory_embeddings_model: Optional[Model],
+        tools: Optional[List[InvokableTool]],
+        planner: Planner,
+        exposed_as: Optional[str],
+        knowledge: Optional[KnowledgeProvider],
+        max_iterations: int,
     ):
         tools_specs, tools = await prepare_tools(node, tools)
         # the memory is shared between all the agent workers

--- a/implementations/python/python/ockam/agents/agent.py
+++ b/implementations/python/python/ockam/agents/agent.py
@@ -17,6 +17,7 @@ from ..tools.protocol import InvokableTool
 from .agent_memory_knowledge import AgentMemoryKnowledge
 from ..knowledge.noop import NoopKnowledge
 from ..nodes import RemoteNode, LocalNodeProtocol
+from ..logging.logging import InfoContext, DebugContext
 from ..planning import Planner
 from ..knowledge import KnowledgeProvider
 from ..memory import Memory
@@ -260,7 +261,7 @@ class AgentStateMachine:
             yield result
 
 
-class Agent:
+class Agent(InfoContext, DebugContext):
     _logger = None
     tools: Dict[str, InvokableTool]
     memory_knowledge: Optional[AgentMemoryKnowledge]
@@ -291,11 +292,11 @@ class Agent:
         maximum_iterations: int,
     ):
         self.logger = Agent.class_logger()
-        self.logger.info(f"start agent '{name}'")
-        self.node = node
+        with self.info(f"Starting agent '{name}'", f"Started agent '{name}'"):
+            self.node = node
 
-        self.tools = tools
-        self.tool_specs = tool_specs
+            self.tools = tools
+            self.tool_specs = tool_specs
 
         self.name = name
         self.model = model
@@ -303,19 +304,19 @@ class Agent:
         self.memory_embeddings_model = memory_embeddings_model
         self.memory_knowledge = None
 
-        self.memory = memory
-        memory.set_instructions(system_message(instructions))
+            self.memory = memory
+            memory.set_instructions(system_message(instructions))
 
         self.planner = planner
         self.maximum_iterations = maximum_iterations
 
         self.knowledge = knowledge
 
-        self.converter = MessageConverter.create(node)
+            self.converter = MessageConverter.create(node)
 
     async def handle_message(self, context, message):
         try:
-            self.logger.debug(f"agent '{self.name}' received: {message}")
+            self.logger.debug(f"Agent '{self.name}' received: {message}")
 
             message = self.converter.message_from_json(message)
             handlers = {
@@ -334,7 +335,7 @@ class Agent:
                 if handler is not None:
                     reply = await handler(message)
                 else:
-                    self.logger.error(f"unexpected message: {message}")
+                    self.logger.error(f"Unexpected message: {message}")
                     reply = Error(f"Unexpected Message: {message}")
 
                 if reply is not None:
@@ -501,8 +502,16 @@ class Agent:
         self, scope, conversation, contextual_knowledge, stream: bool = False
     ) -> AsyncGenerator[Tuple[Optional[Exception], bool, AssistantMessage], None]:
         input_context = await self.determine_input_context(scope, conversation, contextual_knowledge)
-
+        self.logger.info(
+            f"Sending {len(input_context)} messages from agent '{self.name}' to model '{self.model.original_name}'"
+        )
         response = await self.model.complete_chat(tools=self.tool_specs, messages=input_context, stream=stream)
+        messages = [choice.message for choice in response.choices]
+        plural = "s" if len(messages) > 1 else ""
+        self.logger.info(
+            f"Received {len(messages)} message{plural} from model '{self.model.original_name}' for agent '{self.name}'"
+        )
+
         if stream:
             tool_calls: Dict[int, ToolCall] = {}
             async for chunk in response:
@@ -550,7 +559,7 @@ class Agent:
                 role = delta.role
 
             if choice.finish_reason is not None:
-                self.logger.debug(f"finished streaming reply with reason {choice.get('finish_reason', 'unknown')}")
+                self.logger.debug(f"Finished streaming reply with reason {choice.get('finish_reason', 'unknown')}")
                 finished = True
                 response = {"role": role}
             else:
@@ -742,7 +751,7 @@ class Agent:
 
         await node.start_spawner(name, agent_creator, key_extractor, None, exposed_as)
 
-        Agent.class_logger().debug(f"successfully started agent {name}")
+        Agent.class_logger().debug(f"Successfully started agent {name}")
 
 
 def key_extractor(message):

--- a/implementations/python/python/ockam/agents/agent.py
+++ b/implementations/python/python/ockam/agents/agent.py
@@ -7,10 +7,8 @@ from enum import Enum
 from copy import deepcopy
 from typing import Optional, AsyncGenerator, Tuple, Dict
 
-
 import secrets
 import copy
-
 
 from .conversation_response import ConversationResponse
 from ..tools.protocol import InvokableTool
@@ -176,7 +174,7 @@ class AgentStateMachine:
 
         self.tool_calls = []
         async for err, finished, model_response in self.agent.complete_chat(
-            self.scope, self.conversation, self.contextual_knowledge, stream=self.stream
+                self.scope, self.conversation, self.contextual_knowledge, stream=self.stream
         ):
             if err:
                 yield self.streaming_response.make_snippet(err)
@@ -277,19 +275,19 @@ class Agent(InfoContext, DebugContext):
             return cls._logger
 
     def __init__(
-        self,
-        node: LocalNodeProtocol,
-        name: str,
-        instructions: str,
-        model: Model,
-        memory_model: Optional[Model],
-        memory_embeddings_model: Optional[Model],
-        tool_specs: List[dict],
-        tools: Dict[str, InvokableTool],
-        planner: Planner,
-        memory: Memory,
-        knowledge: KnowledgeProvider,
-        maximum_iterations: int,
+            self,
+            node: LocalNodeProtocol,
+            name: str,
+            instructions: str,
+            model: Model,
+            memory_model: Optional[Model],
+            memory_embeddings_model: Optional[Model],
+            tool_specs: List[dict],
+            tools: Dict[str, InvokableTool],
+            planner: Planner,
+            memory: Memory,
+            knowledge: KnowledgeProvider,
+            maximum_iterations: int,
     ):
         self.logger = Agent.class_logger()
         with self.info(f"Starting agent '{name}'", f"Started agent '{name}'"):
@@ -304,15 +302,15 @@ class Agent(InfoContext, DebugContext):
         self.memory_embeddings_model = memory_embeddings_model
         self.memory_knowledge = None
 
-            self.memory = memory
-            memory.set_instructions(system_message(instructions))
+        self.memory = memory
+        memory.set_instructions(system_message(instructions))
 
         self.planner = planner
         self.maximum_iterations = maximum_iterations
 
         self.knowledge = knowledge
 
-            self.converter = MessageConverter.create(node)
+        self.converter = MessageConverter.create(node)
 
     async def handle_message(self, context, message):
         try:
@@ -355,7 +353,7 @@ class Agent(InfoContext, DebugContext):
         return GetConversationsResponse(self.memory.get_messages_only(message.scope, message.conversation))
 
     async def handle__conversation_snippet(
-        self, snippet: StreamedConversationSnippet | ConversationSnippet
+            self, snippet: StreamedConversationSnippet | ConversationSnippet
     ) -> AsyncGenerator[StreamedConversationSnippet | ConversationSnippet | Error, None]:
         stream = type(snippet) is StreamedConversationSnippet
         if stream:
@@ -456,9 +454,9 @@ class Agent(InfoContext, DebugContext):
         while True:
             self.memory_knowledge = await AgentMemoryKnowledge.create(self.memory_model, self.memory_embeddings_model)
             for i in range(0, len(skipped_message_history), 2):
-                self.logger.info(f"ADDING MESSAGES to knowledge: {skipped_message_history[i : i + 2]}")
+                self.logger.info(f"ADDING MESSAGES to knowledge: {skipped_message_history[i: i + 2]}")
                 await self.memory_knowledge.add(
-                    scope=scope, conversation=conversation, messages=skipped_message_history[i : i + 2]
+                    scope=scope, conversation=conversation, messages=skipped_message_history[i: i + 2]
                 )
 
             # We should actually clear knowledge in this function each time...
@@ -499,7 +497,7 @@ class Agent(InfoContext, DebugContext):
             iterations += 1
 
     async def complete_chat(
-        self, scope, conversation, contextual_knowledge, stream: bool = False
+            self, scope, conversation, contextual_knowledge, stream: bool = False
     ) -> AsyncGenerator[Tuple[Optional[Exception], bool, AssistantMessage], None]:
         input_context = await self.determine_input_context(scope, conversation, contextual_knowledge)
         self.logger.info(
@@ -599,17 +597,17 @@ class Agent(InfoContext, DebugContext):
 
     @staticmethod
     async def start(
-        node: NodeProtocol,
-        instructions: str,
-        name: Optional[str] = None,
-        model: Model = None,
-        memory_model: Optional[Model] = None,
-        memory_embeddings_model: Optional[Model] = None,
-        tools: Optional[List[InvokableTool]] = None,
-        planner: Planner = None,
-        exposed_as: Optional[str] = None,
-        knowledge: KnowledgeProvider = NoopKnowledge(),
-        max_iterations: int = 14,
+            node: NodeProtocol,
+            instructions: str,
+            name: Optional[str] = None,
+            model: Model = None,
+            memory_model: Optional[Model] = None,
+            memory_embeddings_model: Optional[Model] = None,
+            tools: Optional[List[InvokableTool]] = None,
+            planner: Planner = None,
+            exposed_as: Optional[str] = None,
+            knowledge: KnowledgeProvider = NoopKnowledge(),
+            max_iterations: int = 14,
     ):
         if name is None:
             name = secrets.token_hex(12)
@@ -659,16 +657,16 @@ class Agent(InfoContext, DebugContext):
 
     @staticmethod
     async def start_many(
-        node: NodeProtocol,
-        instructions: str,
-        number_of_agents: int,
-        model: Model = None,
-        memory_model: Optional[Model] = None,
-        memory_embeddings_model: Optional[Model] = None,
-        tools: Optional[list] = None,
-        planner=None,
-        knowledge: Optional[KnowledgeProvider] = None,
-        max_iterations: int = 14,
+            node: NodeProtocol,
+            instructions: str,
+            number_of_agents: int,
+            model: Model = None,
+            memory_model: Optional[Model] = None,
+            memory_embeddings_model: Optional[Model] = None,
+            tools: Optional[list] = None,
+            planner=None,
+            knowledge: Optional[KnowledgeProvider] = None,
+            max_iterations: int = 14,
     ):
         if model is None:
             model = Model(name="llama3.2")
@@ -717,17 +715,17 @@ class Agent(InfoContext, DebugContext):
 
     @staticmethod
     async def start_agent_impl(
-        node: LocalNodeProtocol,
-        instructions: str,
-        name: Optional[str],
-        model: Model,
-        memory_model: Optional[Model],
-        memory_embeddings_model: Optional[Model],
-        tools: Optional[List[InvokableTool]],
-        planner: Planner,
-        exposed_as: Optional[str],
-        knowledge: Optional[KnowledgeProvider],
-        max_iterations: int,
+            node: LocalNodeProtocol,
+            instructions: str,
+            name: Optional[str],
+            model: Model,
+            memory_model: Optional[Model],
+            memory_embeddings_model: Optional[Model],
+            tools: Optional[List[InvokableTool]],
+            planner: Planner,
+            exposed_as: Optional[str],
+            knowledge: Optional[KnowledgeProvider],
+            max_iterations: int,
     ):
         tools_specs, tools = await prepare_tools(node, tools)
         # the memory is shared between all the agent workers

--- a/implementations/python/python/ockam/agents/http.py
+++ b/implementations/python/python/ockam/agents/http.py
@@ -12,7 +12,7 @@ from .socket_address import parse_host_and_port
 from ..agents import AgentReference
 from ..nodes.message import GetConversationsRequest, StreamedConversationSnippet, Phase, Reference, FlowReference
 from ..nodes.local import LocalNode
-from ..logging.logging import InfoContext
+from ..logging.logging import InfoContext, get_logging_config
 
 """
     This class starts an HTTP server allowing a user to interact with a node and its agents.
@@ -215,7 +215,9 @@ class HttpServer(InfoContext):
 
     async def serve(self):
         self.logger.info("Starting the http server")
-        config = uvicorn.Config(self.app, host=self.host, port=self.port)
+        config = uvicorn.Config(
+            self.app, host=self.host, port=self.port, log_config=get_logging_config(), access_log=True
+        )
         server = uvicorn.Server(config)
         self.logger.info("Started the http server")
         await server.serve()

--- a/implementations/python/python/ockam/agents/http.py
+++ b/implementations/python/python/ockam/agents/http.py
@@ -12,6 +12,7 @@ from .socket_address import parse_host_and_port
 from ..agents import AgentReference
 from ..nodes.message import GetConversationsRequest, StreamedConversationSnippet, Phase, Reference, FlowReference
 from ..nodes.local import LocalNode
+from ..logging.logging import InfoContext
 
 """
     This class starts an HTTP server allowing a user to interact with a node and its agents.
@@ -21,7 +22,7 @@ DEFAULT_HOST = os.environ.get("DEFAULT_HOST_HTTP", "0.0.0.0")
 DEFAULT_PORT = int(os.environ.get("DEFAULT_PORT_HTTP", "8000"))
 
 
-class HttpServer:
+class HttpServer(InfoContext):
     _logger = None
 
     @classmethod
@@ -62,35 +63,43 @@ class HttpServer:
 
         @self.app.get("/agents")
         async def get_agents(node=Depends(self.get_node)):
-            self.logger.info("get agents")
-            return {"agents": await node.list_agents()}
+            with self.info("Retrieving agents", "Retrieved agents"):
+                return {"agents": await node.list_agents()}
 
         @self.app.get("/workers")
         async def get_workers(node=Depends(self.get_node)):
-            self.logger.info("get workers")
-            return {"workers": await node.list_workers()}
+            with self.info("Retrieving workers", "Retrieved workers"):
+                return {"workers": await node.list_workers()}
 
         @self.app.get("/agents/{name}")
         async def get_agent_by_name(name: str, node=Depends(self.get_node)):
-            self.logger.info(f"get agent by name: {name}")
-            return await find_agent(node, name)
+            with self.info(f"Retrieving agent with name '{name}'", f"Retrieved agent with name '{name}'"):
+                return await find_agent(node, name)
 
         @self.app.get("/agents/{name}/conversations")
         async def get_conversations_by_agent_name(name: str, node=Depends(self.get_node)):
-            self.logger.info(f"get conversations by agent name: {name}")
-            return await get_agent_by_name_and_scope_and_conversation_impl(name, None, None, node)
+            with self.info(
+                f"Retrieving conversations for agent '{name}'", f"Retrieved conversations for agent '{name}'"
+            ):
+                return await get_agent_by_name_and_scope_and_conversation_impl(name, None, None, node)
 
         @self.app.get("/agents/{name}/scopes/{scope}/conversations")
         async def get_conversations_by_agent_name_and_scope(name: str, scope: str, node=Depends(self.get_node)):
-            self.logger.info(f"get conversations by agent {name} and scope {scope}")
-            return await get_agent_by_name_and_scope_and_conversation_impl(name, scope, None, node)
+            with self.info(
+                f"Retrieving conversations for agent '{name}' and scope '{scope}'",
+                f"Retrieved conversations for agent '{name}' and scope '{scope}'",
+            ):
+                return await get_agent_by_name_and_scope_and_conversation_impl(name, scope, None, node)
 
         @self.app.get("/agents/{name}/scopes/{scope}/conversations/{conversation}")
         async def get_agent_by_name_and_scope_and_conversation(
             name: str, scope: str, conversation: str, node=Depends(self.get_node)
         ):
-            self.logger.info(f"getting conversations by agent {name}, scope {scope} and conversation {conversation}")
-            return await get_agent_by_name_and_scope_and_conversation_impl(name, scope, conversation, node)
+            with self.info(
+                f"Retrieving conversations for agent '{name}', scope '{scope}' and conversation '{conversation}'",
+                f"Retrieved conversations for agent '{name}', scope '{scope}' and conversation '{conversation}'",
+            ):
+                return await get_agent_by_name_and_scope_and_conversation_impl(name, scope, conversation, node)
 
         async def get_agent_by_name_and_scope_and_conversation_impl(
             name: str, scope: None | str, conversation: None | str, node
@@ -116,9 +125,11 @@ class HttpServer:
             timeout: int = 60,
             node=Depends(self.get_node),
         ):
-            self.logger.info(f"send a message to agent '{name}'")
-            await find_agent(node, name)
-            return await send_message_to_reference(AgentReference(name, node), message, stream, content_size, timeout)
+            with self.info(f"Sending a message to agent '{name}'", f"Sent a message to agent '{name}'"):
+                await find_agent(node, name)
+                return await send_message_to_reference(
+                    AgentReference(name, node), message, stream, content_size, timeout
+                )
 
         @self.app.post("/flows/{name}")
         async def send_message_to_flow(
@@ -129,9 +140,11 @@ class HttpServer:
             timeout: int = 60,
             node=Depends(self.get_node),
         ):
-            self.logger.info(f"send a message to flow '{name}'")
-            await find_worker(node, name)
-            return await send_message_to_reference(FlowReference(name, node), message, stream, content_size, timeout)
+            with self.info(f"Sending a message to flow '{name}'", f"Sent a message to flow '{name}'"):
+                await find_worker(node, name)
+                return await send_message_to_reference(
+                    FlowReference(name, node), message, stream, content_size, timeout
+                )
 
         async def find_agent(node, name):
             agents = await node.list_agents()
@@ -194,25 +207,27 @@ class HttpServer:
                 else:
                     return await reference.send(msg, scope, conversation, timeout=timeout)
             except Exception as e:
-                self.logger.error(f"failed to send message to '{reference.name}': {e}")
+                self.logger.error(f"Failed to send message to '{reference.name}': {e}")
                 raise HTTPException(status_code=500, detail="Failed to send message")
 
         @self.app.get("/tools")
         async def get_tools(node=Depends(self.get_node)):
-            self.logger.info("get the exposed tools")
-            return node.list_tools()
+            with self.info("Get the exposed tools", "Retrieved the exposed tools"):
+                return node.list_tools()
 
         @self.app.get("/tools/{name}")
         async def get_tool_by_name(name: str, node=Depends(self.get_node)):
-            self.logger.info(f"get tool by name: {name}")
-            return find_tool(node, name)
+            with self.info(f"Get tool: {name}", f"Retrieved tool: {name}"):
+                return find_tool(node, name)
 
     def get_node(self):
         return self.node
 
     async def serve(self):
+        self.logger.info("Starting the http server")
         config = uvicorn.Config(self.app, host=self.host, port=self.port)
         server = uvicorn.Server(config)
+        self.logger.info("Started the http server")
         await server.serve()
 
     def set_host_and_port(self, listen_address):

--- a/implementations/python/python/ockam/agents/http.py
+++ b/implementations/python/python/ockam/agents/http.py
@@ -23,20 +23,10 @@ DEFAULT_PORT = int(os.environ.get("DEFAULT_PORT_HTTP", "8000"))
 
 
 class HttpServer(InfoContext):
-    _logger = None
-
-    @classmethod
-    def class_logger(cls):
-        if cls._logger:
-            return cls._logger
-        else:
-            from ..logging.logging import get_logger
-
-            cls._logger = get_logger("http")
-            return cls._logger
-
     def __init__(self, listen_address=f"{DEFAULT_HOST}:{DEFAULT_PORT}", app: FastAPI = None):
-        self.logger = HttpServer.class_logger()
+        from ..logging.logging import get_logger
+
+        self.logger = get_logger("http")
         self.node = None
         self.host = DEFAULT_HOST
         self.port = DEFAULT_PORT

--- a/implementations/python/python/ockam/agents/repl.py
+++ b/implementations/python/python/ockam/agents/repl.py
@@ -54,7 +54,7 @@ class Repl:
     async def start(
         agent_reference, listen_address=f"{DEFAULT_HOST}:{DEFAULT_PORT}", functions=None, timeout=None, stream=True
     ):
-        Repl.class_logger().info("starting the REPL")
+        Repl.class_logger().info("Starting the repl")
         repl = Repl(agent_reference, listen_address, functions, timeout, stream)
         # start the repl in a separate thread since we might also have a HTTP server running
         asyncio.create_task(repl.start_impl())
@@ -68,7 +68,7 @@ class Repl:
             raise ValueError(f"Invalid listen_address: {listen_address}")
 
     async def list_functions(self, writer):
-        self.logger.debug("list functions")
+        self.logger.debug("List functions")
         functions_list = "\n".join([f"{name}" for name in self.functions.keys()])
         await self.write_repl_message(writer, functions_list)
 
@@ -211,11 +211,12 @@ class Repl:
 
     async def start_impl(self):
         self.server = await asyncio.start_server(self.handle_client, self.host, self.port)
+        Repl.class_logger().info("Started the repl")
         async with self.server:
             await self.server.serve_forever()
 
     async def stop(self):
-        self.logger.info("stop the REPL")
+        self.logger.info("Stop the repl")
         if self.server:
             self.server.close()
             await self.server.wait_closed()

--- a/implementations/python/python/ockam/agents/repl.py
+++ b/implementations/python/python/ockam/agents/repl.py
@@ -11,22 +11,13 @@ DEFAULT_PORT = int(os.environ.get("DEFAULT_PORT_REPL", "7000"))
 
 
 class Repl:
-    _logger = None
-
-    @classmethod
-    def class_logger(cls):
-        if cls._logger:
-            return cls._logger
-        else:
-            from ..logging.logging import get_logger
-
-            cls._logger = get_logger("repl")
-            return cls._logger
-
     def __init__(
         self, agent_reference, listen_address=f"{DEFAULT_HOST}:{DEFAULT_PORT}", functions=None, timeout=120, stream=True
     ):
-        self.logger = Repl.class_logger()
+        from ..logging.logging import get_logger
+
+        self.logger = get_logger("repl")
+        self.logger.info("Starting the repl")
         self.functions = functions or {}
         self.host = DEFAULT_HOST
         self.port = DEFAULT_PORT
@@ -54,7 +45,6 @@ class Repl:
     async def start(
         agent_reference, listen_address=f"{DEFAULT_HOST}:{DEFAULT_PORT}", functions=None, timeout=None, stream=True
     ):
-        Repl.class_logger().info("Starting the repl")
         repl = Repl(agent_reference, listen_address, functions, timeout, stream)
         # start the repl in a separate thread since we might also have a HTTP server running
         asyncio.create_task(repl.start_impl())
@@ -211,7 +201,7 @@ class Repl:
 
     async def start_impl(self):
         self.server = await asyncio.start_server(self.handle_client, self.host, self.port)
-        Repl.class_logger().info("Started the repl")
+        self.logger.info("Started the repl")
         async with self.server:
             await self.server.serve_forever()
 

--- a/implementations/python/python/ockam/flows/flow.py
+++ b/implementations/python/python/ockam/flows/flow.py
@@ -106,7 +106,7 @@ class FlowWorker:
         if not snippet.conversation:
             snippet.conversation = secrets.token_hex(16)
 
-        self.logger.debug(f"INIT: {snippet}\n\n")
+        self.logger.debug(f"Init: {snippet}\n\n")
 
         self.flow.state.reset()
 

--- a/implementations/python/python/ockam/logging/__init__.py
+++ b/implementations/python/python/ockam/logging/__init__.py
@@ -1,4 +1,4 @@
-from .logging import info, debug, error, warning, set_log_level, set_log_levels, get_logger
+from .logging import info, debug, error, warning, set_log_level, set_log_levels, get_logger, InfoContext, DebugContext
 from .colored_formatter import OckamColoredFormatter
 
 __all__ = [
@@ -11,4 +11,6 @@ __all__ = [
     "get_logger",
     "set_log_level",
     "set_log_levels",
+    "InfoContext",
+    "DebugContext",
 ]

--- a/implementations/python/python/ockam/logging/colored_formatter.py
+++ b/implementations/python/python/ockam/logging/colored_formatter.py
@@ -17,20 +17,22 @@ class OckamColoredFormatter(colorlog.ColoredFormatter):
             record.levelname = f"{self.YELLOW} WARN{self.RESET}"
         return super().format(record)
 
-    def formatTime(self, record, datefmt=None):
+    def formatTime(self, record, datefmt=None) -> str:
         try:
             dt = datetime.fromtimestamp(record.created, UTC)
             if datefmt:
                 return dt.strftime(datefmt)
             return super().formatTime(record, datefmt)
         except Exception:
-            return ""
+            # during shutdown an exception can occur because the time cannot be formatted
+            return f"{record.created}"
 
-    def formatMessage(self, record):
+    def formatMessage(self, record) -> str:
         try:
+            record.name = f"{self.GREY}{record.name}{self.RESET}"
             original_asctime = self.formatTime(record, self.datefmt)
             record.asctime = f"{self.GREY}{original_asctime}{self.RESET}"
-            record.name = f"{self.GREY}{record.name}{self.RESET}"
             return super().formatMessage(record)
         except Exception:
-            return ""
+            # during shutdown an exception can occur because the time cannot be formatted
+            return super().formatMessage(record)

--- a/implementations/python/python/ockam/logging/colored_formatter.py
+++ b/implementations/python/python/ockam/logging/colored_formatter.py
@@ -5,11 +5,17 @@ from datetime import datetime, UTC
 class OckamColoredFormatter(colorlog.ColoredFormatter):
     GREY = "\033[90m"
     CYAN = "\033[36m"
+    YELLOW = "\033[33m"
     RESET = "\033[0m"
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("datefmt", "%Y-%m-%dT%H:%M:%S.%fZ")
         super().__init__(*args, **kwargs)
+
+    def format(self, record):
+        if record.levelname == "WARNING":
+            record.levelname = f"{self.YELLOW} WARN{self.RESET}"
+        return super().format(record)
 
     def formatTime(self, record, datefmt=None):
         try:

--- a/implementations/python/python/ockam/logging/logging.py
+++ b/implementations/python/python/ockam/logging/logging.py
@@ -11,6 +11,14 @@ FORMAT = DEFAULT_LOG_FORMAT + (" [%(pathname)s:%(lineno)d]" if os.getenv("OCKAM_
 
 LOG_LEVELS = {}
 
+LEVELS: dict[str, int] = {
+    "critical": logging.CRITICAL,
+    "error": logging.ERROR,
+    "warning": logging.WARNING,
+    "info": logging.INFO,
+    "debug": logging.DEBUG,
+}
+
 
 def get_logging_config() -> dict[str, int | bool | dict | str | None]:
     # Disable logging if explicitly set to 0; otherwise, assume it's enabled
@@ -74,8 +82,21 @@ def create_logging_config(levels: dict, log_format: str) -> dict[str, int | bool
         "loggers": {
             "asyncio": {"handlers": ["default"], "level": levels.get("asyncio", "WARNING"), "propagate": False},
             "uvicorn": {"handlers": ["default"], "level": levels.get("uvicorn", "WARNING"), "propagate": False},
-            "uvicorn.error": {"handlers": ["default"], "level": levels.get("uvicorn", "WARNING"), "propagate": False},
-            "uvicorn.access": {"handlers": ["default"], "level": levels.get("uvicorn", "WARNING"), "propagate": False},
+            "uvicorn.error": {
+                "handlers": ["default"],
+                "level": levels.get("uvicorn.error", "WARNING"),
+                "propagate": False,
+            },
+            "uvicorn.access": {
+                "handlers": ["default"],
+                "level": levels.get("uvicorn.access", "WARNING"),
+                "propagate": False,
+            },
+            "uvicorn.asgi": {
+                "handlers": ["default"],
+                "level": levels.get("uvicorn.asgi", "WARNING"),
+                "propagate": False,
+            },
             "httpcore": {"handlers": ["default"], "level": levels.get("httpcore", "WARNING"), "propagate": False},
             "httpx": {"handlers": ["default"], "level": levels.get("httpx", "WARNING"), "propagate": False},
             "LiteLLM": {"handlers": ["default"], "level": levels.get("LiteLLM", "WARNING"), "propagate": False},

--- a/implementations/python/python/ockam/logging/logging.py
+++ b/implementations/python/python/ockam/logging/logging.py
@@ -1,5 +1,8 @@
+from contextlib import contextmanager
+
 import os
 import logging.config
+from typing import Protocol
 
 DEFAULT_LOG_FORMAT = os.getenv(
     "DEFAULT_LOG_FORMAT", "%(asctime)s %(log_color)s%(levelname)5s%(reset)s %(name)-14s %(message)s"
@@ -73,7 +76,6 @@ def create_logging_config(levels: dict, log_format: str) -> dict[str, int | bool
             "uvicorn": {"handlers": ["default"], "level": levels.get("uvicorn", "WARNING"), "propagate": False},
             "uvicorn.error": {"handlers": ["default"], "level": levels.get("uvicorn", "WARNING"), "propagate": False},
             "uvicorn.access": {"handlers": ["default"], "level": levels.get("uvicorn", "WARNING"), "propagate": False},
-            "http": {"handlers": ["default"], "level": levels.get("http", "WARNING"), "propagate": False},
             "httpcore": {"handlers": ["default"], "level": levels.get("httpcore", "WARNING"), "propagate": False},
             "httpx": {"handlers": ["default"], "level": levels.get("httpx", "WARNING"), "propagate": False},
             "LiteLLM": {"handlers": ["default"], "level": levels.get("LiteLLM", "WARNING"), "propagate": False},
@@ -87,6 +89,7 @@ def create_logging_config(levels: dict, log_format: str) -> dict[str, int | bool
                 "level": levels.get("model") or levels.get("default"),
                 "propagate": False,
             },
+            "http": {"handlers": ["ockam"], "level": levels.get("http") or levels.get("default"), "propagate": False},
             "node": {"handlers": ["ockam"], "level": levels.get("node") or levels.get("default"), "propagate": False},
             "tool": {"handlers": ["ockam"], "level": levels.get("tool") or levels.get("default"), "propagate": False},
         },
@@ -143,3 +146,31 @@ def debug(msg, *args, **kwargs):
 def error(msg, *args, **kwargs):
     logger = logging.getLogger("node")
     logger.error(msg, stacklevel=2, *args, **kwargs)
+
+
+class LoggerAware(Protocol):
+    logger: logging.Logger
+
+
+class InfoContext(LoggerAware):
+    @contextmanager
+    def info(self, before_msg, after_msg):
+        self.logger.info(before_msg)
+        try:
+            yield
+        except Exception as e:
+            self.logger.info(f"{e}")
+            return
+        self.logger.info(after_msg)
+
+
+class DebugContext(LoggerAware):
+    @contextmanager
+    def debug(self, before_msg, after_msg):
+        self.logger.debug(before_msg)
+        try:
+            yield
+        except Exception as e:
+            self.logger.debug(f"{e}")
+            return
+        self.logger.debug(after_msg)

--- a/implementations/python/python/ockam/models/model.py
+++ b/implementations/python/python/ockam/models/model.py
@@ -10,6 +10,7 @@ import boto3
 import threading
 
 from ..nodes.message import ConversationMessage
+from ..logging.logging import InfoContext, DebugContext
 
 PROVIDER_ALIASES = {
     "litellm_proxy": {
@@ -186,7 +187,7 @@ def construct_bedrock_arn(model_identifier: str, original_name: str) -> Optional
                 return None
 
 
-class Model:
+class Model(InfoContext, DebugContext):
     _logger = None
 
     @classmethod
@@ -227,7 +228,7 @@ class Model:
                 f"Model '{original_name}' (resolved to '{resolved_name}') is not supported or enabled by any configured provider."
             )
 
-        self.logger.debug(f"the resolved model name is '{resolved_name}'")
+        self.logger.debug(f"The resolved model name is '{resolved_name}'")
         self.name = resolved_name
 
         # TODO: test and uncomment
@@ -290,13 +291,15 @@ class Model:
         return "bedrock" not in self.name and "litellm_proxy" not in self.name
 
     async def complete_chat(self, messages: List[dict] | List[ConversationMessage], stream: bool = False, **kwargs):
-        self.logger.info(f"send {len(messages)} messages to model '{self.original_name}'")
-        self.logger.debug(f"the messages are: {messages} (stream={stream})")
+        self.logger.info(f"Processing {len(messages)} messages with model '{self.original_name}'")
+        self.logger.debug(f"Sending the following messages to the model: {messages} (stream={stream})")
 
         messages, kwargs = self.prepare_llm_call(messages, **kwargs)
 
         response = await self.router().acompletion(self.name, messages=messages, stream=stream, **kwargs)
-        self.logger.debug(f"got a response from the model '{self.original_name}': {response}")
+        self.logger.debug(f"Got a response from model '{self.original_name}': {response}")
+        self.logger.info(f"Finished processing messages with model '{self.original_name}'")
+
         return response
 
     async def embeddings(self, text: List[str], **kwargs) -> List[List[float]]:

--- a/implementations/python/python/ockam/nodes/node.py
+++ b/implementations/python/python/ockam/nodes/node.py
@@ -68,15 +68,16 @@ class Node:
             else:
                 asyncio.create_task(http_server.start(node))
 
+            Node.logger().info(f"Started node '{name}'")
             await main(node)
 
         try:
-            Node.logger().info(f"start node '{name}'")
+            Node.logger().info(f"Starting node '{name}'")
             RustNode.start(
                 start_node, name=name, ticket=ticket, allow=allow, cache_secure_channels=cache_secure_channels, **kwargs
             )
         except KeyboardInterrupt:
-            Node.logger().debug("shutting down node due to KeyboardInterrupt")
+            Node.logger().debug("Shutting down node due to KeyboardInterrupt")
             Node.logger().debug(f"\nNode {name} shutting down")
 
 

--- a/implementations/python/python/ockam/tools/tool.py
+++ b/implementations/python/python/ockam/tools/tool.py
@@ -7,9 +7,10 @@ from functools import wraps
 from docstring_parser import parse
 
 from .protocol import InvokableTool
+from ..logging.logging import InfoContext
 
 
-class Tool(InvokableTool):
+class Tool(InvokableTool, InfoContext):
     _logger = None
 
     @classmethod
@@ -36,19 +37,19 @@ class Tool(InvokableTool):
         return self._spec
 
     async def invoke(self, json_argument: Optional[str]) -> str:
-        self.logger.info(f"invoke tool '{self.name}'")
-        self.logger.debug(f"the arguments are: {json_argument}")
-        try:
-            if json_argument is None or json_argument == "":
-                args = {}
-            else:
-                args = json.loads(json_argument)
-            tool_response = str(await self.func(**args))
-            self.logger.debug("the tool call succeeded: {tool_response}")
-        except Exception as e:
-            tool_response = f"the tool call failed with error: {e}"
-            self.logger.error(tool_response)
-        return tool_response
+        with self.info(f"Invoke tool: '{self.name}'", f"invoked tool: '{self.name}'"):
+            self.logger.debug(f"The tool arguments are: {json_argument}")
+            try:
+                if json_argument is None or json_argument == "":
+                    args = {}
+                else:
+                    args = json.loads(json_argument)
+                tool_response = str(await self.func(**args))
+                self.logger.debug(f"The tool call succeeded: {tool_response}")
+            except Exception as e:
+                tool_response = f"The tool call failed with error: {e}"
+                self.logger.error(tool_response)
+            return tool_response
 
 
 def wrap(f) -> callable:


### PR DESCRIPTION
This PR improves a number of log messages. Here is an example of a simple output where we send a message to an agent:

<img width="805" alt="image" src="https://github.com/user-attachments/assets/40e9085b-60dd-41ab-808b-c457ebc9242f" />

Notice that:

 - There's a start/end message for each action.
 - The messages all start with a capital letter.
 - The `WARNING` level from Python is displayed as `WARN` (with the same color that would be used by the rust code). 