### PR TITLE
feat: support setting zone config and secret config as inline strings

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
@@ -144,11 +144,55 @@ impl ZoneNameLongOrConfigArg {
 
 #[derive(Clone, Debug, Args, Default)]
 pub struct SecretsConfigArg {
-    /// The path to the secrets file, in yaml or json format.
+    /// The path to the secrets file, in yaml or json format, or the inline content of the secrets.
     /// If not set, the `./secrets.yaml` file from the current directory will be used.
-    /// If no file is found, the command will just list the existing secrets.
     #[arg(long, visible_alias = "secrets")]
     pub secrets_config: Option<String>,
+}
+
+impl SecretsConfigArg {
+    /// Get the contents of the secrets config as a string.
+    /// If the input is a file path that exists, read from the file.
+    /// Otherwise, treat the input as inline content.
+    pub fn contents(&self) -> crate::Result<Option<String>> {
+        let config_input = match &self.secrets_config {
+            Some(input) => input,
+            None => {
+                return if std::path::Path::new("./secrets.yaml")
+                    .try_exists()
+                    .into_diagnostic()?
+                {
+                    Ok(Some(
+                        std::fs::read_to_string("./secrets.yaml")
+                            .into_diagnostic()
+                            .wrap_err("Failed to read ./secrets.yaml")?,
+                    ))
+                } else if std::path::Path::new("./secrets.yml")
+                    .try_exists()
+                    .into_diagnostic()?
+                {
+                    Ok(Some(
+                        std::fs::read_to_string("./secrets.yml")
+                            .into_diagnostic()
+                            .wrap_err("Failed to read ./secrets.yml")?,
+                    ))
+                } else {
+                    Ok(None)
+                }
+            }
+        };
+
+        // Try to read as file first, if it fails treat as inline content
+        let contents = if std::path::Path::new(config_input).exists() {
+            std::fs::read_to_string(config_input)
+                .into_diagnostic()
+                .wrap_err(format!("Failed to read secrets file at {}", config_input))?
+        } else {
+            config_input.clone()
+        };
+
+        Ok(Some(contents))
+    }
 }
 
 #[derive(Clone, Debug, Args, Default)]
@@ -260,6 +304,107 @@ mod tests {
 
             // Should fail when no config is provided and no default files exist
             assert!(result.is_err());
+        }
+    }
+
+    mod secrets_config_arg {
+        use super::*;
+
+        #[test]
+        fn test_contents_from_inline_string() {
+            let yaml_content = r#"
+pg_username: testuser
+pg_password: testpass
+"#;
+            let secrets_config = SecretsConfigArg {
+                secrets_config: Some(yaml_content.to_string()),
+            };
+
+            let result = secrets_config.contents().unwrap();
+            assert!(result.is_some());
+            assert_eq!(result.unwrap(), yaml_content);
+        }
+
+        #[test]
+        fn test_contents_from_file_path() {
+            let temp_dir = TempDir::new().unwrap();
+            let config_file_path = temp_dir.path().join("secrets.yaml");
+            let yaml_content = r#"
+pg_username: fileuser
+pg_password: filepass
+"#;
+            fs::write(&config_file_path, yaml_content).unwrap();
+
+            let secrets_config = SecretsConfigArg {
+                secrets_config: Some(config_file_path.to_string_lossy().to_string()),
+            };
+
+            let result = secrets_config.contents().unwrap();
+            assert!(result.is_some());
+            assert_eq!(result.unwrap(), yaml_content);
+        }
+
+        #[test]
+        fn test_contents_nonexistent_file_returns_inline() {
+            let nonexistent_path = "/path/that/does/not/exist.yaml";
+            let secrets_config = SecretsConfigArg {
+                secrets_config: Some(nonexistent_path.to_string()),
+            };
+
+            let result = secrets_config.contents().unwrap();
+            assert!(result.is_some());
+            assert_eq!(result.unwrap(), nonexistent_path);
+        }
+
+        #[test]
+        fn test_contents_no_config_checks_default_files() {
+            let secrets_config = SecretsConfigArg {
+                secrets_config: None,
+            };
+
+            let result = secrets_config.contents().unwrap();
+            // Should return None if no default files exist
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn test_contents_finds_default_secrets_yaml() {
+            let temp_dir = TempDir::new().unwrap();
+            let original_dir = std::env::current_dir().unwrap();
+            std::env::set_current_dir(&temp_dir).unwrap();
+
+            let yaml_content = "default_secret: value";
+            fs::write("./secrets.yaml", yaml_content).unwrap();
+
+            let secrets_config = SecretsConfigArg {
+                secrets_config: None,
+            };
+
+            let result = secrets_config.contents().unwrap();
+            assert!(result.is_some());
+            assert_eq!(result.unwrap(), yaml_content);
+
+            std::env::set_current_dir(original_dir).unwrap();
+        }
+
+        #[test]
+        fn test_contents_finds_default_secrets_yml() {
+            let temp_dir = TempDir::new().unwrap();
+            let original_dir = std::env::current_dir().unwrap();
+            std::env::set_current_dir(&temp_dir).unwrap();
+
+            let yaml_content = "default_secret: value";
+            fs::write("./secrets.yml", yaml_content).unwrap();
+
+            let secrets_config = SecretsConfigArg {
+                secrets_config: None,
+            };
+
+            let result = secrets_config.contents().unwrap();
+            assert!(result.is_some());
+            assert_eq!(result.unwrap(), yaml_content);
+
+            std::env::set_current_dir(original_dir).unwrap();
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
@@ -49,6 +49,7 @@ impl ZoneConfigArg {
         }
     }
 
+    /// Parse the zone config contents as an inline string or from a file.
     pub fn zone_config(&self) -> crate::Result<ZoneConfig> {
         let contents = match self.zone_config_path() {
             Ok(path) => {
@@ -67,7 +68,7 @@ impl ZoneConfigArg {
             }
         };
         ZoneConfig::from_contents(&contents)
-            .map_err(|e| miette!("Failed to parse zone config file: {}", e))
+            .map_err(|e| miette!("Failed to parse zone config: {}", e))
     }
 
     pub fn zone_name(&self) -> crate::Result<String> {
@@ -200,4 +201,65 @@ pub struct ZoneInletsArgs {
     /// Skip the creation of the inlet to the logs outlet.
     #[arg(long)]
     pub no_logs: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    mod zone_config_arg {
+        use super::*;
+
+        #[test]
+        fn test_zone_config_from_inline_string() {
+            let yaml_content = serde_yaml::to_string(&ZoneConfig::default()).unwrap();
+            let zone_config_arg = ZoneConfigArg::new(Some(yaml_content.to_string()));
+            let result = zone_config_arg.zone_config();
+
+            assert!(result.is_ok());
+            let config = result.unwrap();
+            assert_eq!(config.name, "zone");
+        }
+
+        #[test]
+        fn test_zone_config_from_file_path() {
+            let temp_dir = TempDir::new().unwrap();
+            let config_file_path = temp_dir.path().join("zone_config.yaml");
+
+            let yaml_content = serde_yaml::to_string(&ZoneConfig::default()).unwrap();
+            fs::write(&config_file_path, yaml_content).unwrap();
+
+            let zone_config_arg =
+                ZoneConfigArg::new(Some(config_file_path.to_string_lossy().to_string()));
+            let result = zone_config_arg.zone_config();
+
+            assert!(result.is_ok());
+            let config = result.unwrap();
+            assert_eq!(config.name, "zone");
+        }
+
+        #[test]
+        fn test_zone_config_invalid_yaml() {
+            let invalid_yaml = "invalid: yaml: content: [";
+            let zone_config_arg = ZoneConfigArg::new(Some(invalid_yaml.to_string()));
+            let result = zone_config_arg.zone_config();
+
+            assert!(result.is_err());
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to parse zone config"));
+        }
+
+        #[test]
+        fn test_zone_config_no_config_provided() {
+            let zone_config_arg = ZoneConfigArg::new(None);
+            let result = zone_config_arg.zone_config();
+
+            // Should fail when no config is provided and no default files exist
+            assert!(result.is_err());
+        }
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/common_args.rs
@@ -13,7 +13,7 @@ const ZONE_NAME_HELP: &str = "The name of the Zone";
 
 #[derive(Clone, Debug, Args, Default)]
 pub struct ZoneConfigArg {
-    #[arg(long, visible_alias = "config", help = ZONE_CONFIG_HELP)]
+    #[arg(long, visible_alias = "config", help = ZONE_CONFIG_HELP, env = "OCKAM_ZONE_CONFIG")]
     pub zone_config: Option<String>,
 }
 
@@ -82,7 +82,7 @@ pub struct ZoneNameOrConfigArg {
     #[arg(value_parser = alphanumeric_parser, help = ZONE_NAME_HELP)]
     pub zone_name: Option<String>,
 
-    #[arg(long, visible_alias = "config", help = ZONE_CONFIG_HELP)]
+    #[arg(long, visible_alias = "config", help = ZONE_CONFIG_HELP, env = "OCKAM_ZONE_CONFIG")]
     pub zone_config: Option<String>,
 }
 
@@ -132,7 +132,7 @@ pub struct ZoneNameLongOrConfigArg {
     #[arg(long = "zone", value_parser = alphanumeric_parser, help = ZONE_NAME_HELP)]
     pub zone_name: Option<String>,
 
-    #[arg(long, visible_alias = "config", help = ZONE_CONFIG_HELP)]
+    #[arg(long, visible_alias = "config", help = ZONE_CONFIG_HELP, env = "OCKAM_ZONE_CONFIG")]
     pub zone_config: Option<String>,
 }
 
@@ -146,7 +146,7 @@ impl ZoneNameLongOrConfigArg {
 pub struct SecretsConfigArg {
     /// The path to the secrets file, in yaml or json format, or the inline content of the secrets.
     /// If not set, the `./secrets.yaml` file from the current directory will be used.
-    #[arg(long, visible_alias = "secrets")]
+    #[arg(long, visible_alias = "secrets", env = "OCKAM_ZONE_SECRETS")]
     pub secrets_config: Option<String>,
 }
 
@@ -305,6 +305,27 @@ mod tests {
             // Should fail when no config is provided and no default files exist
             assert!(result.is_err());
         }
+
+        #[test]
+        fn test_zone_config_from_env_var() {
+            let yaml_content = serde_yaml::to_string(&ZoneConfig::default()).unwrap();
+            std::env::set_var("OCKAM_ZONE_CONFIG", &yaml_content);
+
+            use clap::Parser;
+            #[derive(Parser)]
+            struct TestArgs {
+                #[command(flatten)]
+                zone_config: ZoneConfigArg,
+            }
+
+            let args = TestArgs::parse_from(&[] as &[&str]);
+            let result = args.zone_config.zone_config();
+            std::env::remove_var("OCKAM_ZONE_CONFIG");
+
+            assert!(result.is_ok());
+            let config = result.unwrap();
+            assert_eq!(config.name, "zone");
+        }
     }
 
     mod secrets_config_arg {
@@ -405,6 +426,29 @@ pg_password: filepass
             assert_eq!(result.unwrap(), yaml_content);
 
             std::env::set_current_dir(original_dir).unwrap();
+        }
+
+        #[test]
+        fn test_contents_from_env_var() {
+            let yaml_content = r#"
+env_username: envuser
+env_password: envpass
+"#;
+            std::env::set_var("OCKAM_ZONE_SECRETS", yaml_content);
+
+            use clap::Parser;
+            #[derive(Parser)]
+            struct TestArgs {
+                #[command(flatten)]
+                secrets: SecretsConfigArg,
+            }
+
+            let args = TestArgs::parse_from(&[] as &[&str]);
+            let result = args.secrets.contents().unwrap();
+            std::env::remove_var("OCKAM_ZONE_SECRETS");
+
+            assert!(result.is_some());
+            assert_eq!(result.unwrap(), yaml_content);
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/zone/secret.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/secret.rs
@@ -116,7 +116,7 @@ impl SecretCommand {
         cluster: &str,
         zone_name: &str,
     ) -> Result<()> {
-        let secrets = match self.parse_secrets_file()? {
+        let secrets = match self.parse_secrets_config()? {
             Some(secrets) => secrets,
             None => {
                 return Ok(());
@@ -169,26 +169,11 @@ impl SecretCommand {
         Ok(())
     }
 
-    fn parse_secrets_file(&self) -> Result<Option<Secrets>> {
-        let path = match &self.secrets_config.secrets_config {
-            Some(path) => path,
-            None => {
-                if std::path::Path::new("./secrets.yaml")
-                    .try_exists()
-                    .into_diagnostic()?
-                {
-                    "./secrets.yaml"
-                } else if std::path::Path::new("./secrets.yml")
-                    .try_exists()
-                    .into_diagnostic()?
-                {
-                    "./secrets.yml"
-                } else {
-                    return Ok(None);
-                }
-            }
-        };
-        Ok(Some(Secrets::from_file(path)?))
+    fn parse_secrets_config(&self) -> Result<Option<Secrets>> {
+        match self.secrets_config.contents()? {
+            Some(contents) => Ok(Some(Secrets::from_contents(&contents)?)),
+            None => Ok(None),
+        }
     }
 }
 
@@ -396,5 +381,106 @@ mod tests {
         let result = Secrets::from_file(file.path());
         assert!(result.is_err());
         Ok(())
+    }
+
+    mod parsing_from_arg {
+        use super::*;
+        use crate::zone::common_args::SecretsConfigArg;
+
+        #[test]
+        fn test_parse_secrets_from_inline_yaml() -> Result<()> {
+            let yaml_content = r#"
+            pg_username: testuser
+            pg_password: testpass
+            "#;
+            let secrets_config = SecretsConfigArg {
+                secrets_config: Some(yaml_content.to_string()),
+            };
+            let command = SecretCommand {
+                secrets_config,
+                ..Default::default()
+            };
+
+            let result = command.parse_secrets_config()?;
+            assert!(result.is_some());
+
+            let secrets = result.unwrap();
+            assert_eq!(secrets.0.len(), 1);
+            let secret = &secrets.0[0];
+            assert_eq!(secret.name, Secrets::SECRET_NAME);
+            assert!(secret.fields.contains_key("pg_username"));
+            assert!(secret.fields.contains_key("pg_password"));
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_parse_secrets_from_inline_json() -> Result<()> {
+            let json_content = r#"[
+              {
+                "name": "test-secret",
+                "fields": {
+                  "username": "testuser",
+                  "password": "testpass"
+                }
+              }
+            ]"#;
+            let secrets_config = SecretsConfigArg {
+                secrets_config: Some(json_content.to_string()),
+            };
+            let command = SecretCommand {
+                secrets_config,
+                ..Default::default()
+            };
+
+            let result = command.parse_secrets_config()?;
+            assert!(result.is_some());
+
+            let secrets = result.unwrap();
+            assert_eq!(secrets.0.len(), 1);
+            assert_eq!(secrets.0[0].name, "test-secret");
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_parse_secrets_file_path_takes_precedence() -> Result<()> {
+            let yaml_content = r#"
+            file_username: fileuser
+            file_password: filepass
+            "#;
+            let file = create_temp_file_with_content(yaml_content)?;
+            let secrets_config = SecretsConfigArg {
+                secrets_config: Some(file.path().to_string_lossy().to_string()),
+            };
+            let command = SecretCommand {
+                secrets_config,
+                ..Default::default()
+            };
+
+            let result = command.parse_secrets_config()?;
+            assert!(result.is_some());
+
+            let secrets = result.unwrap();
+            let secret = &secrets.0[0];
+            assert!(secret.fields.contains_key("file_username"));
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_parse_secrets_invalid_inline_content() {
+            let invalid_content = "invalid: yaml: content: [";
+            let secrets_config = SecretsConfigArg {
+                secrets_config: Some(invalid_content.to_string()),
+            };
+            let command = SecretCommand {
+                secrets_config,
+                ..Default::default()
+            };
+
+            let result = command.parse_secrets_config();
+            assert!(result.is_err());
+        }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/zone/secret.rs
+++ b/implementations/rust/ockam/ockam_command/src/zone/secret.rs
@@ -6,7 +6,6 @@ use async_trait::async_trait;
 use base64ct::Encoding;
 use clap::Args;
 use colorful::Colorful;
-use miette::{IntoDiagnostic, WrapErr};
 use ockam_api::colors::color_primary;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::orchestrator::ai_platform::api::AiPlatformApi;
@@ -215,16 +214,6 @@ impl Secrets {
         }
     }
 
-    fn from_file(path: impl AsRef<std::path::Path>) -> Result<Self> {
-        let content = std::fs::read_to_string(&path)
-            .into_diagnostic()
-            .wrap_err(format!(
-                "Failed to read secrets file at {}",
-                path.as_ref().display()
-            ))?;
-        Self::from_contents(&content)
-    }
-
     fn from_parsed_yaml(parsed_yaml: SecretsYaml) -> Result<Self> {
         let mut secrets = Vec::new();
         let mut secret = Secret {
@@ -251,6 +240,7 @@ impl Secrets {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use miette::{IntoDiagnostic, WrapErr};
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -270,8 +260,7 @@ mod tests {
             pg_username: u
             pg_password: p
             "#;
-            let file = create_temp_file_with_content(yaml_content)?;
-            let secrets = Secrets::from_file(file.path())?;
+            let secrets = Secrets::from_contents(yaml_content)?;
             let _secrets_as_str = serde_yaml::to_string(&secrets)
                 .into_diagnostic()
                 .wrap_err("Failed to serialize secrets to YAML")?;
@@ -296,8 +285,7 @@ mod tests {
                 username: u
                 password: p
             "#;
-            let file = create_temp_file_with_content(yaml_content)?;
-            let secrets = Secrets::from_file(file.path())?;
+            let secrets = Secrets::from_contents(yaml_content)?;
 
             assert_eq!(secrets.0.len(), 1);
             assert_eq!(secrets.0[0].name, "pg");
@@ -325,8 +313,7 @@ mod tests {
                 host: localhost
                 port: 6379
             "#;
-            let file = create_temp_file_with_content(yaml_content)?;
-            let secrets = Secrets::from_file(file.path())?;
+            let secrets = Secrets::from_contents(yaml_content)?;
 
             assert_eq!(secrets.0.len(), 2);
 
@@ -356,8 +343,7 @@ mod tests {
                 }
               }
             ]"#;
-            let file = create_temp_file_with_content(json_content)?;
-            let secrets = Secrets::from_file(file.path())?;
+            let secrets = Secrets::from_contents(json_content)?;
 
             assert_eq!(secrets.0.len(), 1);
             assert_eq!(secrets.0[0].name, "pg");
@@ -377,8 +363,7 @@ mod tests {
     #[test]
     fn test_parse_invalid_yaml() -> Result<()> {
         let invalid_yaml = "this is not valid yaml";
-        let file = create_temp_file_with_content(invalid_yaml)?;
-        let result = Secrets::from_file(file.path());
+        let result = Secrets::from_contents(invalid_yaml);
         assert!(result.is_err());
         Ok(())
     }


### PR DESCRIPTION
Additionally, the zone config can be set via `OCKAM_ZONE_CONFIG` and the secrets config via `OCKAM_ZONE_SECRETS`.