### PR TITLE
test: improve bats output for failed tests

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -99,10 +99,14 @@ teardown_home_dir() {
     export OCKAM_HOME="$dir"
     # If BATS_TEST_COMPLETED is not set, the test failed.
     # If BATS_TEST_SKIPPED is not set, then the test was not skipped.
-    if [[ -z "$BATS_TEST_COMPLETED" && -z "$BATS_TEST_SKIPPED" ]]; then
+    if [[ -z "$BATS_TEST_COMPLETED" && -z "$BATS_TEST_SKIPPED" && "$OCKAM_HOME" != "$OCKAM_HOME_BASE" ]]; then
       # Copy the CLI directory to $HOME/.bats-tests so it can be inspected.
       # For some reason, if the directory is moved instead of copied, the teardown function gets stuck.
-      echo "Failed test dir: $OCKAM_HOME" >&3
+      if [[ -z "$FAILED_DIRS" ]]; then
+        FAILED_DIRS="${OCKAM_HOME##*/}"
+      else
+        FAILED_DIRS="$FAILED_DIRS, ${OCKAM_HOME##*/}"
+      fi
       cp -r "$OCKAM_HOME" "$OCKAM_HOME_BASE/.bats-tests"
     fi
     run $OCKAM node delete --all --yes
@@ -115,6 +119,11 @@ teardown_home_dir() {
       rm -f "$pid_file"
     done
   done
+
+  if [[ -n "$FAILED_DIRS" ]]; then
+    echo "   Failed test dirs: $FAILED_DIRS" >&3
+  fi
+
   export OCKAM_HOME=$OCKAM_HOME_BASE
   run $OCKAM node delete --all --yes
 }


### PR DESCRIPTION
```bash
# Before
➜ ORCHESTRATOR_TESTS=1 bats ./orchestrator_enrolled/identity.bats
identity.bats
 ✗ identity - export/import
Failed test dir: /var/folders/5s/mhm0wqk17311zkdgv7v4tgrh0000gn/T/bats-run-5vo09a/file/1/9ab35586a880fd8f
Failed test dir: /var/folders/5s/mhm0wqk17311zkdgv7v4tgrh0000gn/T/bats-run-5vo09a/file/1/5530bcb6103ce15d

# Now
➜ ORCHESTRATOR_TESTS=1 bats ./orchestrator_enrolled/identity.bats
identity.bats
 ✗ identity - export/import
   Failed test dirs: dd69a72f22e83d0b, 75e7430b4c7e0c4a
```