### PR TITLE
fix: store user when importing an identity

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/users.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/users.rs
@@ -33,4 +33,17 @@ impl CliState {
             ))?,
         }
     }
+
+    #[instrument(skip_all, level = Level::TRACE)]
+    pub async fn get_user(&self, email: &EmailAddress) -> Result<UserInfo> {
+        let repository = self.users_repository();
+        match repository.get_user(email).await? {
+            Some(user) => Ok(user),
+            None => Err(Error::new(
+                Origin::Api,
+                Kind::NotFound,
+                format!("there is no user with email {email}"),
+            ))?,
+        }
+    }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
@@ -63,6 +63,10 @@ impl InMemoryNode {
         self.node_manager.ctx()
     }
 
+    pub fn name(&self) -> &str {
+        &self.node_manager.node_name
+    }
+
     pub fn state(&self) -> Arc<CliState> {
         self.node_manager.state()
     }

--- a/implementations/rust/ockam/ockam_command/src/identity/export.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/export.rs
@@ -4,6 +4,7 @@ use clap::Args;
 use miette::IntoDiagnostic;
 use ockam::identity::Identity;
 use ockam_api::orchestrator::email_address::EmailAddress;
+use ockam_api::orchestrator::enroll::auth0::UserInfo;
 use ockam_node::Context;
 use ockam_vault::SigningSecret;
 use serde::{Deserialize, Serialize};
