### PR TITLE
fix: install script when there is a running ockam process

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -198,12 +198,15 @@ download() {
 
   _url="$_download_base_url/$_version/$_binary_file_name"
 
+  # Download to a temporary file first
   info "Downloading $_url"
-  curl --proto '=https' --tlsv1.2 --location --silent --fail --show-error --output "$install_path/bin/ockam" "$_url"
-  info "Downloaded ockam binary at the specified directory: $install_path/bin/ockam"
+  curl --proto '=https' --tlsv1.2 --location --silent --fail --show-error --output "$install_path/bin/ockam.new" "$_url"
 
-  info "Granting permission to execute: chmod u+x $install_path/bin/ockam"
-  chmod u+x "$install_path/bin/ockam"
+  info "Granting permission to execute"
+  chmod u+x "$install_path/bin/ockam.new"
+
+  # Replace the old binary
+  mv -f "$install_path/bin/ockam.new" "$install_path/bin/ockam"
 }
 
 create_bin() {


### PR DESCRIPTION
Instead of replacing the old binary with curl, we first download it to a temporary file, set the permissions, and then use `mv` to replace the old binary.

How to test:

```bash
# In a terminal
$HOME/.ockam/bin/ockam --rm

# In a different terminal
./tools/install.sh
$HOME/.ockam/bin/ockam --version
```