### PR TITLE
Thinking is normalized and exposed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ vendor
 # examples
 secrets.yaml
 000
+# inference cache
+.recorded_inference

--- a/implementations/python/examples/08.py
+++ b/implementations/python/examples/08.py
@@ -12,8 +12,8 @@ async def main(node):
         node=node,
         name="Assistant",
         instructions="Assistant to solve some complex task ...",
-        model=Model(name="ollama_chat/llama3.2"),
-        planner=CoTPlanner(),
+        model=Model(name="deepseek-r1"),
+        planner=CoTPlanner(model=Model(name="deepseek-r1")),
     )
 
     async for chunk in agent.send_stream("Estimate how many violins are in the world", timeout=60 * 20):
@@ -21,14 +21,20 @@ async def main(node):
             continue
 
         phase = chunk.snippet.messages[-1].phase
+        thinking = chunk.snippet.messages[-1].thinking
         text = chunk.snippet.messages[-1].content
 
-        if phase == Phase.THINKING:
-            print(f"\033[94m{text}\033[0m", end="")  # thinking: blue
-        elif phase == Phase.PLANNING:
-            print(f"\033[92m{text}\033[0m", end="")  # planning: green
-        elif phase == Phase.EXECUTING:
-            print(f"\033[90m{text}\033[0m", end="")  # executing: grey
+        # reasoning is always in italic
+        if phase == Phase.PLANNING:  # planning: green
+            if thinking:
+                print(f"\033[3;92m{text}\033[0m", end="")
+            else:
+                print(f"\033[92m{text}\033[0m", end="")
+        elif phase == Phase.EXECUTING:  # executing: grey
+            if thinking:
+                print(f"\033[3;90m{text}\033[0m", end="")
+            else:
+                print(f"\033[90m{text}\033[0m", end="")
         else:
             raise RuntimeError(f"unknown phase {phase}")
 

--- a/implementations/python/examples/20.py
+++ b/implementations/python/examples/20.py
@@ -1,0 +1,26 @@
+from ockam import Agent, Model, Node
+
+"""
+    This example shows how a thinking model shows the reasoning process.
+"""
+
+
+async def main(node):
+    agent = await Agent.start(
+        node=node,
+        name="assistant",
+        instructions="You are an assistant.",
+        model=Model(name="deepseek-r1"),
+    )
+
+    messages = await agent.send("Create python code that prints 'Hello World'.")
+    for message in messages:
+        if message.thinking:
+            print(f"\033[3;94m{message.content}\033[0m", end="")
+        else:
+            print(f"{message.content}", end="")
+
+
+Node.start(main, wait_until_interrupted=False)
+
+# OCKAM_SQLITE_IN_MEMORY=1 uv run examples/20.py

--- a/implementations/python/python/ockam/agents/agent.py
+++ b/implementations/python/python/ockam/agents/agent.py
@@ -176,7 +176,7 @@ class AgentStateMachine:
             self.scope, self.conversation, self.contextual_knowledge, stream=self.stream
         ):
             if err:
-                yield self.streaming_response.make_snippet(err)
+                yield err
                 self.state = AgentState.FINISHED
                 return
 
@@ -192,10 +192,11 @@ class AgentStateMachine:
                 # Store tool calls for later processing
                 self.tool_calls.extend(model_response.tool_calls)
                 self.state = AgentState.TOOL_CALLING
-            elif finished or not self.stream:
+            elif finished:
                 # either we are streaming and we finished, or we are expecting a single response
                 if self.stream:
-                    yield self.streaming_response.make_snippet(model_response)
+                    if model_response.content or model_response.tool_calls:
+                        yield self.streaming_response.make_snippet(model_response)
                 else:
                     self.whole_response.messages.append(model_response)
 
@@ -208,8 +209,11 @@ class AgentStateMachine:
                         self.state = AgentState.PLANNING
                     return
             else:
-                # Handle streamed response chunk
-                yield self.streaming_response.make_snippet(model_response)
+                if self.stream:
+                    if model_response.content or model_response.tool_calls:
+                        yield self.streaming_response.make_snippet(model_response)
+                else:
+                    self.whole_response.messages.append(model_response)
 
     async def _handle_tool_calling_state(self):
         """Handle the TOOL_CALLING state: Process tool calls from the model response."""
@@ -531,12 +535,13 @@ class Agent(InfoContext, DebugContext):
                         response.tool_calls = list(tool_calls.values())
                         yield None, False, response
 
-                if finished or (delta.content is not None and len(delta.content) > 0):
-                    yield await self.send_response(chunk)
+                async for err, finished, model_response in self.send_response(chunk):
+                    yield err, finished, model_response
         else:
-            yield await self.send_response(response)
+            async for err, finished, model_response in self.send_response(response):
+                yield err, finished, model_response
 
