### PR TITLE
feat: just display the log record message on shutdown

### DIFF
--- a/implementations/python/python/ockam/logging/colored_formatter.py
+++ b/implementations/python/python/ockam/logging/colored_formatter.py
@@ -35,4 +35,4 @@ class OckamColoredFormatter(colorlog.ColoredFormatter):
             return super().formatMessage(record)
         except Exception:
             # during shutdown an exception can occur because the time cannot be formatted
-            return super().formatMessage(record)
+            return record.message


### PR DESCRIPTION
Ideally we should spend some time to understand how to emit proper log messages even during shutdown.