### PR TITLE
feat: small log messages fixes

### DIFF
--- a/implementations/python/python/ockam/__init__.py
+++ b/implementations/python/python/ockam/__init__.py
@@ -30,6 +30,13 @@ from .gather import gather
 
 from .ockam_in_rust_for_python import Mailbox, McpClient, McpServer
 
+# intercept deprecation warnings early to avoid cluttering the logs.
+import warnings
+
+warnings.filterwarnings(
+    "ignore",
+    category=DeprecationWarning,
+)
 __doc__ = ""
 __all__ = [
     # from .agents

--- a/implementations/python/python/ockam/logging/colored_formatter.py
+++ b/implementations/python/python/ockam/logging/colored_formatter.py
@@ -29,7 +29,7 @@ class OckamColoredFormatter(colorlog.ColoredFormatter):
 
     def formatMessage(self, record) -> str:
         try:
-            record.name = f"{self.GREY}{record.name}{self.RESET}"
+            record.name = f"{self.GREY}{record.name.replace(".", "::")}{self.RESET}"
             original_asctime = self.formatTime(record, self.datefmt)
             record.asctime = f"{self.GREY}{original_asctime}{self.RESET}"
             return super().formatMessage(record)

--- a/implementations/python/python/ockam/logging/colored_formatter.py
+++ b/implementations/python/python/ockam/logging/colored_formatter.py
@@ -3,7 +3,7 @@ from datetime import datetime, UTC
 
 
 class OckamColoredFormatter(colorlog.ColoredFormatter):
-    GREY = "\033[90m"
+    GREY = "\033[38;5;245m"
     CYAN = "\033[36m"
     YELLOW = "\033[33m"
     RESET = "\033[0m"

--- a/implementations/python/python/ockam/logging/colored_formatter.py
+++ b/implementations/python/python/ockam/logging/colored_formatter.py
@@ -29,7 +29,7 @@ class OckamColoredFormatter(colorlog.ColoredFormatter):
 
     def formatMessage(self, record) -> str:
         try:
-            record.name = f"{self.GREY}{record.name.replace(".", "::")}{self.RESET}"
+            record.name = f"{self.GREY}{record.name.replace('.', '::')}{self.RESET}"
             original_asctime = self.formatTime(record, self.datefmt)
             record.asctime = f"{self.GREY}{original_asctime}{self.RESET}"
             return super().formatMessage(record)

--- a/implementations/python/python/ockam/logging/logging.py
+++ b/implementations/python/python/ockam/logging/logging.py
@@ -4,7 +4,6 @@ import os
 import logging.config
 from typing import Protocol
 
-import datetime
 
 DEFAULT_LOG_FORMAT = os.getenv(
     "DEFAULT_LOG_FORMAT", "%(asctime)s %(log_color)s%(levelname)5s%(reset)s %(name)-14s %(message)s"
@@ -102,6 +101,16 @@ def create_logging_config(levels: dict, log_format: str) -> dict[str, int | bool
             "httpcore": {"handlers": ["default"], "level": levels.get("httpcore", "WARNING"), "propagate": False},
             "httpx": {"handlers": ["default"], "level": levels.get("httpx", "WARNING"), "propagate": False},
             "LiteLLM": {"handlers": ["default"], "level": levels.get("LiteLLM", "WARNING"), "propagate": False},
+            "LiteLLM Router": {
+                "handlers": ["default"],
+                "level": levels.get("LiteLLM Router", "WARNING"),
+                "propagate": False,
+            },
+            "LiteLLM Proxy": {
+                "handlers": ["default"],
+                "level": levels.get("LiteLLM Proxy", "WARNING"),
+                "propagate": False,
+            },
             "agent": {
                 "handlers": ["ockam"],
                 "level": levels.get("agent") or levels.get("default"),

--- a/implementations/python/python/ockam/logging/logging.py
+++ b/implementations/python/python/ockam/logging/logging.py
@@ -4,6 +4,8 @@ import os
 import logging.config
 from typing import Protocol
 
+import datetime
+
 DEFAULT_LOG_FORMAT = os.getenv(
     "DEFAULT_LOG_FORMAT", "%(asctime)s %(log_color)s%(levelname)5s%(reset)s %(name)-14s %(message)s"
 )

--- a/implementations/python/python/ockam/nodes/node.py
+++ b/implementations/python/python/ockam/nodes/node.py
@@ -25,16 +25,16 @@ class Node:
 
     @staticmethod
     def start(
-        main: Optional[Callable[[LocalNode], Awaitable[None]]] = None,
-        name: Optional[str] = None,
-        ticket: Optional[str] = None,
-        allow: Optional[str] = None,
-        http_server=None,
-        wait_until_interrupted: bool = True,
-        cache_secure_channels: bool = False,
-        use_local_db: bool = False,
-        llm_debug: bool = False,
-        **kwargs,
+            main: Optional[Callable[[LocalNode], Awaitable[None]]] = None,
+            name: Optional[str] = None,
+            ticket: Optional[str] = None,
+            allow: Optional[str] = None,
+            http_server=None,
+            wait_until_interrupted: bool = True,
+            cache_secure_channels: bool = False,
+            use_local_db: bool = False,
+            llm_debug: bool = False,
+            **kwargs,
     ):
         # This will make the node use a local SQLite database instead of the Postgres database
         if use_local_db:

--- a/implementations/python/python/ockam/nodes/node.py
+++ b/implementations/python/python/ockam/nodes/node.py
@@ -25,16 +25,16 @@ class Node:
 
     @staticmethod
     def start(
-            main: Optional[Callable[[LocalNode], Awaitable[None]]] = None,
-            name: Optional[str] = None,
-            ticket: Optional[str] = None,
-            allow: Optional[str] = None,
-            http_server=None,
-            wait_until_interrupted: bool = True,
-            cache_secure_channels: bool = False,
-            use_local_db: bool = False,
-            llm_debug: bool = False,
-            **kwargs,
+        main: Optional[Callable[[LocalNode], Awaitable[None]]] = None,
+        name: Optional[str] = None,
+        ticket: Optional[str] = None,
+        allow: Optional[str] = None,
+        http_server=None,
+        wait_until_interrupted: bool = True,
+        cache_secure_channels: bool = False,
+        use_local_db: bool = False,
+        llm_debug: bool = False,
+        **kwargs,
     ):
         # This will make the node use a local SQLite database instead of the Postgres database
         if use_local_db:


### PR DESCRIPTION
This PR fixes a few small issues with logs:

- Deprecation warnings in logs -> they are all suppressed by default.
- Difference in color for the text in Python log messages vs Rust log messages.
- Difference separators for module names in Python and Rust.
- Default log level for LLM Lite messages.