@@ -35,6 +36,11 @@ impl Command for ExportCommand {
             .get_identity_enrollment(&identity_name)
             .await?
             .and_then(|i| i.status().email().cloned());
+        let enrolled_user = match enrolled_email.as_ref() {
+            Some(email) => Some(opts.state.get_user(email).await?),
+            None => None,
+        };
+
         let named_identity = opts.state.get_named_identity(&identity_name).await?;
         let named_vault = opts
             .state
@@ -55,8 +61,13 @@ impl Command for ExportCommand {
             .identity_vault
             .export_key(&signing_secret_key_handle)
             .await?;
-        let exported_identity =
-            ExportedIdentity::new(&identity_name, enrolled_email, identity, signing_secret_key)?;
+        let exported_identity = ExportedIdentity::new(
+            &identity_name,
+            enrolled_email,
+            enrolled_user,
+            identity,
+            signing_secret_key,
+        )?;
         let as_string = exported_identity.export()?;
         opts.terminal.to_stdout().machine(as_string).write_line()?;
         Ok(())
@@ -66,7 +77,11 @@ impl Command for ExportCommand {
 #[derive(Serialize, Deserialize)]
 pub(super) struct ExportedIdentity {
     pub name: String,
+    // Kept for backward compatibility
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub enrolled_email: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enrolled_user: Option<String>,
     pub change_history: String,
     signing_secret: String,
     signing_secret_type: u8,
@@ -76,12 +91,16 @@ impl ExportedIdentity {
     pub fn new(
         name: &str,
         enrolled_email: Option<EmailAddress>,
+        enrolled_user: Option<UserInfo>,
         identity: Identity,
         signing_secret: SigningSecret,
     ) -> miette::Result<Self> {
         Ok(ExportedIdentity {
             name: name.to_string(),
             enrolled_email: enrolled_email.map(|e| e.to_string()),
+            enrolled_user: enrolled_user
+                .map(|e| serde_json::to_string(&e).into_diagnostic())
+                .transpose()?,
             change_history: identity.export_as_string()?,
             signing_secret: hex::encode(signing_secret.key()),
             signing_secret_type: signing_secret.type_as_u8(),
@@ -107,5 +126,95 @@ impl ExportedIdentity {
         let key = hex::decode(&self.signing_secret).into_diagnostic()?;
         let key_type = self.signing_secret_type;
         SigningSecret::from_key(&key, key_type).into_diagnostic()
+    }
+
+    pub fn user_email(&self) -> miette::Result<Option<EmailAddress>> {
+        if let Some(email) = &self.enrolled_email {
+            Ok(Some(EmailAddress::parse(email)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn user(&self) -> miette::Result<Option<UserInfo>> {
+        if let Some(user_json) = &self.enrolled_user {
+            let user: UserInfo = serde_json::from_str(user_json).into_diagnostic()?;
+            Ok(Some(user))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_backward_compatibility_missing_enrolled_user() -> miette::Result<()> {
+        let json = r#"{"name":"test","enrolled_email":"user@example.com","change_history":"history","signing_secret":"secret123","signing_secret_type":1}"#;
+        let hex_encoded = hex::encode(json);
+
+        let deserialized = ExportedIdentity::from_hex(&hex_encoded)?;
+        assert_eq!(deserialized.name, "test");
+        assert_eq!(
+            deserialized.enrolled_email,
+            Some("user@example.com".to_string())
+        );
+        assert_eq!(deserialized.enrolled_user, None);
+        assert_eq!(deserialized.change_history, "history");
+        assert_eq!(deserialized.signing_secret, "secret123");
+        assert_eq!(deserialized.signing_secret_type, 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_exported_identity_optional_fields_serialization() -> miette::Result<()> {
+        // Only enrolled_email is defined
+        let identity1 = ExportedIdentity {
+            name: "id1".to_string(),
+            enrolled_email: Some("user@example.com".to_string()),
+            enrolled_user: None,
+            change_history: "history1".to_string(),
+            signing_secret: "secret1".to_string(),
+            signing_secret_type: 1,
+        };
+
+        // Only enrolled_user is defined
+        let identity2 = ExportedIdentity {
+            name: "id2".to_string(),
+            enrolled_email: None,
+            enrolled_user: Some(r#"{"name":"User Name","email":"user@example.com"}"#.to_string()),
+            change_history: "history2".to_string(),
+            signing_secret: "secret2".to_string(),
+            signing_secret_type: 1,
+        };
+
+        // Both enrolled_email and enrolled_user are defined
+        let identity3 = ExportedIdentity {
+            name: "id3".to_string(),
+            enrolled_email: Some("user@example.com".to_string()),
+            enrolled_user: Some(r#"{"name":"User Name","email":"user@example.com"}"#.to_string()),
+            change_history: "history3".to_string(),
+            signing_secret: "secret3".to_string(),
+            signing_secret_type: 1,
+        };
+
+        for identity in [identity1, identity2, identity3] {
+            let serialized = identity.export()?;
+            let deserialized = ExportedIdentity::from_hex(&serialized)?;
+            assert_eq!(identity.name, deserialized.name);
+            assert_eq!(identity.enrolled_email, deserialized.enrolled_email);
+            assert_eq!(identity.enrolled_user, deserialized.enrolled_user);
+            assert_eq!(identity.change_history, deserialized.change_history);
+            assert_eq!(identity.signing_secret, deserialized.signing_secret);
+            assert_eq!(
+                identity.signing_secret_type,
+                deserialized.signing_secret_type
+            );
+        }
+
+        Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/identity/import.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/import.rs
@@ -4,7 +4,6 @@ use colorful::Colorful;
 use ockam_api::cli_state::random_name;
 use ockam_api::colors::color_primary;
 use ockam_api::fmt_ok;
-use ockam_api::orchestrator::email_address::EmailAddress;
 use ockam_node::Context;
 
 use crate::identity::export::ExportedIdentity;
@@ -31,7 +30,8 @@ impl Command for ImportCommand {
         let exported_identity = ExportedIdentity::from_hex(&self.exported)?;
         let signing_secret = exported_identity.signing_secret()?;
         let change_history = exported_identity.hex_decoded_change_history()?;
-        let enrolled_email = exported_identity.enrolled_email;
+        let user_email = exported_identity.user_email()?;
+        let user = exported_identity.user()?;
         let identity_name = if opts
             .state
             .get_named_identity(&exported_identity.name)
@@ -60,10 +60,16 @@ impl Command for ImportCommand {
             .store_named_identity(&identifier, &identity_name, &vault_name)
             .await?;
 
-        if let Some(email) = enrolled_email {
+        if let Some(user_email) = user_email.as_ref() {
             opts.state
-                .set_identifier_as_enrolled(&identifier, &EmailAddress::parse(&email)?)
+                .set_identifier_as_enrolled(&identifier, user_email)
                 .await?;
+        }
+        if let Some(user) = user {
+            opts.state
+                .set_identifier_as_enrolled(&identifier, &user.email)
+                .await?;
+            opts.state.store_user(&user).await?;
         }
 
         opts.terminal

--- a/implementations/rust/ockam/ockam_command/src/status/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/status/mod.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
 use miette::IntoDiagnostic;
+use ockam_api::orchestrator::project::ProjectsOrchestratorApi;
 use serde::Serialize;
 use std::fmt::Display;
 use std::sync::Arc;
@@ -23,7 +24,7 @@ use ockam_api::nodes::models::node::NodeResources;
 use ockam_api::nodes::{BackgroundNodeClient, InMemoryNode};
 use ockam_api::orchestrator::project::models::OrchestratorVersionInfo;
 use ockam_api::orchestrator::project::Project;
-use ockam_api::orchestrator::space::Space;
+use ockam_api::orchestrator::space::{Space, Spaces};
 use ockam_api::output::Output;
 use ockam_api::{fmt_heading, fmt_log, fmt_separator, fmt_warn};
 
@@ -64,15 +65,26 @@ impl InMemoryNodeCommand for StatusNodeCommand {
         let nodes = self
             .command
             .get_nodes_resources(node.ctx(), &self.opts)
-            .await?;
+            .await?
+            .into_iter()
+            .filter(|n| n.name != node.name())
+            .collect::<Vec<_>>();
         let controller = node.create_controller().await?;
         let orchestrator_version = controller
             .get_orchestrator_version_info(node.ctx())
             .await
             .map_err(|e| warn!(%e, "Failed to retrieve orchestrator version"))
             .unwrap_or_default();
-        let spaces = self.opts.state.get_spaces().await?;
-        let projects = self.opts.state.projects().get_projects().await?;
+        let spaces = if let Ok(spaces) = node.get_spaces().await {
+            spaces
+        } else {
+            self.opts.state.get_spaces().await?
+        };
+        let projects = if let Ok(projects) = node.get_admin_projects().await {
+            projects
+        } else {
+            self.opts.state.projects().get_projects().await?
+        };
         let status = StatusData::from_parts(
             orchestrator_version,
             spaces,


### PR DESCRIPTION
- `identiy import` is backwards compatible with an exported identity that only contains the user email
- The exported identity now includes the user info, which is necessary to retrieve the associated projects
- Fixes the `status` command to retrieve spaces and projects from the controller if possible, and falls back to reading the data from the database if not. Also, filters out the current temporary node from the shown list of nodes