### PR TITLE
feat: add timeout to `zone inlet/outlet` creation when waiting for the portal to be up

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -259,7 +259,7 @@ pub async fn wait_for_node_callback_process(
     );
     tokio::select! {
         res = handle.wait() => {
-            trace!(?res, "node output drained");
+            trace!(?res, "node process exited");
             let status = res.into_diagnostic()?;
             if !status.success() {
                 std::process::exit(status.code().unwrap_or(1));
@@ -282,7 +282,7 @@ pub async fn wait_for_node_callback_future(
     );
     tokio::select! {
         res = handle => {
-            trace!(?res, "node output drained");
+            trace!(?res, "node process exited");
             res.into_diagnostic()?
         }
         res = node_callback.wait_for_signal() => {

--- a/implementations/rust/ockam/ockam_command/src/zone/attach.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/attach.rs
@@ -2,9 +2,7 @@ use crate::cluster::common_args::HttpApiArgs;
 use crate::entry_point::RUNTIME;
 use crate::node_command::InMemoryNodeCommand;
 use crate::util::port_is_free_guard;
-use crate::zone::common_args::{
-    EnrollmentTicketConfigArg, ZoneConfigArg, ZoneInletsArgs, ZoneNameOrConfigArg,
-};
+use crate::zone::common_args::{ZoneConfigArg, ZoneInletsArgs, ZoneNameOrConfigArg};
 use crate::zone::ctrlc::ZoneCtrlcHandler;
 use crate::zone::get_cluster_name::GetClusterName;
 use crate::zone::repl::ReplCommand;
@@ -200,9 +198,6 @@ impl AttachCommand {
             zone: ZoneNameOrConfigArg::from_zone_name(zone_name.to_string()),
             http_api: self.http_api.clone(),
             pod: Some(pod_name.to_string()),
-            enrollment_ticket: EnrollmentTicketConfigArg {
-                enrollment_ticket: None,
-            },
             from: Some(from.clone()),
             to: Some(to.to_string()),
             background: true,

--- a/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
@@ -155,7 +155,7 @@ pub struct EnrollmentTicketConfigArg {
     #[arg(long, env = "ENROLLMENT_TICKET", value_name = "ENROLLMENT TICKET")]
     #[arg(help = docs::about("\
     A path, URL or inlined hex-encoded enrollment ticket to use for the Ockam Identity associated to this node. \
-    If ommited one will be created automatically with default attributes
+    If omitted, one will be created automatically with default attributes
     "))]
     pub enrollment_ticket: Option<String>,
 }

--- a/implementations/rust/ockam/ockam_command/src/zone/inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/inlet.rs
@@ -20,6 +20,7 @@ use ockam_api::CliState;
 use ockam_node::Context;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 const LONG_ABOUT: &str = include_str!("./static/inlet/long_about.txt");
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
@@ -102,9 +103,10 @@ impl InMemoryNodeCommand for InletNodeCommand {
             .await?;
         let relay_name = format!("{}-{}-{}", cluster, zone_name, self.command.pod());
         let outlet_name = self.command.to.as_deref().unwrap_or(self.command.pod());
+        let inlet_from = self.command.from();
         let mut node_config = serde_json::json!({
             "tcp-inlet": {
-                "from": self.command.from().to_string(),
+                "from": inlet_from.to_string(),
                 "to": outlet_name,
                 "via": relay_name
             }
@@ -143,7 +145,20 @@ impl InMemoryNodeCommand for InletNodeCommand {
             res
         });
         if let Some(node_callback) = node_callback {
-            wait_for_node_callback_future(handle, node_callback).await?;
+            tokio::select! {
+                res = wait_for_node_callback_future(handle, node_callback) => {
+                    res
+                },
+                _ = tokio::time::sleep(Duration::from_secs(60)) => {
+                    // Check if the outlet address is reachable or return an error
+                    let addr = inlet_from.hostname_port().to_string();
+                    if let Err(e) = tokio::net::TcpStream::connect(&addr).await {
+                        Err(miette::miette!(e).wrap_err(miette::miette!("Inlet failed to start at {}", addr)))
+                    } else {
+                        Ok(())
+                    }
+                }
+            }?
         } else {
             handle.await.into_diagnostic()??;
         }

--- a/implementations/rust/ockam/ockam_command/src/zone/outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/outlet.rs
@@ -19,6 +19,7 @@ use ockam_api::nodes::InMemoryNode;
 use ockam_api::CliState;
 use ockam_node::Context;
 use std::sync::Arc;
+use std::time::Duration;
 
 const LONG_ABOUT: &str = include_str!("./static/outlet/long_about.txt");
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
@@ -111,8 +112,8 @@ impl InMemoryNodeCommand for OutletNodeCommand {
         let mut node_config = serde_json::json!({
             "relay": relay_name,
             "tcp-outlet": {
-                "to": self.command.to.to_string(),
-                }
+              "to": self.command.to.to_string(),
+            }
         });
         let from = &self.command.from.as_ref().unwrap_or(&self.command.relay);
         node_config["tcp-outlet"]["from"] = from.to_string().into();
@@ -150,7 +151,20 @@ impl InMemoryNodeCommand for OutletNodeCommand {
             res
         });
         if let Some(node_callback) = node_callback {
-            wait_for_node_callback_future(handle, node_callback).await?;
+            tokio::select! {
+                res = wait_for_node_callback_future(handle, node_callback) => {
+                    res
+                },
+                _ = tokio::time::sleep(Duration::from_secs(60)) => {
+                    // Check if the outlet address is reachable or return an error
+                    let addr = self.command.to.to_string();
+                    if let Err(e) = tokio::net::TcpStream::connect(&addr).await {
+                        Err(miette::miette!(e).wrap_err(miette::miette!("Outlet failed to start at {}", addr)))
+                    } else {
+                        Ok(())
+                    }
+                }
+            }?
         } else {
             handle.await.into_diagnostic()??;
         }


### PR DESCRIPTION
In some rare cases, the `wait_for_node_callback_future` function doesn't resolve, even if the underlying node + portal are created and up, causing the command to block indefinitely for no reason. 

This PR adds a timeout that, when triggered, checks if the inlet/outlet is up, which should be a positive/equivalent signal that the node + portal is up.