-    async def send_response(self, response) -> (Error | None, int, bool, AssistantMessage):
+    async def send_response(self, response) -> (Optional[Error], int, bool, AssistantMessage):
         """
         This function converts the model response into an AssistantMessage.
         When streaming is used the function also returns a boolean indicating if this is the last part of the response
@@ -544,11 +549,11 @@ class Agent(InfoContext, DebugContext):
         if response is None or not hasattr(response, "choices") or not response.choices:
             e = ValueError(f"The model returned a response with an unexpected structure - {response}")
             error = Error(str(e))
-            return error, None
+            yield error, True, None
 
         choice = response.choices[0]
-        finished = False
         if hasattr(choice, "delta"):
+            finished = False
             delta = choice.delta
             # sometimes the role is not set
             if delta.role is None:
@@ -557,14 +562,28 @@ class Agent(InfoContext, DebugContext):
                 role = delta.role
 
             if choice.finish_reason is not None:
-                self.logger.debug(f"Finished streaming reply with reason {choice.get('finish_reason', 'unknown')}")
+                self.logger.debug(f"Finished streaming reply with reason {choice.finish_reason or 'unknown'}")
                 finished = True
                 response = {"role": role}
             else:
+                if hasattr(delta, "reasoning_content") and delta.reasoning_content:
+                    response = {"role": role, "content": delta.reasoning_content, "thinking": True}
+                    yield None, False, self.converter.conversation_message_from_dict(response)
                 response = {"role": role, "content": delta.content}
             message = delta
         else:
+            finished = True
             message = choice.message
+            if hasattr(message, "reasoning_content") and message.reasoning_content:
+                yield (
+                    None,
+                    False,
+                    self.converter.conversation_message_from_dict(
+                        {"role": message.role, "content": message.reasoning_content, "thinking": True}
+                    ),
+                )
+                message.reasoning_content = ""
+
             response = {"role": message.role, "content": message.content}
 
         if message.tool_calls:
@@ -575,7 +594,8 @@ class Agent(InfoContext, DebugContext):
                 args = tool_call.function.arguments
                 response["tool_calls"].append({"id": id, "function": {"name": name, "arguments": args}})
 
-        return None, finished, self.converter.conversation_message_from_dict(response)
+        if response.get("content") or response.get("tool_calls") or finished:
+            yield None, finished, self.converter.conversation_message_from_dict(response)
 
     async def call_tool(self, tool_call: ToolCall) -> Tuple[Optional[Error], ToolCallResponseMessage]:
         id = tool_call.id

--- a/implementations/python/python/ockam/agents/agent_test.py
+++ b/implementations/python/python/ockam/agents/agent_test.py
@@ -1,8 +1,311 @@
+from copy import deepcopy
+from typing import List
+
 import pytest
 
 from .agent import Agent
+from .. import Node, Tool, CoTPlanner, HttpServer
+from ..nodes.message import Message, ConversationRole, Phase, ToolCall, FunctionToolCall
 
 
 async def test_agent_name():
     with pytest.raises(ValueError):
         await Agent.start(name="!123-abc~", exposed_as="henry", node=None, instructions=None)
+
+
+class Mock:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class ModelSimulator:
+    provided_messages: List[dict]
+    max_input_tokens: int
+
+    def __init__(self, messages: List[dict], max_input_tokens=None):
+        self.provided_messages = messages or []
+        self.max_input_tokens = max_input_tokens
+        self.original_name = "MockModel"
+        self.tool_call_counter = 0
+
+    async def _complete_chat_streaming(self, provided_message: dict):
+        delta = Mock()
+        delta.role = provided_message.get("role", "assistant")
+        delta.content = ""
+
+        for character in provided_message.get("reasoning_content", ""):
+            delta.reasoning_content = str(character)
+            delta.content = None
+            delta.tool_calls = []
+            yield Mock(choices=[Mock(delta=deepcopy(delta), finish_reason=None)])
+
+        for character in provided_message.get("content", ""):
+            delta.content = str(character)
+            delta.reasoning_content = None
+            delta.tool_calls = []
+            yield Mock(choices=[Mock(delta=deepcopy(delta), finish_reason=None)])
+
+        delta.content = ""
+
+        for provided_tool_call in provided_message.get("tool_calls", []):
+            function = Mock()
+            function.name = provided_tool_call["name"]
+            function.arguments = ""
+            tool_call = Mock()
+            tool_call.type = "function"
+            tool_call.id = f"tool_call_{self.tool_call_counter}"
+            tool_call.index = str(self.tool_call_counter)
+            self.tool_call_counter += 1
+            tool_call.function = function
+            delta.tool_calls = [tool_call]
+
+            yield Mock(choices=[Mock(delta=deepcopy(delta), finish_reason=None)])
+            function.name = None
+            tool_call.id = None
+            tool_call.type = None
+
+            for character in provided_tool_call.get("arguments", ""):
+                function.arguments = str(character)
+                yield Mock(choices=[Mock(delta=deepcopy(delta), finish_reason=None)])
+
+        delta.content = None
+        delta.reasoning_content = None
+        delta.tool_calls = []
+        yield Mock(choices=[Mock(delta=deepcopy(delta), finish_reason="stop")])
+
+    async def _complete_chat(self, provided_message: dict):
+        message = Mock()
+        message.content = provided_message.get("content", "")
+        message.reasoning_content = provided_message.get("reasoning_content", "")
+        message.role = provided_message.get("role", "assistant")
+        message.tool_calls = []
+        for tool_call in provided_message.get("tool_calls", []):
+            function = Mock()
+            function.name = tool_call["name"]
+            function.arguments = tool_call["arguments"]
+            tool_call = Mock()
+            tool_call.id = f"tool_call_{len(message.tool_calls)}"
+            tool_call.function = function
+            message.tool_calls.append(tool_call)
+        choice = Mock()
+        choice.message = message
+
+        instance = Mock()
+        instance.choices = [choice]
+        return instance
+
+    async def complete_chat(self, messages: List[Message], stream: bool, **kwargs):
+        print(f"MockModel called with messages: {messages}")
+
+        if not self.provided_messages:
+            raise ValueError("MockModel has no more messages to return")
+
+        provided_message = self.provided_messages.pop(0)
+        if stream:
+            return self._complete_chat_streaming(provided_message)
+        else:
+            return await self._complete_chat(provided_message)
+
+    async def embeddings(self, text, **kwargs):
+        return [[0.1, 0.2, 0.3]] * len(text)
+
+
+def weather_tool(argument: str):
+    """
+    Mock tool function that simulates a tool call.
+    """
+    return "sunny"
+
+
+def test_full_flow():
+    Node.start(_test_full_flow, wait_until_interrupted=False, http_server=HttpServer(listen_address="127.0.0.1:0"))
+
+
+async def _test_full_flow(node):
+    planner_model = ModelSimulator(
+        [
+            {
+                "role": "assistant",
+                "reasoning_content": "I'm thinking a lot...",
+                "content": "The plan is to query the weather tool!",
+            }
+        ]
+    )
+
+    agent_model = ModelSimulator(
+        [
+            {"role": "assistant", "tool_calls": [{"name": "weather_tool", "arguments": '{"argument": "Paris"}'}]},
+            {
+                "role": "assistant",
+                "reasoning_content": "I'm thinking that the result is sunny, so I should answer sunny...",
+                "content": "The weather in Paris is sunny!",
+            },
+        ]
+    )
+
+    agent = await Agent.start(
+        node=node,
+        instructions="You are an agent that will test the full flow of an agent!",
+        planner=CoTPlanner(model=planner_model),
+        tools=[Tool(weather_tool)],
+        model=agent_model,
+    )
+
+    messages = await agent.send("What is the weather in Paris?")
+    assert len(messages) == 6
+
+    assert messages[0].role == ConversationRole.USER
+    assert messages[0].content == "I'm thinking a lot..."
+    assert messages[0].phase == Phase.PLANNING
+    assert messages[0].thinking
+
+    assert messages[1].role == ConversationRole.USER
+    assert messages[1].phase == Phase.PLANNING
+    assert messages[1].content == "The plan is to query the weather tool!"
+    assert messages[1].thinking is False
+
+    assert messages[2].role == ConversationRole.ASSISTANT
+    assert messages[2].phase == Phase.EXECUTING
+    assert messages[2].content == ""
+    assert messages[2].tool_calls == [
+        ToolCall(
+            id="tool_call_0",
+            function=FunctionToolCall(name="weather_tool", arguments='{"argument": "Paris"}'),
+            type="function",
+        )
+    ]
+
+    assert messages[3].role == ConversationRole.TOOL
+    assert messages[3].phase == Phase.EXECUTING
+    assert messages[3].name == "weather_tool"
+    assert messages[3].content == "sunny"
+    assert messages[3].tool_call_id == "tool_call_0"
+
+    assert messages[4].role == ConversationRole.ASSISTANT
+    assert messages[4].phase == Phase.EXECUTING
+    assert messages[4].content == "I'm thinking that the result is sunny, so I should answer sunny..."
+    assert messages[4].thinking
+
+    assert messages[5].role == ConversationRole.ASSISTANT
+    assert messages[5].phase == Phase.EXECUTING
+    assert messages[5].content == "The weather in Paris is sunny!"
+    assert messages[5].thinking is False
+
+
+def test_full_flow_streaming():
+    Node.start(
+        _test_full_flow_streaming, wait_until_interrupted=False, http_server=HttpServer(listen_address="127.0.0.1:0")
+    )
+
+
+async def _test_full_flow_streaming(node):
+    planner_model = ModelSimulator(
+        [
+            {
+                "role": "assistant",
+                "reasoning_content": "I'm thinking a lot...",
+                "content": "The plan is to query the weather tool!",
+            }
+        ]
+    )
+
+    agent_model = ModelSimulator(
+        [
+            {"role": "assistant", "tool_calls": [{"name": "weather_tool", "arguments": '{"argument": "Paris"}'}]},
+            {
+                "role": "assistant",
+                "reasoning_content": "I'm thinking that the result is sunny, so I should answer sunny...",
+                "content": "The weather in Paris is sunny!",
+            },
+        ]
+    )
+
+    agent = await Agent.start(
+        node=node,
+        instructions="You are an agent that will test the full flow of an agent!",
+        planner=CoTPlanner(model=planner_model),
+        tools=[Tool(weather_tool)],
+        model=agent_model,
+    )
+
+    chunks = []
+    async for chunk in agent.send_stream("What is the weather in Paris?"):
+        chunks.append(chunk)
+
+    # assemble the messages back
+    messages = []
+
+    # I'm thinking a lot...
+    message = chunks.pop(0).snippet.messages[0]
+    for _ in range(20):
+        message.content += chunks.pop(0).snippet.messages[0].content
+    messages.append(message)
+
+    # The plan is to query the weather tool!
+    message = chunks.pop(0).snippet.messages[0]
+    for _ in range(37):
+        message.content += chunks.pop(0).snippet.messages[0].content
+    messages.append(message)
+
+    # tool call - exposed as a single message
+    messages.append(chunks.pop(0).snippet.messages[0])
+
+    # tool response - exposed as a single message
+    messages.append(chunks.pop(0).snippet.messages[0])
+
+    # I'm thinking that the result is sunny, so I should answer sunny...
+    message = chunks.pop(0).snippet.messages[0]
+    for _ in range(65):
+        message.content += chunks.pop(0).snippet.messages[0].content
+    messages.append(message)
+
+    # The weather in Paris is sunny!
+    message = chunks.pop(0).snippet.messages[0]
+    for _ in range(29):
+        message.content += chunks.pop(0).snippet.messages[0].content
+    messages.append(message)
+
+    # last finished message
+    last_chunk = chunks.pop(0)
+    assert last_chunk.snippet.messages == []
+    assert last_chunk.finished
+
+    assert len(messages) == 6
+
+    assert messages[0].role == ConversationRole.USER
+    assert messages[0].content == "I'm thinking a lot..."
+    assert messages[0].phase == Phase.PLANNING
+    assert messages[0].thinking
+
+    assert messages[1].role == ConversationRole.USER
+    assert messages[1].phase == Phase.PLANNING
+    assert messages[1].content == "The plan is to query the weather tool!"
+    assert messages[1].thinking is False
+
+    assert messages[2].role == ConversationRole.ASSISTANT
+    assert messages[2].phase == Phase.EXECUTING
+    assert messages[2].content == ""
+    assert messages[2].tool_calls == [
+        ToolCall(
+            id="tool_call_0",
+            function=FunctionToolCall(name="weather_tool", arguments='{"argument": "Paris"}'),
+            type="function",
+        )
+    ]
+
+    assert messages[3].role == ConversationRole.TOOL
+    assert messages[3].phase == Phase.EXECUTING
+    assert messages[3].name == "weather_tool"
+    assert messages[3].content == "sunny"
+    assert messages[3].tool_call_id == "tool_call_0"
+
+    assert messages[4].role == ConversationRole.ASSISTANT
+    assert messages[4].phase == Phase.EXECUTING
+    assert messages[4].content == "I'm thinking that the result is sunny, so I should answer sunny..."
+    assert messages[4].thinking
+
+    assert messages[5].role == ConversationRole.ASSISTANT
+    assert messages[5].phase == Phase.EXECUTING
+    assert messages[5].content == "The weather in Paris is sunny!"
+    assert messages[5].thinking is False

--- a/implementations/python/python/ockam/models/model.py
+++ b/implementations/python/python/ockam/models/model.py
@@ -345,9 +345,7 @@ class Model(InfoContext, DebugContext):
                     if chunk.choices[0].finish_reason:
                         break
 
-                os.makedirs(".recorded_inference", exist_ok=True)
-                with open(file, "wb") as f:
-                    f.write(dill.dumps(chunks))
+                await self._store_cache(file, chunks)
             else:
                 chunks = await self.router().acompletion(self.name, messages=messages, stream=True, **kwargs)
 
@@ -389,9 +387,7 @@ class Model(InfoContext, DebugContext):
         self.logger.info(f"Finished processing messages with model '{self.original_name}'")
 
         if _cache_inference:
-            os.makedirs(".recorded_inference", exist_ok=True)
-            with open(file, "wb") as f:
-                f.write(dill.dumps(response))
+            await self._store_cache(file, response)
 
         end_think_tag = response.choices[0].message.content.find("</think>")
         if end_think_tag != -1:
@@ -423,6 +419,11 @@ class Model(InfoContext, DebugContext):
                 f.write(dill.dumps(embedding))
 
         return [embedding["embedding"] for embedding in embedding.data]
+
+    async def _store_cache(self, file, data):
+        os.makedirs(".recorded_inference", exist_ok=True)
+        with open(file, "wb") as f:
+            f.write(dill.dumps(data))
 
     def _hash_completion_request(self, model_name: str, messages: List[dict], stream: bool, kwargs: dict) -> str:
         request = json.dumps({"model": model_name, "messages": messages, "stream": stream, **kwargs}, sort_keys=True)

--- a/implementations/python/python/ockam/models/model.py
+++ b/implementations/python/python/ockam/models/model.py
@@ -272,14 +272,18 @@ class Model(InfoContext, DebugContext):
                             f"Failed to obtain/create inference profile ARN for model_identifier: {model_identifier}. Model will be called directly."
                         )
 
-    def count_tokens(self, messages: List[dict] | List[ConversationMessage], tools) -> int:
-        messages, kwargs = self.prepare_llm_call(messages)
+    def count_tokens(
+        self, messages: List[dict] | List[ConversationMessage], is_thinking: bool = False, tools=None
+    ) -> int:
+        messages, kwargs = self.prepare_llm_call(messages, is_thinking)
 
         # FIXME: Do kwargs we provide to acompletion could potentially affect this calculation?
         return litellm.token_counter(self.name, messages=messages, tools=tools)
 
-    def prepare_llm_call(self, messages: List[dict] | List[ConversationMessage], **kwargs):
-        messages = normalize_messages(messages, self.support_tools(), self.support_forced_assistant_answer())
+    def prepare_llm_call(self, messages: List[dict] | List[ConversationMessage], is_thinking: bool, **kwargs):
+        messages = normalize_messages(
+            messages, is_thinking, self.support_tools(), self.support_forced_assistant_answer()
+        )
 
         # parameters provided in kwargs will override the default parameters
         kwargs = {**self.kwargs, **kwargs}
@@ -298,59 +302,104 @@ class Model(InfoContext, DebugContext):
     def support_forced_assistant_answer(self):
         return "bedrock" not in self.name and "litellm_proxy" not in self.name
 
-    async def complete_chat(self, messages: List[dict] | List[ConversationMessage], stream: bool = False, **kwargs):
+    async def complete_chat(
+        self,
+        messages: List[dict] | List[ConversationMessage],
+        stream: bool = False,
+        is_thinking: bool = False,
+        **kwargs,
+    ):
+        """
+        Send a chat completion request to the model.
+
+        :param messages: List of messages to send to the model. Each message should be a dictionary with 'role' and 'content' keys.
+        :param stream: When True, the response will be streamed back as it is generated. If False, the full response will be returned at once.
+        :param is_thinking: Must be true when the thinking has already started but not completed yet.
+        :param kwargs: Additional parameters to pass to the model, such as temperature, max_tokens, etc.
+        :rtype The response from the model, either as a full response or a stream of responses.
+        """
         self.logger.info(f"Processing {len(messages)} messages with model '{self.original_name}'")
         self.logger.debug(f"Sending the following messages to the model: {messages} (stream={stream})")
 
-        messages, kwargs = self.prepare_llm_call(messages, **kwargs)
+        messages, kwargs = self.prepare_llm_call(messages, is_thinking, **kwargs)
 
         if stream:
-            return self._complete_chat_stream(messages, **kwargs)
+            return self._complete_chat_stream(messages, is_thinking, **kwargs)
         else:
             return await self._complete_chat(messages, **kwargs)
 
-    async def _complete_chat_stream(self, messages: List[dict], **kwargs):
+    async def _complete_chat_stream(self, messages: List[dict], is_thinking: bool, **kwargs):
+        chunks = None
+
         if _cache_inference:
             request_hash = self._hash_completion_request(self.name, messages, stream=True, kwargs=kwargs)
             file = f".recorded_inference/{request_hash}.dill"
             if os.path.exists(file):
                 chunks = dill.load(open(file, "rb"))
-                for chunk in chunks:
+
+        if chunks is None:
+            if _cache_inference:
+                chunks = []
+                async for chunk in await self.router().acompletion(self.name, messages=messages, stream=True, **kwargs):
+                    chunks.append(chunk)
+                    if chunk.choices[0].finish_reason:
+                        break
+
+                os.makedirs(".recorded_inference", exist_ok=True)
+                with open(file, "wb") as f:
+                    f.write(dill.dumps(chunks))
+            else:
+                chunks = await self.router().acompletion(self.name, messages=messages, stream=True, **kwargs)
+
+        # convert chunks to an async generator if they are a list
+        if type(chunks) is list:
+            chunk_list = chunks
+
+            async def chunk_generator():
+                for chunk in chunk_list:
                     yield chunk
-                return
 
-        if _cache_inference:
-            chunks = []
-            async for chunk in await self.router().acompletion(self.name, messages=messages, stream=True, **kwargs):
-                chunks.append(chunk)
-                if chunk.choices[0].finish_reason:
-                    break
+            chunks = chunk_generator()
 
-            os.makedirs(".recorded_inference", exist_ok=True)
-            with open(file, "wb") as f:
-                f.write(dill.dumps(chunks))
+        async for chunk in chunks:
+            if chunk.choices[0].delta.content and "<think>" in chunk.choices[0].delta.content:
+                is_thinking = True
+                chunk.choices[0].delta.content = chunk.choices[0].delta.content.replace("<think>", "")
 
-            for chunk in chunks:
-                yield chunk
-        else:
-            await self.router().acompletion(self.name, messages=messages, stream=True, **kwargs)
+            if chunk.choices[0].delta.content and "</think>" in chunk.choices[0].delta.content:
+                is_thinking = False
+                chunk.choices[0].delta.content = chunk.choices[0].delta.content.replace("</think>", "")
+
+            if is_thinking:
+                chunk.choices[0].delta.reasoning_content = chunk.choices[0].delta.content
+                chunk.choices[0].delta.content = None
+            yield chunk
 
     async def _complete_chat(self, messages: List[dict], **kwargs):
+        response = None
         if _cache_inference:
             request_hash = self._hash_completion_request(self.name, messages, False, kwargs)
             file = f".recorded_inference/{request_hash}.dill"
             if os.path.exists(file):
                 response = dill.load(open(file, "rb"))
-                return response
 
-        response = await self.router().acompletion(self.name, messages=messages, stream=False, **kwargs)
-        self.logger.debug(f"Got a response from model '{self.original_name}': {response}")
+        if response is None:
+            response = await self.router().acompletion(self.name, messages=messages, stream=False, **kwargs)
+            self.logger.debug(f"Got a response from model '{self.original_name}': {response}")
         self.logger.info(f"Finished processing messages with model '{self.original_name}'")
 
         if _cache_inference:
             os.makedirs(".recorded_inference", exist_ok=True)
             with open(file, "wb") as f:
                 f.write(dill.dumps(response))
+
+        end_think_tag = response.choices[0].message.content.find("</think>")
+        if end_think_tag != -1:
+            thinking_content = response.choices[0].message.content[:end_think_tag].replace("<think>", "")
+            non_thinking_content = response.choices[0].message.content[end_think_tag + len("</think>") :]
+
+            response.choices[0].message.reasoning_content = thinking_content
+            response.choices[0].message.content = non_thinking_content
 
         return response
 
@@ -390,7 +439,10 @@ class Model(InfoContext, DebugContext):
 
 
 def normalize_messages(
-    messages: List[dict] | List[ConversationMessage], tools_supported: bool, forced_assistant_answer_supported: bool
+    messages: List[dict] | List[ConversationMessage],
+    is_thinking: bool,
+    tools_supported: bool,
+    forced_assistant_answer_supported: bool,
 ) -> List[dict]:
     messages = deepcopy(messages)
 
@@ -412,6 +464,13 @@ def normalize_messages(
     for message in messages:
         if "content" in message and len(message["content"]) == 0:
             del message["content"]
+
+    # remove extra fields: phase and thinking
+    for message in messages:
+        if "phase" in message:
+            del message["phase"]
+        if "thinking" in message:
+            del message["thinking"]
 
     if tools_supported:
         for message in messages:
@@ -475,5 +534,12 @@ def normalize_messages(
     # force_assistant_answer is not supported
     if not forced_assistant_answer_supported and len(messages) > 0 and messages[-1]["role"] == "assistant":
         messages[-1]["role"] = "user"
+
+    # if thinking, we need to add <think> tag at the beginning of the last message
+    if is_thinking and len(messages) > 0:
+        if "content" in messages[-1]:
+            messages[-1]["content"] = "<think>" + messages[-1]["content"]
+        else:
+            messages[-1]["content"] = "<think>"
 
     return messages

--- a/implementations/python/python/ockam/models/model.py
+++ b/implementations/python/python/ockam/models/model.py
@@ -5,6 +5,9 @@ from litellm import Router
 
 from copy import deepcopy
 
+import hashlib
+import dill
+import json
 import os
 import boto3
 import threading
@@ -102,6 +105,11 @@ init_lock = threading.Lock()
 _inference_profile_cache = {}
 _cache_lock = threading.Lock()
 
+# CACHE_INFERENCE is an environment variable that allows caching of inference results, it's meant
+# to be used in development and testing environments.
+# During streaming inference, the results will be consumed, cached and then returned at once, so that
+# any error during the execution will not cause the response to be lost.
+_cache_inference = os.environ.get("CACHE_INFERENCE", "").lower() in ["1", "true", "yes", "on"]
 
 # slightly modify the parameters to accommodate services
 litellm.modify_params = True
@@ -296,9 +304,53 @@ class Model(InfoContext, DebugContext):
 
         messages, kwargs = self.prepare_llm_call(messages, **kwargs)
 
-        response = await self.router().acompletion(self.name, messages=messages, stream=stream, **kwargs)
+        if stream:
+            return self._complete_chat_stream(messages, **kwargs)
+        else:
+            return await self._complete_chat(messages, **kwargs)
+
+    async def _complete_chat_stream(self, messages: List[dict], **kwargs):
+        if _cache_inference:
+            request_hash = self._hash_completion_request(self.name, messages, stream=True, kwargs=kwargs)
+            file = f".recorded_inference/{request_hash}.dill"
+            if os.path.exists(file):
+                chunks = dill.load(open(file, "rb"))
+                for chunk in chunks:
+                    yield chunk
+                return
+
+        if _cache_inference:
+            chunks = []
+            async for chunk in await self.router().acompletion(self.name, messages=messages, stream=True, **kwargs):
+                chunks.append(chunk)
+                if chunk.choices[0].finish_reason:
+                    break
+
+            os.makedirs(".recorded_inference", exist_ok=True)
+            with open(file, "wb") as f:
+                f.write(dill.dumps(chunks))
+
+            for chunk in chunks:
+                yield chunk
+        else:
+            await self.router().acompletion(self.name, messages=messages, stream=True, **kwargs)
+
+    async def _complete_chat(self, messages: List[dict], **kwargs):
+        if _cache_inference:
+            request_hash = self._hash_completion_request(self.name, messages, False, kwargs)
+            file = f".recorded_inference/{request_hash}.dill"
+            if os.path.exists(file):
+                response = dill.load(open(file, "rb"))
+                return response
+
+        response = await self.router().acompletion(self.name, messages=messages, stream=False, **kwargs)
         self.logger.debug(f"Got a response from model '{self.original_name}': {response}")
         self.logger.info(f"Finished processing messages with model '{self.original_name}'")
+
+        if _cache_inference:
+            os.makedirs(".recorded_inference", exist_ok=True)
+            with open(file, "wb") as f:
+                f.write(dill.dumps(response))
 
         return response
 
@@ -306,8 +358,30 @@ class Model(InfoContext, DebugContext):
         # parameters provided in kwargs will override the default parameters
         kwargs = {**self.kwargs, **kwargs}
 
+        if _cache_inference:
+            request_hash = self._hash_embedding_request(self.name, text, kwargs)
+            file = f".recorded_inference/{request_hash}.dill"
+            if os.path.exists(file):
+                embedding = dill.load(open(file, "rb"))
+                return [embedding["embedding"] for embedding in embedding.data]
+
         embedding = await self.router().aembedding(self.name, text, **kwargs)
+
+        if _cache_inference:
+            os.makedirs(".recorded_inference", exist_ok=True)
+            request_hash = self._hash_embedding_request(self.name, text, kwargs)
+            with open(f".recorded_inference/{request_hash}.dill", "wb") as f:
+                f.write(dill.dumps(embedding))
+
         return [embedding["embedding"] for embedding in embedding.data]
+
+    def _hash_completion_request(self, model_name: str, messages: List[dict], stream: bool, kwargs: dict) -> str:
+        request = json.dumps({"model": model_name, "messages": messages, "stream": stream, **kwargs}, sort_keys=True)
+        return hashlib.sha256(request.encode("utf-8")).hexdigest()
+
+    def _hash_embedding_request(self, model_name: str, text: List[str], kwargs: dict) -> str:
+        request = json.dumps({"model": model_name, "text": text, **kwargs}, sort_keys=True)
+        return hashlib.sha256(request.encode("utf-8")).hexdigest()
 
     def router(self):
         global router

--- a/implementations/python/python/ockam/models/test_normalize_messages.py
+++ b/implementations/python/python/ockam/models/test_normalize_messages.py
@@ -8,7 +8,9 @@ def test_conversion_from_conversation_message():
         UserMessage("hello"),
         AssistantMessage("hello user!"),
     ]
-    result = normalize_messages(messages, tools_supported=True, forced_assistant_answer_supported=True)
+    result = normalize_messages(
+        messages, is_thinking=False, tools_supported=True, forced_assistant_answer_supported=True
+    )
     assert all(isinstance(m, dict) for m in result)
     assert len(result) == 3
     assert result[0]["role"] == "system"
@@ -21,7 +23,9 @@ def test_conversion_from_conversation_message():
 
 def test_removal_of_empty_content():
     messages = [{"role": "user", "content": ""}, {"role": "assistant", "content": "hi"}]
-    result = normalize_messages(messages, tools_supported=True, forced_assistant_answer_supported=True)
+    result = normalize_messages(
+        messages, is_thinking=False, tools_supported=True, forced_assistant_answer_supported=True
+    )
     assert all("content" in m for m in result)
     assert len(result) == 1
     assert result[0]["role"] == "assistant"
@@ -29,7 +33,9 @@ def test_removal_of_empty_content():
 
 def test_removal_of_empty_tool_calls_tools_supported():
     messages = [{"role": "assistant", "content": "hi", "tool_calls": []}]
-    result = normalize_messages(messages, tools_supported=True, forced_assistant_answer_supported=True)
+    result = normalize_messages(
+        messages, is_thinking=False, tools_supported=True, forced_assistant_answer_supported=True
+    )
     assert "tool_calls" not in result[0]
 
 
@@ -40,7 +46,9 @@ def test_tool_role_conversion_and_tool_calls_removal():
         {"role": "tool", "content": "output", "name": "toolname"},
     ]
     # Only the last message has a name, so only it should remain, and its role should be 'assistant'
-    result = normalize_messages(messages, tools_supported=False, forced_assistant_answer_supported=True)
+    result = normalize_messages(
+        messages, is_thinking=False, tools_supported=False, forced_assistant_answer_supported=True
+    )
     assert len(result) == 1
     assert result[0]["role"] == "assistant"
     assert "tool_calls" not in result[0]
@@ -51,7 +59,9 @@ def test_removal_of_scope_and_conversation():
         {"role": "user", "content": "hi", "scope": "abc", "conversation": "xyz"},
         {"role": "assistant", "content": "ok"},
     ]
-    result = normalize_messages(messages, tools_supported=True, forced_assistant_answer_supported=True)
+    result = normalize_messages(
+        messages, is_thinking=False, tools_supported=True, forced_assistant_answer_supported=True
+    )
     assert all("scope" not in m and "conversation" not in m for m in result)
 
 
@@ -67,7 +77,9 @@ def test_filtering_of_useless_messages():
         {"role": "assistant", "content": "ok"},  # valid
         {"role": "assistant", "tool_calls": [1]},  # valid
     ]
-    result = normalize_messages(messages, tools_supported=True, forced_assistant_answer_supported=True)
+    result = normalize_messages(
+        messages, is_thinking=False, tools_supported=True, forced_assistant_answer_supported=True
+    )
     roles = [m["role"] for m in result]
     assert roles == ["tool", "user", "assistant", "assistant"]
 
@@ -78,26 +90,34 @@ def test_message_with_content_and_tool_calls():
         {"role": "assistant", "tool_calls": [2]},
         {"role": "assistant", "content": "foo"},
     ]
-    result = normalize_messages(messages, tools_supported=True, forced_assistant_answer_supported=True)
+    result = normalize_messages(
+        messages, is_thinking=False, tools_supported=True, forced_assistant_answer_supported=True
+    )
     assert len(result) == 3
     assert all(m["role"] == "assistant" for m in result)
 
 
 def test_empty_input():
-    assert normalize_messages([], tools_supported=True, forced_assistant_answer_supported=True) == []
-    assert normalize_messages([], tools_supported=False, forced_assistant_answer_supported=False) == []
+    assert normalize_messages([], is_thinking=False, tools_supported=True, forced_assistant_answer_supported=True) == []
+    assert (
+        normalize_messages([], is_thinking=False, tools_supported=False, forced_assistant_answer_supported=False) == []
+    )
 
 
 def test_tool_calls_preserved_when_not_empty():
     messages = [{"role": "assistant", "content": "hi", "tool_calls": [1, 2]}]
-    result = normalize_messages(messages, tools_supported=True, forced_assistant_answer_supported=True)
+    result = normalize_messages(
+        messages, is_thinking=False, tools_supported=True, forced_assistant_answer_supported=True
+    )
     assert "tool_calls" in result[0]
     assert result[0]["tool_calls"] == [1, 2]
 
 
 def test_tool_calls_removed_when_tools_not_supported():
     messages = [{"role": "assistant", "content": "hi", "tool_calls": [1, 2]}]
-    result = normalize_messages(messages, tools_supported=False, forced_assistant_answer_supported=True)
+    result = normalize_messages(
+        messages, is_thinking=False, tools_supported=False, forced_assistant_answer_supported=True
+    )
     assert "tool_calls" not in result[0]
 
 
@@ -107,7 +127,9 @@ def test_scope_and_conversation_only_removed():
         {"role": "assistant", "conversation": "xyz"},
         {"role": "user", "content": "hi", "scope": "abc", "conversation": "xyz"},
     ]
-    result = normalize_messages(messages, tools_supported=True, forced_assistant_answer_supported=True)
+    result = normalize_messages(
+        messages, is_thinking=False, tools_supported=True, forced_assistant_answer_supported=True
+    )
     assert all("scope" not in m and "conversation" not in m for m in result)
     assert len(result) == 1
     assert result[0]["content"] == "hi"
@@ -118,7 +140,9 @@ def test_system_message_with_content_kept():
         {"role": "system", "content": "instructions"},
         {"role": "system"},
     ]
-    result = normalize_messages(messages, tools_supported=True, forced_assistant_answer_supported=True)
+    result = normalize_messages(
+        messages, is_thinking=False, tools_supported=True, forced_assistant_answer_supported=True
+    )
     assert len(result) == 1
     assert result[0]["role"] == "system"
     assert result[0]["content"] == "instructions"
@@ -129,7 +153,9 @@ def test_tool_message_with_name_kept():
         {"role": "tool", "name": "toolname"},
         {"role": "tool"},
     ]
-    result = normalize_messages(messages, tools_supported=True, forced_assistant_answer_supported=True)
+    result = normalize_messages(
+        messages, is_thinking=False, tools_supported=True, forced_assistant_answer_supported=True
+    )
     assert len(result) == 1
     assert result[0]["role"] == "tool"
     assert result[0]["name"] == "toolname"
@@ -145,7 +171,9 @@ def test_compacts_consecutive_messages_with_same_role_and_fields():
         {"role": "user", "content": "bar", "foo": 1},
         {"role": "user", "content": "baz", "foo": 2},
     ]
-    result = normalize_messages(messages, tools_supported=True, forced_assistant_answer_supported=True)
+    result = normalize_messages(
+        messages, is_thinking=False, tools_supported=True, forced_assistant_answer_supported=True
+    )
     assert len(result) == 4
     assert result[0]["content"] == "helloworld"
     assert result[1]["content"] == "hithere"
@@ -158,10 +186,32 @@ def test_last_message_assistant_without_forced_answer():
         {"role": "assistant", "content": "Create me a new recipe for a cake."},
         {"role": "assistant", "content": "First we need to gather ingredients, such as"},
     ]
-    result = normalize_messages(messages, tools_supported=True, forced_assistant_answer_supported=True)
+    result = normalize_messages(
+        messages, is_thinking=False, tools_supported=True, forced_assistant_answer_supported=True
+    )
     assert len(result) == 1
     assert result[0]["role"] == "assistant"
 
-    result = normalize_messages(messages, tools_supported=True, forced_assistant_answer_supported=False)
+    result = normalize_messages(
+        messages, is_thinking=False, tools_supported=True, forced_assistant_answer_supported=False
+    )
     assert len(result) == 1
     assert result[0]["role"] == "user"
+
+
+def test_is_thinking_adds_think_tag():
+    messages = [
+        {"role": "user", "content": "What is the capital of France?"},
+        {"role": "assistant", "content": "Let me think..."},
+    ]
+
+    result = normalize_messages(
+        messages, is_thinking=True, tools_supported=True, forced_assistant_answer_supported=True
+    )
+
+    assert len(result) == 2
+    assert result[0]["role"] == "user"
+    assert result[0]["content"] == "What is the capital of France?"
+
+    assert result[1]["role"] == "assistant"
+    assert result[1]["content"] == "<think>Let me think..."

--- a/implementations/python/python/ockam/nodes/message.py
+++ b/implementations/python/python/ockam/nodes/message.py
@@ -5,7 +5,7 @@ import secrets
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Union, Any, Optional
+from typing import Union, Any, Optional, List, AsyncGenerator
 
 from .local import LocalNodeProtocol
 from .remote import RemoteNode
@@ -35,7 +35,6 @@ class ToolCall:
 
 
 class Phase(Enum):
-    THINKING = "thinking"
     PLANNING = "planning"
     EXECUTING = "executing"
 
@@ -44,6 +43,7 @@ class Phase(Enum):
 class UserMessage:
     content: str = ""
     phase: Phase = Phase.EXECUTING
+    thinking: bool = False
     role: ConversationRole = ConversationRole.USER
 
 
@@ -57,6 +57,7 @@ class SystemMessage:
 class AssistantMessage:
     content: str = ""
     phase: Phase = Phase.EXECUTING
+    thinking: bool = False
     role: ConversationRole = ConversationRole.ASSISTANT
     tool_calls: list[ToolCall] = field(default_factory=list)
 
@@ -94,6 +95,99 @@ class ReceiveReference:
         return response.messages
 
 
+class MessageType(Enum):
+    CONVERSATION_SNIPPET = "conversation_snippet"
+    STREAMED_CONVERSATION_SNIPPET = "streamed_conversation_snippet"
+    GET_IDENTIFIER_REQUEST = "get_identifier_request"
+    GET_IDENTIFIER_RESPONSE = "get_identifier_response"
+    GET_CONVERSATIONS_REQUEST = "get_conversations_request"
+    GET_CONVERSATIONS_RESPONSE = "get_conversations_response"
+    ERROR = "error"
+
+
+@dataclass
+class GetIdentifierRequest:
+    scope: str
+    conversation: str
+    type: MessageType = MessageType.GET_IDENTIFIER_REQUEST
+
+
+@dataclass
+class GetIdentifierResponse:
+    scope: str
+    conversation: str
+    identifier: str
+    type: MessageType = MessageType.GET_IDENTIFIER_RESPONSE
+
+
+@dataclass
+class GetConversationsRequest:
+    scope: None | str
+    conversation: None | str
+    type: MessageType = MessageType.GET_CONVERSATIONS_REQUEST
+
+
+@dataclass
+class GetConversationsResponse:
+    conversations: list[dict]
+    type: MessageType = MessageType.GET_CONVERSATIONS_RESPONSE
+
+
+@dataclass
+class Error:
+    message: str
+    type: MessageType = MessageType.ERROR
+
+
+@dataclass
+class ConversationSnippet:
+    scope: str = ""
+    conversation: str = ""
+    messages: List[ConversationMessage] = field(default_factory=list)
+    type: MessageType = MessageType.CONVERSATION_SNIPPET
+
+    def compact_assistant_messages(self):
+        messages = self.messages
+        all_messages = []
+        assistant_message = None
+        for m in messages:
+            if isinstance(m, AssistantMessage):
+                if assistant_message is None:
+                    assistant_message = m
+                else:
+                    assistant_message.content += m.content
+            else:
+                all_messages.append(m)
+
+        if assistant_message is not None:
+            all_messages.append(assistant_message)
+        self.messages = all_messages
+        return self
+
+
+@dataclass
+class StreamedConversationSnippet:
+    snippet: ConversationSnippet
+    part_nb: int = 0
+    finished: bool = False
+    type: MessageType = MessageType.STREAMED_CONVERSATION_SNIPPET
+
+    # This is required to sort the received snippets when they are received out of order.
+    def __lt__(self, other):
+        return self.part_nb < other.part_nb
+
+
+Message = Union[
+    ConversationSnippet,
+    StreamedConversationSnippet,
+    GetIdentifierRequest,
+    GetIdentifierResponse,
+    GetConversationsRequest,
+    GetConversationsResponse,
+    Error,
+]
+
+
 # TODO: There is some overlap in functionality between Reference class and Local/Remote node classes
 class Reference:
     # TODO: Policies
@@ -116,12 +210,14 @@ class Reference:
         response = await self.send_and_receive_request(GetIdentifierRequest(scope, conversation))
         return response.identifier
 
-    async def send(self, message, scope="", conversation="", timeout=None):
+    async def send(self, message, scope="", conversation="", timeout=None) -> List[ConversationMessage]:
         request = ConversationSnippet(scope, conversation, [UserMessage(message)])
         response = await self.send_and_receive_request(request, timeout=timeout)
         return response.messages
 
-    async def send_stream(self, message, scope="", conversation="", timeout=None):
+    async def send_stream(
+        self, message, scope="", conversation="", timeout=None
+    ) -> AsyncGenerator[StreamedConversationSnippet, None]:
         request = StreamedConversationSnippet(ConversationSnippet(scope, conversation, [UserMessage(message)]))
         async for response in self.send_request_stream(request, timeout=timeout):
             yield response
@@ -290,98 +386,6 @@ class SquadReference(Reference):
     ):
         super().__init__(name, node, ReferenceType.SQUAD)
 
-
-class MessageType(Enum):
-    CONVERSATION_SNIPPET = "conversation_snippet"
-    STREAMED_CONVERSATION_SNIPPET = "streamed_conversation_snippet"
-    GET_IDENTIFIER_REQUEST = "get_identifier_request"
-    GET_IDENTIFIER_RESPONSE = "get_identifier_response"
-    GET_CONVERSATIONS_REQUEST = "get_conversations_request"
-    GET_CONVERSATIONS_RESPONSE = "get_conversations_response"
-    ERROR = "error"
-
-
-@dataclass
-class GetIdentifierRequest:
-    scope: str
-    conversation: str
-    type: MessageType = MessageType.GET_IDENTIFIER_REQUEST
-
-
-@dataclass
-class GetIdentifierResponse:
-    scope: str
-    conversation: str
-    identifier: str
-    type: MessageType = MessageType.GET_IDENTIFIER_RESPONSE
-
-
-@dataclass
-class GetConversationsRequest:
-    scope: None | str
-    conversation: None | str
-    type: MessageType = MessageType.GET_CONVERSATIONS_REQUEST
-
-
-@dataclass
-class GetConversationsResponse:
-    conversations: list[dict]
-    type: MessageType = MessageType.GET_CONVERSATIONS_RESPONSE
-
-
-@dataclass
-class Error:
-    message: str
-    type: MessageType = MessageType.ERROR
-
-
-@dataclass
-class ConversationSnippet:
-    scope: str = ""
-    conversation: str = ""
-    messages: list[ConversationMessage] = field(default_factory=list)
-    type: MessageType = MessageType.CONVERSATION_SNIPPET
-
-    def compact_assistant_messages(self):
-        messages = self.messages
-        all_messages = []
-        assistant_message = None
-        for m in messages:
-            if isinstance(m, AssistantMessage):
-                if assistant_message is None:
-                    assistant_message = m
-                else:
-                    assistant_message.content += m.content
-            else:
-                all_messages.append(m)
-
-        if assistant_message is not None:
-            all_messages.append(assistant_message)
-        self.messages = all_messages
-        return self
-
-
-@dataclass
-class StreamedConversationSnippet:
-    snippet: ConversationSnippet
-    part_nb: int = 0
-    finished: bool = False
-    type: MessageType = MessageType.STREAMED_CONVERSATION_SNIPPET
-
-    # This is required to sort the received snippets when they are received out of order.
-    def __lt__(self, other):
-        return self.part_nb < other.part_nb
-
-
-Message = Union[
-    ConversationSnippet,
-    StreamedConversationSnippet,
-    GetIdentifierRequest,
-    GetIdentifierResponse,
-    GetConversationsRequest,
-    GetConversationsResponse,
-    Error,
-]
 
 CACHE = None
 

--- a/implementations/python/python/ockam/planning/cot.py
+++ b/implementations/python/python/ockam/planning/cot.py
@@ -1,6 +1,6 @@
 from typing import Optional, AsyncGenerator
 
-from ockam.nodes.message import ConversationRole, UserMessage, AssistantMessage, Phase
+from ockam.nodes.message import ConversationRole, UserMessage, AssistantMessage
 
 from .protocol import Planner, Plan
 from .utils import complete_think_chat
@@ -72,10 +72,10 @@ Make sure that the last step reaches the goal of the task.
                 AssistantMessage(
                     f"""<think>Alright, so I need to create a plan to address the task: "{self.query}". """
                 ),
-            ]
+            ],
         )
 
-        async for chunk in complete_think_chat(self.model, step_messages, self.stream, Phase.THINKING):
+        async for chunk in complete_think_chat(self.model, step_messages, self.stream):
             yield chunk
 
 

--- a/implementations/python/python/ockam/planning/dynamic.py
+++ b/implementations/python/python/ockam/planning/dynamic.py
@@ -1,7 +1,7 @@
 from typing import Optional, AsyncGenerator
 from .protocol import Planner, Plan
 from .utils import complete_think_chat
-from ..nodes.message import ConversationMessage, SystemMessage, UserMessage, AssistantMessage, ConversationRole, Phase
+from ..nodes.message import ConversationMessage, SystemMessage, UserMessage, AssistantMessage, ConversationRole
 from ..models import Model
 
 
@@ -177,7 +177,6 @@ The key features include a homepage, blog section, about page, and contact form.
             self.model,
             step_messages,
             self.stream,
-            Phase.THINKING,
         ):
             yield chunk
 

--- a/implementations/python/python/ockam/planning/utils.py
+++ b/implementations/python/python/ockam/planning/utils.py
@@ -2,51 +2,34 @@ from ..models import Model
 from ockam.nodes.message import Phase, UserMessage
 
 
-async def complete_think_chat(model: Model, step_messages: list, stream: bool, initial_phase: Phase = Phase.PLANNING):
-    expect_reasoning_content = False
-    phase = initial_phase
+async def complete_think_chat(model: Model, step_messages: list, stream: bool):
+    thinking = False
     if stream:
         async for chunk in await model.complete_chat(
             messages=step_messages,
+            is_thinking=True,
             temperature=0,
             stream=True,
         ):
             content = chunk.choices[0].delta.content
-            if content is not None:
-                if "<think>" in content:
-                    phase = Phase.THINKING
-                if "</think>" in content:
-                    phase = Phase.PLANNING
-                content = content.replace("<think>", "").replace("</think>", "")
 
-            if expect_reasoning_content and not hasattr(chunk.choices[0].delta, "reasoning_content"):
-                phase = Phase.PLANNING
-
-            if (
-                hasattr(chunk.choices[0].delta, "reasoning_content")
-                and len(chunk.choices[0].delta.reasoning_content) > 0
-            ):
-                expect_reasoning_content = True
-                phase = Phase.THINKING
+            if hasattr(chunk.choices[0].delta, "reasoning_content") and chunk.choices[0].delta.reasoning_content:
+                thinking = True
                 content = chunk.choices[0].delta.reasoning_content
+            else:
+                thinking = False
 
             if content is not None and len(content) > 0:
-                yield UserMessage(content, phase=phase)
+                yield UserMessage(content, phase=Phase.PLANNING, thinking=thinking)
     else:
         response = await model.complete_chat(
             messages=step_messages,
             temperature=0,
             stream=False,
         )
-        text = response.choices[0].message.content
-        if "</think>" in text:
-            pieces = text.split("</think>")
-            think_text = pieces[0].replace("<think>", "")
-            yield UserMessage(think_text, phase=Phase.THINKING)
-            text = pieces[1]
+        message = response.choices[0].message
 
-        if hasattr(response, "reasoning_content") and len(response.reasoning_content) > 0:
-            reasoning_content = response.reasoning_content
-            yield UserMessage(reasoning_content, phase=Phase.THINKING)
+        if hasattr(message, "reasoning_content") and message.reasoning_content:
+            yield UserMessage(message.reasoning_content, phase=Phase.PLANNING, thinking=True)
 
-        yield UserMessage(text, phase=Phase.PLANNING)
+        yield UserMessage(message.content, phase=Phase.PLANNING, thinking=False)


### PR DESCRIPTION
`<think>` tag normalization responsibility has been moved to the model, the calling code will always expect `reasoning_content`.
The exposed field is called `thinking`, and it's a boolean that can be present in any message.

It's possible to specify `CACHE_INFERENCE` environment variable to enable inference cache, this is meant to help developers and should not be used in production.

Agent has now `test_full_flow` and `test_full_flow_streaming`, that test the majority of agent flow except memory.

