### PR TITLE
fix: bump bytes to 1.11.1 and time to 0.3.47 for CVE remediation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,7 +1316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata",
  "serde",
 ]
 
@@ -4114,11 +4114,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -4518,16 +4518,6 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
-name = "nu-ansi-term"
 version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
@@ -4861,7 +4851,7 @@ dependencies = [
  "minicbor",
  "multimap",
  "nix 0.29.0",
- "nu-ansi-term 0.50.1",
+ "nu-ansi-term",
  "ockam",
  "ockam_abac",
  "ockam_core",
@@ -5513,12 +5503,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
 
 [[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
 name = "owo-colors"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5906,7 +5890,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -6369,7 +6353,7 @@ dependencies = [
  "crossterm 0.27.0",
  "fd-lock",
  "itertools 0.12.1",
- "nu-ansi-term 0.50.1",
+ "nu-ansi-term",
  "serde",
  "strip-ansi-escapes",
  "strum",
@@ -6387,17 +6371,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -6408,7 +6383,7 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -6416,12 +6391,6 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -7851,7 +7820,7 @@ dependencies = [
  "once_cell",
  "onig",
  "plist",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "serde",
  "serde_derive",
  "serde_json",
@@ -8447,14 +8416,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
- "nu-ansi-term 0.46.0",
+ "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4537,11 +4537,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
@@ -6568,9 +6567,9 @@ checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
 name = "rsa"
-version = "0.9.7"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
  "digest",

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -56,7 +56,7 @@ cfg_aliases = "0.2.1"
 
 [dependencies]
 base64-url = "3.0.0"
-bytes = { version = "=1.9.0", default-features = false, features = ["serde"] }
+bytes = { version = "=1.11.1", default-features = false, features = ["serde"] }
 cfg-if = "1.0.0"
 chrono = { version = "0.4" }
 clap = { version = "4.5", default-features = false, features = ["derive", "std"], optional = true }
@@ -112,7 +112,7 @@ syntect = { version = "5.2.0", default-features = false, features = ["default-sy
 sysinfo = "0.32"
 termbg = "0.5.2"
 thiserror = "2.0.9"
-time = { version = "=0.3.39", default-features = false, features = ["std", "formatting", "local-offset", "macros"] }
+time = { version = "=0.3.47", default-features = false, features = ["std", "formatting", "local-offset", "macros"] }
 tiny_http = "0.12.0"
 tokio = { version = "1.43.1", features = ["full"] }
 tokio-retry = "0.3.0"

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -102,7 +102,7 @@ sqlx-core = { version = "0.8.3", optional = true, default-features = false }
 sqlx-postgres = { version = "0.8.2", optional = true, default-features = false }
 sqlx-sqlite = { version = "0.8.2", optional = true, default-features = false }
 tempfile = { version = "3.17.1", optional = true }
-time = { version = "=0.3.39", default-features = false, optional = true }
+time = { version = "=0.3.47", default-features = false, optional = true }
 tokio = { version = "1.43", default-features = false, optional = true, features = ["sync", "time", "rt", "rt-multi-thread", "macros"] }
 tokio-retry = { version = "0.3.0", optional = true }
 tracing = { version = "0.1", default-features = false }

--- a/implementations/rust/ockam/ockam_rust_elixir_nifs/Cargo.toml
+++ b/implementations/rust/ockam/ockam_rust_elixir_nifs/Cargo.toml
@@ -43,5 +43,5 @@ ockam_vault = { path = "../ockam_vault", default-features = false, features = ["
 ockam_vault_aws = { path = "../ockam_vault_aws", version = "^0.62.0" }
 # Enable credentials-sso feature in ockam_vault_aws for use on sso environments (like dev machines)
 rustler = "0.35.0"
-time = "=0.3.39"
+time = "=0.3.47"
 tokio = "1.43.1"


### PR DESCRIPTION
Bumps pinned dependency versions for CVE remediation:
- bytes 1.9.0 → 1.11.1 (CVE-2026-25541, due Apr 4)
- time 0.3.39 → 0.3.47 (CVE-2026-25727, due Apr 6)

Cargo.lock needs regeneration via cargo update -p bytes -p time.